### PR TITLE
Add ProxyCommand support and make ProxyJump actually work

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ AnySCP is a free, open-source desktop application that combines an SSH terminal,
 - Split terminal panes (horizontal and vertical) within a single SSH session
 - In-terminal search with regex support
 - Tabbed SSH sessions with keyboard shortcuts
-- Configurable keep-alive intervals, startup commands, default shell, and proxy jump (bastion host)
+- Configurable keep-alive intervals, startup commands, default shell, ProxyJump (single-hop bastion host), and ProxyCommand
 - SSH key authentication with automatic PPK-to-OpenSSH conversion
 - Import connections from `~/.ssh/config`
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+onlyBuiltDependencies:
+  - esbuild
+verifyDepsBeforeRun: false

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -107,6 +107,7 @@ dependencies = [
  "reqwest 0.12.28",
  "rusqlite",
  "russh",
+ "russh-config",
  "russh-keys",
  "russh-sftp",
  "rust-s3",
@@ -500,6 +501,16 @@ checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -1935,6 +1946,19 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
 
 [[package]]
 name = "gobject-sys"
@@ -4455,6 +4479,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "russh-config"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "641191c7c84789c1d36a44747979acbdbb7eb64bff8ac362bac6e1dfe42c1961"
+dependencies = [
+ "futures",
+ "globset",
+ "home",
+ "log",
+ "thiserror 1.0.69",
+ "tokio",
+ "whoami",
+]
+
+[[package]]
 name = "russh-cryptovec"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6543,6 +6582,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6789,6 +6834,17 @@ dependencies = [
  "thiserror 2.0.18",
  "windows 0.61.3",
  "windows-core 0.61.2",
+]
+
+[[package]]
+name = "whoami"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
+dependencies = [
+ "libredox",
+ "wasite",
+ "web-sys",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -30,6 +30,7 @@ serde_json = "1"
 # SSH (pure Rust, async)
 russh = "0.46"
 russh-keys = "0.46"
+russh-config = "0.48"
 async-trait = "0.1"
 
 # Async runtime

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -103,8 +103,10 @@ pub struct SavedHost {
     // Connection behaviour
     /// Shell command to execute automatically after the shell opens.
     pub startup_command: Option<String>,
-    /// ProxyJump / bastion host in `user@host:port` form.
+    /// ProxyJump / bastion host in `[user@]host[:port]` form (single-hop).
     pub proxy_jump: Option<String>,
+    /// OpenSSH-style ProxyCommand. Tokens %h/%p/%r are expanded at connect time.
+    pub proxy_command: Option<String>,
     /// Seconds between SSH keepalive pings (0 = disabled).
     pub keep_alive_interval: Option<u32>,
     /// Default login shell, e.g. "/bin/zsh".
@@ -447,6 +449,15 @@ impl HostDb {
             tracing::info!("migration 10→11 applied: ensured color, environment, notes on s3_connections");
         }
 
+        if version < 12 {
+            conn.execute("ALTER TABLE saved_hosts ADD COLUMN proxy_command TEXT", [])?;
+            conn.execute(
+                "INSERT OR REPLACE INTO _meta (key, value) VALUES ('schema_version', '12')",
+                [],
+            )?;
+            tracing::info!("migration 11→12 applied: added proxy_command to saved_hosts");
+        }
+
         Ok(())
     }
 
@@ -463,14 +474,14 @@ impl HostDb {
             "INSERT INTO saved_hosts (
                  id, label, host, port, username, auth_type, group_id, created_at, updated_at,
                  key_path, color, notes, environment, os_type,
-                 startup_command, proxy_jump, keep_alive_interval, default_shell,
+                 startup_command, proxy_jump, proxy_command, keep_alive_interval, default_shell,
                  font_size, last_connected_at, connection_count
              )
              VALUES (
                  ?1,  ?2,  ?3,  ?4,  ?5,  ?6,  ?7,  ?8,  ?9,
                  ?10, ?11, ?12, ?13, ?14,
-                 ?15, ?16, ?17, ?18,
-                 ?19, ?20, ?21
+                 ?15, ?16, ?17, ?18, ?19,
+                 ?20, ?21, ?22
              )
              ON CONFLICT(id) DO UPDATE SET
                  label                = excluded.label,
@@ -487,6 +498,7 @@ impl HostDb {
                  os_type              = excluded.os_type,
                  startup_command      = excluded.startup_command,
                  proxy_jump           = excluded.proxy_jump,
+                 proxy_command        = excluded.proxy_command,
                  keep_alive_interval  = excluded.keep_alive_interval,
                  default_shell        = excluded.default_shell,
                  font_size            = excluded.font_size,
@@ -509,6 +521,7 @@ impl HostDb {
                 host.os_type,
                 host.startup_command,
                 host.proxy_jump,
+                host.proxy_command,
                 host.keep_alive_interval,
                 host.default_shell,
                 host.font_size,
@@ -526,7 +539,7 @@ impl HostDb {
         let mut stmt = conn.prepare(
             "SELECT id, label, host, port, username, auth_type, group_id, created_at, updated_at,
                     key_path, color, notes, environment, os_type,
-                    startup_command, proxy_jump, keep_alive_interval, default_shell,
+                    startup_command, proxy_jump, proxy_command, keep_alive_interval, default_shell,
                     font_size, last_connected_at, connection_count
              FROM saved_hosts
              ORDER BY label ASC",
@@ -550,11 +563,12 @@ impl HostDb {
                 os_type: row.get(13)?,
                 startup_command: row.get(14)?,
                 proxy_jump: row.get(15)?,
-                keep_alive_interval: row.get(16)?,
-                default_shell: row.get(17)?,
-                font_size: row.get(18)?,
-                last_connected_at: row.get(19)?,
-                connection_count: row.get(20)?,
+                proxy_command: row.get(16)?,
+                keep_alive_interval: row.get(17)?,
+                default_shell: row.get(18)?,
+                font_size: row.get(19)?,
+                last_connected_at: row.get(20)?,
+                connection_count: row.get(21)?,
             })
         })?;
 
@@ -581,7 +595,7 @@ impl HostDb {
         let mut stmt = conn.prepare(
             "SELECT id, label, host, port, username, auth_type, group_id, created_at, updated_at,
                     key_path, color, notes, environment, os_type,
-                    startup_command, proxy_jump, keep_alive_interval, default_shell,
+                    startup_command, proxy_jump, proxy_command, keep_alive_interval, default_shell,
                     font_size, last_connected_at, connection_count
              FROM saved_hosts
              WHERE id = ?1",
@@ -605,11 +619,12 @@ impl HostDb {
                 os_type: row.get(13)?,
                 startup_command: row.get(14)?,
                 proxy_jump: row.get(15)?,
-                keep_alive_interval: row.get(16)?,
-                default_shell: row.get(17)?,
-                font_size: row.get(18)?,
-                last_connected_at: row.get(19)?,
-                connection_count: row.get(20)?,
+                proxy_command: row.get(16)?,
+                keep_alive_interval: row.get(17)?,
+                default_shell: row.get(18)?,
+                font_size: row.get(19)?,
+                last_connected_at: row.get(20)?,
+                connection_count: row.get(21)?,
             })
         })?;
 
@@ -1340,6 +1355,7 @@ mod tests {
             os_type: None,
             startup_command: None,
             proxy_jump: None,
+            proxy_command: None,
             keep_alive_interval: None,
             default_shell: None,
             font_size: None,

--- a/src-tauri/src/import/commands.rs
+++ b/src-tauri/src/import/commands.rs
@@ -71,6 +71,7 @@ pub async fn import_save_ssh_hosts(
                 os_type: None,
                 startup_command: None,
                 proxy_jump: entry.proxy_jump.clone(),
+                proxy_command: entry.proxy_command.clone(),
                 keep_alive_interval: entry.keep_alive_interval,
                 default_shell: None,
                 font_size: None,

--- a/src-tauri/src/import/mod.rs
+++ b/src-tauri/src/import/mod.rs
@@ -18,6 +18,7 @@ pub struct SshConfigEntry {
     pub port: Option<u16>,
     pub identity_file: Option<String>,
     pub proxy_jump: Option<String>,
+    pub proxy_command: Option<String>,
     pub keep_alive_interval: Option<u32>,
     pub is_pattern: bool,
     pub already_exists: bool,
@@ -31,6 +32,7 @@ pub struct SshConfigImportEntry {
     pub port: u16,
     pub identity_file: Option<String>,
     pub proxy_jump: Option<String>,
+    pub proxy_command: Option<String>,
     pub keep_alive_interval: Option<u32>,
 }
 
@@ -65,8 +67,14 @@ pub fn parse_ssh_config(
         .map_err(|e| SshError::IoError(format!("Cannot read {}: {e}", config_path.display())))?;
     let mut reader = BufReader::new(file);
 
+    // ALLOW_UNSUPPORTED_FIELDS lets us recover the raw arg list for fields
+    // ssh2-config recognises but doesn't model (e.g. ProxyCommand) — the
+    // alternative is silent drop.
     let config = SshConfig::default()
-        .parse(&mut reader, ParseRule::ALLOW_UNKNOWN_FIELDS)
+        .parse(
+            &mut reader,
+            ParseRule::ALLOW_UNKNOWN_FIELDS | ParseRule::ALLOW_UNSUPPORTED_FIELDS,
+        )
         .map_err(|e| SshError::IoError(format!("Failed to parse SSH config: {e}")))?;
 
     // Pre-scan for Host block names
@@ -109,6 +117,17 @@ pub fn parse_ssh_config(
             .and_then(|jumps| jumps.first())
             .map(|j| format!("{}", j));
 
+        // ssh2-config 0.7 doesn't model ProxyCommand as a typed field; its
+        // tokenized args land in `unsupported_fields["proxycommand"]`. Join
+        // with single spaces — sufficient for the common case (`ssh -W %h:%p
+        // bastion`, `cloudflared access ssh --hostname %h`, etc). Round-trip
+        // for strings with quoted multi-word args may need a manual touch-up.
+        let proxy_command = params
+            .unsupported_fields
+            .get("proxycommand")
+            .filter(|tokens| !tokens.is_empty())
+            .map(|tokens| tokens.join(" "));
+
         let keep_alive_interval = params
             .server_alive_interval
             .map(|d| d.as_secs() as u32);
@@ -129,6 +148,7 @@ pub fn parse_ssh_config(
             port,
             identity_file,
             proxy_jump,
+            proxy_command,
             keep_alive_interval,
             is_pattern,
             already_exists,

--- a/src-tauri/src/portforward/commands.rs
+++ b/src-tauri/src/portforward/commands.rs
@@ -185,6 +185,8 @@ pub async fn pf_start_tunnel(
         keep_alive_interval: None,
         default_shell: None,
         startup_command: None,
+        proxy_jump: saved_host.proxy_jump,
+        proxy_command: saved_host.proxy_command,
     };
 
     let session_id = ssh_manager.connect_no_pty(config).await?;

--- a/src-tauri/src/ssh/commands.rs
+++ b/src-tauri/src/ssh/commands.rs
@@ -164,6 +164,8 @@ pub async fn connect_saved_host(
         keep_alive_interval: saved_host.keep_alive_interval,
         default_shell: saved_host.default_shell,
         startup_command: saved_host.startup_command,
+        proxy_jump: saved_host.proxy_jump,
+        proxy_command: saved_host.proxy_command,
     };
 
     let session_id = state.connect(config, app_handle).await?;
@@ -229,6 +231,8 @@ pub async fn connect_saved_host_no_pty(
         keep_alive_interval: None,
         default_shell: None,
         startup_command: None,
+        proxy_jump: saved_host.proxy_jump,
+        proxy_command: saved_host.proxy_command,
     };
 
     state.connect_no_pty(config).await

--- a/src-tauri/src/ssh/manager.rs
+++ b/src-tauri/src/ssh/manager.rs
@@ -5,16 +5,33 @@ use dashmap::DashMap;
 use russh::client;
 use std::sync::Arc;
 use tauri::{AppHandle, Emitter};
+use tokio::sync::Mutex;
 use tracing::info;
 
 use super::handler::SshClientHandler;
 use super::session::SshSession;
 
+/// Authenticated SSH handle plus any upstream jump handles that must outlive it.
+/// The jump_chain entries each hold a russh `Handle` that owns the transport
+/// the next inner connection is layered on. Drop them and the inner channel dies.
+struct AuthenticatedHandle {
+    handle: client::Handle<SshClientHandler>,
+    jump_chain: Vec<Arc<Mutex<client::Handle<SshClientHandler>>>>,
+}
+
+/// Bare (no-PTY) SSH connection used by SFTP. Keeps the jump chain alive
+/// alongside the target handle so the underlying transport stays open.
+struct BareHandle {
+    handle: Arc<Mutex<client::Handle<SshClientHandler>>>,
+    #[allow(dead_code)]
+    jump_chain: Vec<Arc<Mutex<client::Handle<SshClientHandler>>>>,
+}
+
 /// Manages all active SSH sessions. Stored as Tauri managed state.
 pub struct SshManager {
     sessions: DashMap<String, SshSession>,
     /// Bare SSH handles for SFTP-only connections (no PTY).
-    bare_handles: DashMap<String, Arc<tokio::sync::Mutex<client::Handle<super::handler::SshClientHandler>>>>,
+    bare_handles: DashMap<String, BareHandle>,
 }
 
 impl SshManager {
@@ -52,68 +69,14 @@ impl SshManager {
             ..Default::default()
         });
 
-        let addr = format!("{}:{}", config.host, config.port);
-        let handler = SshClientHandler;
-        let mut handle = client::connect(russh_config, &addr, handler)
-            .await
-            .map_err(|e| SshError::ConnectionFailed(e.to_string()))?;
+        let host_for_log = config.host.clone();
+        let default_shell = config.default_shell.clone();
+        let startup_command = config.startup_command.clone();
 
-        let authenticated = match &config.auth_method {
-            AuthMethod::Password { password } => handle
-                .authenticate_password(&config.username, password)
-                .await
-                .map_err(|e| SshError::AuthenticationFailed(e.to_string()))?,
-            AuthMethod::PrivateKey {
-                key_path,
-                passphrase,
-            } => {
-                let key_data = tokio::fs::read_to_string(key_path)
-                    .await
-                    .map_err(|e| SshError::IoError(e.to_string()))?;
+        let AuthenticatedHandle { handle, jump_chain } =
+            open_authenticated_handle(config, russh_config).await?;
 
-                // Auto-convert PPK to OpenSSH if detected
-                let key_data = if super::keys::is_ppk_format(&key_data) {
-                    let kp = key_path.clone();
-                    let pp = passphrase.clone();
-                    tokio::task::spawn_blocking(move || {
-                        super::keys::convert_ppk_to_openssh(&kp, pp.as_deref())
-                    })
-                    .await
-                    .map_err(|e| SshError::IoError(format!("task panicked: {e}")))?
-                    ?
-                } else {
-                    key_data
-                };
-
-                Self::auth_with_key_data(
-                    &mut handle,
-                    &config.username,
-                    &key_data,
-                    passphrase.as_deref(),
-                )
-                .await?
-            }
-            AuthMethod::PrivateKeyData {
-                key_data,
-                passphrase,
-            } => {
-                Self::auth_with_key_data(
-                    &mut handle,
-                    &config.username,
-                    key_data,
-                    passphrase.as_deref(),
-                )
-                .await?
-            }
-        };
-
-        if !authenticated {
-            return Err(SshError::AuthenticationFailed(
-                "server rejected credentials".to_string(),
-            ));
-        }
-
-        info!(session_id = %sid, host = %config.host, "SSH authenticated");
+        info!(session_id = %sid, host = %host_for_log, "SSH authenticated");
 
         let session = SshSession::open_pty(
             handle,
@@ -121,8 +84,9 @@ impl SshManager {
             80,
             24,
             app_handle,
-            config.default_shell.clone(),
-            config.startup_command.clone(),
+            default_shell,
+            startup_command,
+            jump_chain,
         )
         .await?;
 
@@ -146,72 +110,18 @@ impl SshManager {
             ..Default::default()
         });
 
-        let addr = format!("{}:{}", config.host, config.port);
-        let handler = SshClientHandler;
-        let mut handle = client::connect(russh_config, &addr, handler)
-            .await
-            .map_err(|e| SshError::ConnectionFailed(e.to_string()))?;
+        let host_for_log = config.host.clone();
+        let AuthenticatedHandle { handle, jump_chain } =
+            open_authenticated_handle(config, russh_config).await?;
 
-        let authenticated = match &config.auth_method {
-            AuthMethod::Password { password } => handle
-                .authenticate_password(&config.username, password)
-                .await
-                .map_err(|e| SshError::AuthenticationFailed(e.to_string()))?,
-            AuthMethod::PrivateKey {
-                key_path,
-                passphrase,
-            } => {
-                let key_data = tokio::fs::read_to_string(key_path)
-                    .await
-                    .map_err(|e| SshError::IoError(e.to_string()))?;
-
-                // Auto-convert PPK to OpenSSH if detected
-                let key_data = if super::keys::is_ppk_format(&key_data) {
-                    let kp = key_path.clone();
-                    let pp = passphrase.clone();
-                    tokio::task::spawn_blocking(move || {
-                        super::keys::convert_ppk_to_openssh(&kp, pp.as_deref())
-                    })
-                    .await
-                    .map_err(|e| SshError::IoError(format!("task panicked: {e}")))?
-                    ?
-                } else {
-                    key_data
-                };
-
-                Self::auth_with_key_data(
-                    &mut handle,
-                    &config.username,
-                    &key_data,
-                    passphrase.as_deref(),
-                )
-                .await?
-            }
-            AuthMethod::PrivateKeyData {
-                key_data,
-                passphrase,
-            } => {
-                Self::auth_with_key_data(
-                    &mut handle,
-                    &config.username,
-                    key_data,
-                    passphrase.as_deref(),
-                )
-                .await?
-            }
-        };
-
-        if !authenticated {
-            return Err(SshError::AuthenticationFailed(
-                "server rejected credentials".to_string(),
-            ));
-        }
-
-        info!(session_id = %sid, host = %config.host, "SSH authenticated (no PTY, for SFTP)");
+        info!(session_id = %sid, host = %host_for_log, "SSH authenticated (no PTY, for SFTP)");
 
         self.bare_handles.insert(
             sid.clone(),
-            Arc::new(tokio::sync::Mutex::new(handle)),
+            BareHandle {
+                handle: Arc::new(Mutex::new(handle)),
+                jump_chain,
+            },
         );
 
         Ok(session_id)
@@ -247,7 +157,7 @@ impl SshManager {
             return Ok(entry.value().ssh_handle());
         }
         if let Some(entry) = self.bare_handles.get(session_id) {
-            return Ok(entry.value().clone());
+            return Ok(entry.value().handle.clone());
         }
         Err(SshError::SessionNotFound(session_id.to_string()))
     }
@@ -337,5 +247,277 @@ impl SshManager {
 
         info!(session_id = %session_id, "SSH disconnected");
         Ok(())
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Proxy-aware connection helper
+// ────────────────────────────────────────────────────────────────────────────
+
+/// Build the SSH transport (direct TCP, ProxyCommand subprocess, or ProxyJump
+/// channel) and authenticate. Returns the authenticated handle along with any
+/// upstream jump handles that must outlive it.
+///
+/// Precedence matches OpenSSH: if both `proxy_command` and `proxy_jump` are
+/// set on the config, `proxy_command` wins.
+///
+/// Returns a `BoxFuture` because the ProxyJump branch recurses into itself —
+/// async fn recursion requires a heap-allocated future with a fixed size.
+fn open_authenticated_handle(
+    config: HostConfig,
+    russh_cfg: Arc<client::Config>,
+) -> std::pin::Pin<
+    Box<dyn std::future::Future<Output = Result<AuthenticatedHandle, SshError>> + Send>,
+> {
+    Box::pin(open_authenticated_handle_inner(config, russh_cfg))
+}
+
+async fn open_authenticated_handle_inner(
+    config: HostConfig,
+    russh_cfg: Arc<client::Config>,
+) -> Result<AuthenticatedHandle, SshError> {
+    let mut jump_chain: Vec<Arc<Mutex<client::Handle<SshClientHandler>>>> = Vec::new();
+
+    let mut handle = if let Some(cmd) = config.proxy_command.as_ref() {
+        // ── ProxyCommand: spawn subprocess via shell, pipe stdio to russh ──
+        let expanded = expand_proxy_command_tokens(
+            cmd.trim(),
+            &config.host,
+            config.port,
+            &config.username,
+        );
+        if expanded.is_empty() {
+            return Err(SshError::ConnectionFailed(
+                "ProxyCommand is empty after token expansion".to_string(),
+            ));
+        }
+        #[cfg(not(windows))]
+        let (shell, flag): (&str, &str) = ("sh", "-c");
+        #[cfg(windows)]
+        let (shell, flag): (&str, &str) = ("cmd", "/C");
+
+        let stream = russh_config::Stream::proxy_command(shell, &[flag, expanded.as_str()])
+            .await
+            .map_err(|e| {
+                SshError::ConnectionFailed(format!("ProxyCommand failed to spawn: {e}"))
+            })?;
+        client::connect_stream(russh_cfg.clone(), stream, SshClientHandler)
+            .await
+            .map_err(|e| SshError::ConnectionFailed(e.to_string()))?
+    } else if let Some(jump_str) = config.proxy_jump.as_ref() {
+        // ── ProxyJump (single-hop): SSH to bastion, then direct-tcpip to target ──
+        if jump_str.contains(',') {
+            return Err(SshError::ConnectionFailed(
+                "Multi-hop ProxyJump is not supported in v1. Express the chain via ProxyCommand (e.g. `ssh -J a,b -W %h:%p`) instead.".to_string(),
+            ));
+        }
+        let (jump_user, jump_host, jump_port) =
+            parse_proxy_jump(jump_str.trim(), &config.username);
+        let jump_config = HostConfig {
+            host: jump_host,
+            port: jump_port,
+            username: jump_user,
+            auth_method: config.auth_method.clone(),
+            label: None,
+            keep_alive_interval: None,
+            default_shell: None,
+            startup_command: None,
+            proxy_jump: None,
+            proxy_command: None,
+        };
+
+        // Recurse to authenticate the jump host (this call is itself boxed
+        // by the outer `open_authenticated_handle` indirection).
+        let jump_auth: AuthenticatedHandle =
+            open_authenticated_handle(jump_config, russh_cfg.clone()).await?;
+
+        let channel = jump_auth
+            .handle
+            .channel_open_direct_tcpip(
+                config.host.clone(),
+                config.port as u32,
+                "127.0.0.1",
+                0,
+            )
+            .await
+            .map_err(|e| {
+                SshError::ConnectionFailed(format!(
+                    "ProxyJump: failed to open direct-tcpip channel: {e}"
+                ))
+            })?;
+        let stream = channel.into_stream();
+
+        // Anchor the jump handle (and its own jumps, transitively) so they
+        // outlive the target session — dropping them would kill the transport.
+        let mut chain = jump_auth.jump_chain;
+        chain.push(Arc::new(Mutex::new(jump_auth.handle)));
+        jump_chain = chain;
+
+        client::connect_stream(russh_cfg.clone(), stream, SshClientHandler)
+            .await
+            .map_err(|e| SshError::ConnectionFailed(e.to_string()))?
+    } else {
+        // ── No proxy: plain TCP (the original code path) ──
+        let addr = format!("{}:{}", config.host, config.port);
+        client::connect(russh_cfg.clone(), &addr, SshClientHandler)
+            .await
+            .map_err(|e| SshError::ConnectionFailed(e.to_string()))?
+    };
+
+    let authenticated = match &config.auth_method {
+        AuthMethod::Password { password } => handle
+            .authenticate_password(&config.username, password)
+            .await
+            .map_err(|e| SshError::AuthenticationFailed(e.to_string()))?,
+        AuthMethod::PrivateKey {
+            key_path,
+            passphrase,
+        } => {
+            let key_data = tokio::fs::read_to_string(key_path)
+                .await
+                .map_err(|e| SshError::IoError(e.to_string()))?;
+
+            // Auto-convert PPK to OpenSSH if detected
+            let key_data = if super::keys::is_ppk_format(&key_data) {
+                let kp = key_path.clone();
+                let pp = passphrase.clone();
+                tokio::task::spawn_blocking(move || {
+                    super::keys::convert_ppk_to_openssh(&kp, pp.as_deref())
+                })
+                .await
+                .map_err(|e| SshError::IoError(format!("task panicked: {e}")))??
+            } else {
+                key_data
+            };
+
+            SshManager::auth_with_key_data(
+                &mut handle,
+                &config.username,
+                &key_data,
+                passphrase.as_deref(),
+            )
+            .await?
+        }
+        AuthMethod::PrivateKeyData {
+            key_data,
+            passphrase,
+        } => {
+            SshManager::auth_with_key_data(
+                &mut handle,
+                &config.username,
+                key_data,
+                passphrase.as_deref(),
+            )
+            .await?
+        }
+    };
+
+    if !authenticated {
+        return Err(SshError::AuthenticationFailed(
+            "server rejected credentials".to_string(),
+        ));
+    }
+
+    Ok(AuthenticatedHandle { handle, jump_chain })
+}
+
+/// Expand OpenSSH ProxyCommand tokens: `%h` → host, `%p` → port, `%r` →
+/// remote user, `%%` → literal `%`. Unknown `%X` sequences pass through
+/// unchanged (matches OpenSSH).
+fn expand_proxy_command_tokens(cmd: &str, host: &str, port: u16, user: &str) -> String {
+    let mut out = String::with_capacity(cmd.len());
+    let mut chars = cmd.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c != '%' {
+            out.push(c);
+            continue;
+        }
+        match chars.next() {
+            Some('h') => out.push_str(host),
+            Some('p') => {
+                out.push_str(&port.to_string());
+            }
+            Some('r') => out.push_str(user),
+            Some('%') => out.push('%'),
+            Some(other) => {
+                out.push('%');
+                out.push(other);
+            }
+            None => out.push('%'),
+        }
+    }
+    out
+}
+
+/// Parse a ProxyJump value `[user@]host[:port]` into (user, host, port).
+/// Falls back to the default user and port 22 when omitted.
+fn parse_proxy_jump(s: &str, default_user: &str) -> (String, String, u16) {
+    let (user, hostport) = match s.split_once('@') {
+        Some((u, h)) if !u.is_empty() => (u.to_string(), h),
+        _ => (default_user.to_string(), s),
+    };
+    // Use rsplit_once so IPv6 brackets / hostnames containing ':' aren't an
+    // issue for the common case `host:port` written by users and ssh-config.
+    let (host, port) = match hostport.rsplit_once(':') {
+        Some((h, p)) => {
+            let parsed = p.trim().parse::<u16>().unwrap_or(22);
+            (h.trim().to_string(), parsed)
+        }
+        None => (hostport.trim().to_string(), 22u16),
+    };
+    (user, host, port)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn expand_tokens_basic() {
+        assert_eq!(
+            expand_proxy_command_tokens("nc %h %p", "example.com", 22, "alice"),
+            "nc example.com 22"
+        );
+    }
+
+    #[test]
+    fn expand_tokens_user_and_literal_percent() {
+        assert_eq!(
+            expand_proxy_command_tokens("ssh -l %r %h:%p && echo 100%%", "h", 2222, "bob"),
+            "ssh -l bob h:2222 && echo 100%"
+        );
+    }
+
+    #[test]
+    fn expand_tokens_unknown_passthrough() {
+        // OpenSSH leaves unknown tokens alone.
+        assert_eq!(
+            expand_proxy_command_tokens("echo %x %h", "host", 22, "u"),
+            "echo %x host"
+        );
+    }
+
+    #[test]
+    fn parse_jump_full() {
+        let (u, h, p) = parse_proxy_jump("alice@bastion.example.com:2222", "fallback");
+        assert_eq!((u.as_str(), h.as_str(), p), ("alice", "bastion.example.com", 2222));
+    }
+
+    #[test]
+    fn parse_jump_host_only() {
+        let (u, h, p) = parse_proxy_jump("bastion", "fallback");
+        assert_eq!((u.as_str(), h.as_str(), p), ("fallback", "bastion", 22));
+    }
+
+    #[test]
+    fn parse_jump_user_only() {
+        let (u, h, p) = parse_proxy_jump("alice@bastion", "fallback");
+        assert_eq!((u.as_str(), h.as_str(), p), ("alice", "bastion", 22));
+    }
+
+    #[test]
+    fn parse_jump_host_port() {
+        let (u, h, p) = parse_proxy_jump("bastion:2222", "fallback");
+        assert_eq!((u.as_str(), h.as_str(), p), ("fallback", "bastion", 2222));
     }
 }

--- a/src-tauri/src/ssh/session.rs
+++ b/src-tauri/src/ssh/session.rs
@@ -35,6 +35,10 @@ pub struct SshSession {
     #[allow(dead_code)]
     session_id: String,
     split_config: SplitConfig,
+    /// Upstream jump-host handles kept alive for the lifetime of this session.
+    /// Dropping them would tear down the channel used as transport for `handle`.
+    #[allow(dead_code)]
+    jump_chain: Vec<Arc<Mutex<Handle<SshClientHandler>>>>,
 }
 
 impl SshSession {
@@ -48,6 +52,7 @@ impl SshSession {
         app_handle: AppHandle,
         default_shell: Option<String>,
         startup_command: Option<String>,
+        jump_chain: Vec<Arc<Mutex<Handle<SshClientHandler>>>>,
     ) -> Result<Self, SshError> {
         // Wrap the handle immediately so it can be shared with SFTP later.
         let handle = Arc::new(Mutex::new(handle));
@@ -170,6 +175,7 @@ impl SshSession {
             reader_task,
             session_id,
             split_config: SplitConfig { default_shell },
+            jump_chain,
         })
     }
 
@@ -276,6 +282,7 @@ impl SshSession {
             reader_task,
             session_id,
             split_config: SplitConfig { default_shell },
+            jump_chain: Vec::new(),
         })
     }
 

--- a/src-tauri/src/types/session.rs
+++ b/src-tauri/src/types/session.rs
@@ -53,6 +53,11 @@ pub struct HostConfig {
     pub default_shell: Option<String>,
     /// Command to execute after the shell is ready.
     pub startup_command: Option<String>,
+    /// Single-hop ProxyJump: `[user@]host[:port]`. Ignored if `proxy_command` is set.
+    pub proxy_jump: Option<String>,
+    /// OpenSSH-style ProxyCommand. Tokens %h/%p/%r are expanded at connect time.
+    /// Run via `sh -c` (Unix) or `cmd /C` (Windows) so quotes/pipes/env vars work.
+    pub proxy_command: Option<String>,
 }
 
 /// Lifecycle state of a single SSH session.

--- a/src-tauri/tests/proxy_command_import.rs
+++ b/src-tauri/tests/proxy_command_import.rs
@@ -1,0 +1,28 @@
+//! Verify ssh2-config 0.7 populates `unsupported_fields["proxycommand"]`
+//! the way our import code expects.
+
+use ssh2_config::{ParseRule, SshConfig};
+use std::io::BufReader;
+
+#[test]
+fn proxy_command_lands_in_unsupported_fields() {
+    let cfg = "Host testhost\n  HostName 198.51.100.10\n  User alice\n  ProxyCommand ssh -W %h:%p user@bastion.example.com\n\nHost *\n  ServerAliveInterval 30\n";
+    let mut reader = BufReader::new(cfg.as_bytes());
+
+    let config = SshConfig::default()
+        .parse(
+            &mut reader,
+            ParseRule::ALLOW_UNKNOWN_FIELDS | ParseRule::ALLOW_UNSUPPORTED_FIELDS,
+        )
+        .expect("parse ok");
+
+    let params = config.query("testhost");
+    eprintln!("unsupported_fields keys: {:?}", params.unsupported_fields.keys().collect::<Vec<_>>());
+    eprintln!("unsupported_fields full: {:?}", params.unsupported_fields);
+
+    let pcmd = params.unsupported_fields.get("proxycommand");
+    assert!(pcmd.is_some(), "expected proxycommand key, got {:?}", params.unsupported_fields);
+    let joined = pcmd.unwrap().join(" ");
+    eprintln!("joined ProxyCommand: {}", joined);
+    assert!(joined.contains("bastion.example.com"));
+}

--- a/src/components/dashboard/HostEditModal.tsx
+++ b/src/components/dashboard/HostEditModal.tsx
@@ -26,6 +26,7 @@ interface FormState {
   groupId: string;
   keyPath: string;
   proxyJump: string;
+  proxyCommand: string;
   keepAliveInterval: string;
   defaultShell: string;
   startupCommand: string;
@@ -49,6 +50,7 @@ const EMPTY_FORM: FormState = {
   groupId: "",
   keyPath: "",
   proxyJump: "",
+  proxyCommand: "",
   keepAliveInterval: "",
   defaultShell: "",
   startupCommand: "",
@@ -81,6 +83,7 @@ function savedHostToForm(host: SavedHost): FormState {
     groupId: host.group_id ?? "",
     keyPath: host.key_path ?? "",
     proxyJump: host.proxy_jump ?? "",
+    proxyCommand: host.proxy_command ?? "",
     keepAliveInterval: host.keep_alive_interval != null ? String(host.keep_alive_interval) : "",
     defaultShell: host.default_shell ?? "",
     startupCommand: host.startup_command ?? "",
@@ -288,6 +291,7 @@ export function HostEditModal() {
       os_type: null,
       startup_command: null,
       proxy_jump: null,
+      proxy_command: null,
       keep_alive_interval: null,
       default_shell: null,
       font_size: null,
@@ -307,6 +311,7 @@ export function HostEditModal() {
         ? form.keyPath.trim()
         : null,
       proxy_jump: form.proxyJump.trim() || null,
+      proxy_command: form.proxyCommand.trim() || null,
       keep_alive_interval: form.keepAliveInterval.trim()
         ? parseInt(form.keepAliveInterval, 10)
         : null,
@@ -721,7 +726,48 @@ export function HostEditModal() {
                 </>
               )}
 
-              {/* TODO: Proxy / Jump Host — hidden until backend support is implemented */}
+              {/* ════════════════ PROXY / JUMP HOST ════════════════ */}
+              <SectionHeader>Proxy / Jump host</SectionHeader>
+
+              {/* ProxyJump (single-hop bastion) */}
+              <div>
+                <label htmlFor="hem-proxy-jump" className={labelClass}>
+                  ProxyJump
+                  <span className="ml-1 text-text-muted font-normal">(optional)</span>
+                </label>
+                <input
+                  id="hem-proxy-jump"
+                  type="text"
+                  value={form.proxyJump}
+                  onChange={(e) => setField("proxyJump", e.target.value)}
+                  placeholder="user@bastion.example.com:22"
+                  disabled={isBusy}
+                  className={`${inputClass} font-mono`}
+                />
+                <p className="mt-1 text-[length:var(--text-xs)] text-text-muted">
+                  Single-hop only. Reuses this host&apos;s credentials to authenticate to the bastion.
+                </p>
+              </div>
+
+              {/* ProxyCommand */}
+              <div>
+                <label htmlFor="hem-proxy-command" className={labelClass}>
+                  ProxyCommand
+                  <span className="ml-1 text-text-muted font-normal">(optional)</span>
+                </label>
+                <input
+                  id="hem-proxy-command"
+                  type="text"
+                  value={form.proxyCommand}
+                  onChange={(e) => setField("proxyCommand", e.target.value)}
+                  placeholder="ssh -W %h:%p user@bastion"
+                  disabled={isBusy}
+                  className={`${inputClass} font-mono`}
+                />
+                <p className="mt-1 text-[length:var(--text-xs)] text-text-muted">
+                  Runs as a local subprocess. Tokens: %h host, %p port, %r remote user. If both proxy fields are set, ProxyCommand wins.
+                </p>
+              </div>
 
               {/* Keep Alive + Default Shell row */}
               <div className="flex gap-3">

--- a/src/components/dashboard/ImportSshConfigModal.tsx
+++ b/src/components/dashboard/ImportSshConfigModal.tsx
@@ -86,6 +86,7 @@ export function ImportSshConfigModal({ onClose, onImported }: ImportSshConfigMod
           port: e.port ?? 22,
           identity_file: e.identity_file,
           proxy_jump: e.proxy_jump,
+          proxy_command: e.proxy_command,
           keep_alive_interval: e.keep_alive_interval,
         }));
 

--- a/src/types/ssh.ts
+++ b/src/types/ssh.ts
@@ -14,6 +14,8 @@ export interface HostConfig {
   keep_alive_interval?: number;
   default_shell?: string;
   startup_command?: string;
+  proxy_jump?: string;
+  proxy_command?: string;
 }
 
 export type ConnectionStatus =
@@ -70,6 +72,7 @@ export interface SavedHost {
   os_type: string | null;              // "linux" | "macos" | "windows" | "freebsd"
   startup_command: string | null;
   proxy_jump: string | null;
+  proxy_command: string | null;
   keep_alive_interval: number | null;
   default_shell: string | null;
   font_size: number | null;
@@ -113,6 +116,7 @@ export interface SshConfigEntry {
   port: number | null;
   identity_file: string | null;
   proxy_jump: string | null;
+  proxy_command: string | null;
   keep_alive_interval: number | null;
   is_pattern: boolean;
   already_exists: boolean;


### PR DESCRIPTION
## Summary

The README already advertises "proxy jump (bastion host)" support, but it turns out `manager.rs` never reads the `proxy_jump` field — the connection always goes direct TCP. So the field has been stored, imported from `~/.ssh/config`, and editable in the UI, but ignored at connect time. This PR wires it up for real and adds ProxyCommand alongside it.

Highlights:

- New `ProxyCommand` field, end-to-end (struct → DB migration → form → import → connect).
- Single-hop ProxyJump now actually does something — native via russh's `channel_open_direct_tcpip`, no shell-out to system `ssh`.
- Both PTY (`connect`) and SFTP (`connect_no_pty`) paths go through one shared `open_authenticated_handle` helper, so SFTP gets proxy support automatically.
- ssh_config importer now picks up `ProxyCommand` directives (it was already grabbing `ProxyJump`).
- README tightened so it stops overstating what's shipped.

## How it works

Transport selection (matches OpenSSH precedence: ProxyCommand wins if both are set):

1. **ProxyCommand**: tokens `%h`/`%p`/`%r`/`%%` are expanded, then the string is handed to `sh -c` (Unix) / `cmd /C` (Windows) via `russh_config::Stream::proxy_command`. Wrapping in a shell rather than calling `Stream`'s built-in `split(' ')` keeps quotes, pipes, env vars and `~` expansion working — matters for anything copy-pasted from `~/.ssh/config`.
2. **ProxyJump**: parse `[user@]host[:port]`, recursively authenticate to the bastion (reusing the target's auth method), open a `direct-tcpip` channel to `(target_host, target_port)`, then feed `channel.into_stream()` to `russh::client::connect_stream` for the target session. The bastion handle is kept alive in `AuthenticatedHandle.jump_chain` — dropping it would tear down the transport.
3. **Neither set**: plain TCP, same code path as before.

Multi-hop ProxyJump (`a,b,c`) is rejected with an error message pointing at ProxyCommand. ~95% of bastion setups are single-hop, and chains have an escape hatch via `ProxyCommand ssh -J a,b,c -W %h:%p`.

## UI

`HostEditModal` gains a "Proxy / Jump host" section with two inputs:

- **ProxyJump** — `[user@]host[:port]`. Hint: "Single-hop only. Reuses this host's credentials to authenticate to the bastion."
- **ProxyCommand** — raw OpenSSH-style command. Hint: "Runs as a local subprocess. Tokens: %h host, %p port, %r remote user. If both proxy fields are set, ProxyCommand wins."

## Why russh-config instead of building it ourselves

`russh-config 0.48` provides `Stream::tcp_connect` / `Stream::proxy_command` returning an `AsyncRead + AsyncWrite` you can feed straight to `russh::client::connect_stream`. No need to hand-roll subprocess piping. Note: `russh-config` itself doesn't handle ProxyJump — its `Config::stream()` only does ProxyCommand. The jump logic in this PR uses raw `russh` channels.

The crate is added as a separate dep at `"0.48"`. It's standalone (no transitive dep on `russh`), so the version skew with this project's `russh = "0.46"` doesn't matter.

## Why native ProxyJump and not shell out to `ssh -J`

Shelling out to system `ssh` would have been ~2 lines (just feed it through ProxyCommand), but:

- Windows users without OpenSSH installed would silently lose ProxyJump support.
- known_hosts trust and ssh-agent keys would split between anyscp's own store and `~/.ssh/`, leading to "works in Terminal but not in anyscp" support tickets.
- The app already owns the full SSH stack (PPK conversion, keychain, etc.) — going native here is consistent.

## Files

| File | Change |
|---|---|
| `src-tauri/Cargo.toml` | + `russh-config = "0.48"` |
| `src-tauri/src/types/session.rs` | `HostConfig` gains `proxy_jump`, `proxy_command` |
| `src-tauri/src/db/mod.rs` | Migration 11→12 adds `proxy_command` column; `SavedHost` field + every SQL site |
| `src-tauri/src/ssh/manager.rs` | Shared `open_authenticated_handle`; transport builder; token expansion; jump-chain anchoring |
| `src-tauri/src/ssh/session.rs` | `SshSession` carries the optional `jump_chain` anchor |
| `src-tauri/src/ssh/commands.rs`, `portforward/commands.rs` | Forward proxy fields when building `HostConfig` |
| `src-tauri/src/import/mod.rs` | Enable `ALLOW_UNSUPPORTED_FIELDS`; extract ProxyCommand from `unsupported_fields["proxycommand"]` |
| `src-tauri/src/import/commands.rs` | Pass `proxy_command` through to `SavedHost` |
| `src-tauri/tests/proxy_command_import.rs` | Integration test pinning the ssh2-config assumption |
| `src/types/ssh.ts` | TS types updated |
| `src/components/dashboard/HostEditModal.tsx` | New section + form fields + state wiring |
| `src/components/dashboard/ImportSshConfigModal.tsx` | Forward `proxy_command` on import |
| `README.md` | Updated to match shipped behaviour |
| `pnpm-workspace.yaml` | Approve esbuild build script + disable pnpm 11's pre-flight deps check (otherwise `pnpm tauri dev` errors on a fresh checkout) |

## Test plan

- [x] `cargo check` clean
- [x] `cargo test --lib` — 7 new unit tests for `expand_proxy_command_tokens` and `parse_proxy_jump`, all pass
- [x] `cargo test --test proxy_command_import` — verifies ssh2-config behaviour our extractor depends on
- [x] `tsc --noEmit` clean
- [x] Manual: DB migration `11→12` ran against an existing `anyscp.db` without losing data
- [x] Manual: imported `~/.ssh/config` with `ProxyCommand /path/to/script %h %p` — value appears in the DB and the host edit modal
- [x] Manual: connect through ProxyCommand against a working AWS SSM ssh-proxy script

Things that are intentionally out of scope:

- Multi-hop ProxyJump (errors with a clear pointer to ProxyCommand).
- Separate credentials for the jump host (reuses target's auth).
- "Test connection" button (the existing Save-and-connect flow is the de-facto test).