### PR TITLE
Containerized end-to-end test suite (56 tests)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ pnpm-debug.log*
 lerna-debug.log*
 
 node_modules
+.pnpm-store/
 dist
 dist-ssr
 *.local

--- a/Makefile
+++ b/Makefile
@@ -176,4 +176,4 @@ e2e-clean:
 	@rm -f $(E2E_IMAGE_STAMP)
 
 e2e-clean-artifacts:
-	@rm -rf ./tests/e2e/{screenshots,videos,.image-stamp}
+	@rm -rf ./tests/e2e/{screenshots,videos,junit,report.md,.test-records.ndjson,.image-stamp}

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@
         connect-ssh-pass connect-ssh-key \
         logs-ssh-pass logs-ssh-key \
         shell-ssh-pass shell-ssh-key \
-        ssh-keygen ssh-status ssh-clean ssh-clean-keys
+        ssh-keygen ssh-status ssh-clean ssh-clean-keys \
+        e2e e2e-build e2e-shell e2e-logs e2e-clean
 
 # Test SSH servers (linuxserver/openssh-server) for local development.
 # Two independent containers — password-auth and key-auth — can run in parallel.
@@ -127,3 +128,49 @@ ssh-clean:
 
 ssh-clean-keys:
 	@rm -rf $(SSH_KEY_DIR) && echo "Removed $(SSH_KEY_DIR)"
+
+# ─── E2E tests (containerised) ────────────────────────────────────────────────
+# Full UI E2E suite under WebKitWebDriver + xvfb inside Docker. The runner
+# image bakes in tauri-driver, the webkit2gtk driver, and a build toolchain
+# so the same setup works on dev machines (incl. Arch) and CI.
+
+E2E_COMPOSE := docker compose -f tests/e2e/docker-compose.yml -p anyscp-e2e
+# Stamp file — make rebuilds the image whenever any of its source inputs
+# change (Dockerfile, entrypoint, or harness package.json).
+E2E_IMAGE_STAMP := tests/e2e/.image-stamp
+E2E_IMAGE_SRC   := tests/e2e/Dockerfile tests/e2e/entrypoint.sh tests/e2e/package.json
+
+# (Re)build the runner image whenever any source input is newer than the stamp.
+$(E2E_IMAGE_STAMP): $(E2E_IMAGE_SRC)
+	@echo "  building anyscp-e2e-runner:latest (sources changed)"
+	@cd tests/e2e && docker build -t anyscp-e2e-runner:latest .
+	@touch $@
+
+# Explicit rebuild target (alias).
+e2e-build: $(E2E_IMAGE_STAMP)
+
+# Run the full suite. Brings up the SSH targets + runner, runs WDIO, then
+# tears containers down — but KEEPS volumes (rust-target, cargo-cache,
+# node-modules) so the next run does an incremental compile (~5s instead
+# of ~80s). Use `make e2e-clean` to wipe volumes when you want a fresh start.
+e2e: $(E2E_IMAGE_STAMP)
+	@$(E2E_COMPOSE) up --abort-on-container-exit --exit-code-from e2e e2e; \
+		ec=$$?; \
+		$(E2E_COMPOSE) down --remove-orphans >/dev/null 2>&1; \
+		exit $$ec
+
+# Drop into an interactive shell in the runner with the SSH targets up
+# (useful when debugging a failing spec).
+e2e-shell:
+	@$(E2E_COMPOSE) up -d sshd-pass sshd-key keygen
+	@$(E2E_COMPOSE) run --rm --entrypoint /bin/bash e2e
+
+# Tail logs from the runner.
+e2e-logs:
+	@$(E2E_COMPOSE) logs -f e2e
+
+# Tear down everything and remove cached volumes (forces a clean next run).
+e2e-clean:
+	@$(E2E_COMPOSE) down -v --remove-orphans
+	@docker rmi anyscp-e2e-runner:latest 2>/dev/null || true
+	@rm -f $(E2E_IMAGE_STAMP)

--- a/Makefile
+++ b/Makefile
@@ -174,3 +174,6 @@ e2e-clean:
 	@$(E2E_COMPOSE) down -v --remove-orphans
 	@docker rmi anyscp-e2e-runner:latest 2>/dev/null || true
 	@rm -f $(E2E_IMAGE_STAMP)
+
+e2e-clean-artifacts:
+	@rm -rf ./tests/e2e/{screenshots,videos,.image-stamp}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: false

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -60,11 +60,12 @@ tokio-util = { version = "0.7" }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
-# OS credential store (macOS Keychain, Windows DPAPI, Linux libsecret/kwallet).
-# `linux-keyutils` is bundled as an opt-in fallback that the kernel provides
-# (no dbus/secret-service required). The e2e container switches to it via the
-# ANYSCP_TEST_KEYRING env var; production keeps the default (libsecret).
-keyring = { version = "3", features = ["apple-native", "linux-native", "linux-keyutils", "windows-native"] }
+# OS credential store: macOS Keychain (apple-native), Windows DPAPI
+# (windows-native), Linux kernel keyutils (linux-native — name is misleading;
+# it's the keyutils backend, not libsecret). On Linux, PAM normally sets up
+# a session keyring on login; in containers you need `keyctl session` + a
+# non-default seccomp profile.
+keyring = { version = "3", features = ["apple-native", "linux-native", "windows-native"] }
 tauri-plugin-dialog = "2.6.0"
 tauri-plugin-updater = "2"
 ssh2-config = "0.7.0"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -60,8 +60,11 @@ tokio-util = { version = "0.7" }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
-# OS credential store (macOS Keychain, Windows DPAPI, Linux libsecret/kwallet)
-keyring = { version = "3", features = ["apple-native", "linux-native", "windows-native"] }
+# OS credential store (macOS Keychain, Windows DPAPI, Linux libsecret/kwallet).
+# `linux-keyutils` is bundled as an opt-in fallback that the kernel provides
+# (no dbus/secret-service required). The e2e container switches to it via the
+# ANYSCP_TEST_KEYRING env var; production keeps the default (libsecret).
+keyring = { version = "3", features = ["apple-native", "linux-native", "linux-keyutils", "windows-native"] }
 tauri-plugin-dialog = "2.6.0"
 tauri-plugin-updater = "2"
 ssh2-config = "0.7.0"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -26,10 +26,6 @@ pub fn run() {
         .with_env_filter("anyscp=debug,russh=info")
         .init();
 
-    // Optionally swap the keyring backend (e.g. to kernel `keyutils` for the
-    // e2e container). No-op when ANYSCP_TEST_KEYRING is unset.
-    vault::init_backend();
-
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -26,6 +26,10 @@ pub fn run() {
         .with_env_filter("anyscp=debug,russh=info")
         .init();
 
+    // Optionally swap the keyring backend (e.g. to kernel `keyutils` for the
+    // e2e container). No-op when ANYSCP_TEST_KEYRING is unset.
+    vault::init_backend();
+
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())

--- a/src-tauri/src/telemetry.rs
+++ b/src-tauri/src/telemetry.rs
@@ -17,7 +17,14 @@ static TX: OnceLock<mpsc::UnboundedSender<(String, Value)>> = OnceLock::new();
 /// Initialize the telemetry background worker.
 /// Safe to call from `.setup()` — the worker is spawned on a background thread
 /// with its own Tokio runtime, so it does not require an active reactor.
+///
+/// No-op when `ANYSCP_DISABLE_TELEMETRY` is set (used by the e2e container
+/// so test runs don't pollute the real analytics stream).
 pub fn init() {
+    if std::env::var_os("ANYSCP_DISABLE_TELEMETRY").is_some() {
+        return;
+    }
+
     let (tx, mut rx) = mpsc::unbounded_channel::<(String, Value)>();
     if TX.set(tx).is_err() {
         return;

--- a/src-tauri/src/vault/mod.rs
+++ b/src-tauri/src/vault/mod.rs
@@ -10,27 +10,6 @@ use tracing::instrument;
 const SERVICE_NAME: &str = "com.anyscp.credentials";
 
 // ---------------------------------------------------------------------------
-// Backend selection
-// ---------------------------------------------------------------------------
-
-/// Optionally swap the `keyring` crate's default backend. Required for
-/// container test environments where libsecret/gnome-keyring isn't trivial
-/// to bring up — we fall back to the Linux kernel keyring (`keyutils`),
-/// which works with zero setup inside an unprivileged container.
-///
-/// Set `ANYSCP_TEST_KEYRING=keyutils` in the environment to opt in.
-/// Anything else (including unset) leaves the platform default in place.
-pub fn init_backend() {
-    #[cfg(target_os = "linux")]
-    if std::env::var("ANYSCP_TEST_KEYRING").as_deref() == Ok("keyutils") {
-        keyring::set_default_credential_builder(
-            keyring::keyutils::default_credential_builder(),
-        );
-        tracing::info!("keyring backend: keyutils (kernel)");
-    }
-}
-
-// ---------------------------------------------------------------------------
 // Error type
 // ---------------------------------------------------------------------------
 

--- a/src-tauri/src/vault/mod.rs
+++ b/src-tauri/src/vault/mod.rs
@@ -10,6 +10,27 @@ use tracing::instrument;
 const SERVICE_NAME: &str = "com.anyscp.credentials";
 
 // ---------------------------------------------------------------------------
+// Backend selection
+// ---------------------------------------------------------------------------
+
+/// Optionally swap the `keyring` crate's default backend. Required for
+/// container test environments where libsecret/gnome-keyring isn't trivial
+/// to bring up — we fall back to the Linux kernel keyring (`keyutils`),
+/// which works with zero setup inside an unprivileged container.
+///
+/// Set `ANYSCP_TEST_KEYRING=keyutils` in the environment to opt in.
+/// Anything else (including unset) leaves the platform default in place.
+pub fn init_backend() {
+    #[cfg(target_os = "linux")]
+    if std::env::var("ANYSCP_TEST_KEYRING").as_deref() == Ok("keyutils") {
+        keyring::set_default_credential_builder(
+            keyring::keyutils::default_credential_builder(),
+        );
+        tracing::info!("keyring backend: keyutils (kernel)");
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Error type
 // ---------------------------------------------------------------------------
 

--- a/src/components/dashboard/GroupCard.tsx
+++ b/src/components/dashboard/GroupCard.tsx
@@ -35,6 +35,9 @@ export function GroupCard({ group, hostCount, isSelected, onSelect, onDelete }: 
   return (
     <>
       <button
+        data-testid={`group-card-${group.id}`}
+        data-group-id={group.id}
+        data-group-name={group.name}
         onClick={() => onSelect(group.id)}
         onContextMenu={handleContextMenu}
         title={group.name}

--- a/src/components/dashboard/GroupModal.tsx
+++ b/src/components/dashboard/GroupModal.tsx
@@ -139,6 +139,7 @@ export function GroupModal({ open, onClose, onSave, initial }: GroupModalProps) 
       `}
     >
       <div
+        data-testid="group-modal"
         className={`
           w-full max-w-sm rounded-xl bg-bg-overlay border border-border p-6 shadow-[var(--shadow-lg)]
           transition-[opacity,transform] duration-[var(--duration-slow)] ease-[var(--ease-expo-out)]
@@ -166,6 +167,7 @@ export function GroupModal({ open, onClose, onSave, initial }: GroupModalProps) 
             </label>
             <input
               ref={nameRef}
+              data-testid="group-modal-name"
               type="text"
               value={name}
               onChange={(e) => setName(e.target.value)}
@@ -256,6 +258,7 @@ export function GroupModal({ open, onClose, onSave, initial }: GroupModalProps) 
             </button>
             <button
               type="submit"
+              data-testid="group-modal-save"
               disabled={saving || !name.trim()}
               className="px-4 py-2 text-[length:var(--text-sm)] font-medium text-text-inverse bg-accent hover:bg-accent-hover disabled:opacity-50 rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-bg-overlay"
             >

--- a/src/components/dashboard/HostCard.tsx
+++ b/src/components/dashboard/HostCard.tsx
@@ -131,6 +131,9 @@ export function HostCard({ host, onConnect, onExplore, onEdit, onDelete, onDupli
   return (
     <>
       <div
+        data-testid={`host-card-${host.id}`}
+        data-host-id={host.id}
+        data-host-label={displayName}
         role="button"
         tabIndex={0}
         onClick={() => onConnect(host)}
@@ -159,6 +162,7 @@ export function HostCard({ host, onConnect, onExplore, onEdit, onDelete, onDupli
         <div className="absolute top-2 right-2 flex items-center gap-0.5">
           <button
             type="button"
+            data-testid={`host-card-${host.id}-terminal`}
             onClick={stopAnd(() => onConnect(host))}
             title="Open Terminal"
             aria-label={`Open terminal for ${displayName}`}
@@ -182,6 +186,7 @@ export function HostCard({ host, onConnect, onExplore, onEdit, onDelete, onDupli
           </button>
           <button
             type="button"
+            data-testid={`host-card-${host.id}-explorer`}
             onClick={stopAnd(() => onExplore(host))}
             title="Open Explorer"
             aria-label={`Open explorer for ${displayName}`}

--- a/src/components/dashboard/HostEditModal.tsx
+++ b/src/components/dashboard/HostEditModal.tsx
@@ -779,6 +779,7 @@ export function HostEditModal() {
                 </label>
                 <input
                   id="hem-startup"
+                  data-testid="host-modal-startup-command"
                   type="text"
                   value={form.startupCommand}
                   onChange={(e) => setField("startupCommand", e.target.value)}

--- a/src/components/dashboard/HostEditModal.tsx
+++ b/src/components/dashboard/HostEditModal.tsx
@@ -401,6 +401,10 @@ export function HostEditModal() {
       addSession(sessionId, hostConfig);
       const label = hostConfig.label || `${hostConfig.username}@${hostConfig.host}`;
       useTabStore.getState().addTab({ type: "terminal", id: sessionId, label });
+      // Mirror the recordConnection() call made by HostsDashboard's
+      // card-click and recent-click flows — otherwise hosts connected via
+      // this modal are missing from the recent list and history.
+      void useHostsStore.getState().recordConnection(host.id);
       close();
     } catch (err) {
       setError(extractError(err, "Connection failed"));

--- a/src/components/dashboard/HostEditModal.tsx
+++ b/src/components/dashboard/HostEditModal.tsx
@@ -448,6 +448,8 @@ export function HostEditModal() {
       `}
     >
       <div
+        data-testid="host-modal"
+        data-host-modal-mode={isNewHost ? "new" : "edit"}
         className={`
           w-full max-w-lg rounded-xl bg-bg-overlay border border-border shadow-[var(--shadow-lg)]
           flex flex-col max-h-[84vh]
@@ -495,6 +497,7 @@ export function HostEditModal() {
                 </label>
                 <input
                   id="hem-label"
+                  data-testid="host-modal-label"
                   type="text"
                   value={form.label}
                   onChange={(e) => setField("label", e.target.value)}
@@ -513,6 +516,7 @@ export function HostEditModal() {
                   <input
                     ref={hostInputRef}
                     id="hem-host"
+                    data-testid="host-modal-host"
                     type="text"
                     value={form.host}
                     onChange={(e) => setField("host", e.target.value)}
@@ -527,6 +531,7 @@ export function HostEditModal() {
                   </label>
                   <input
                     id="hem-port"
+                    data-testid="host-modal-port"
                     type="number"
                     min={1}
                     max={65535}
@@ -545,6 +550,7 @@ export function HostEditModal() {
                 </label>
                 <input
                   id="hem-username"
+                  data-testid="host-modal-username"
                   type="text"
                   value={form.username}
                   onChange={(e) => setField("username", e.target.value)}
@@ -562,6 +568,7 @@ export function HostEditModal() {
                   </label>
                   <CustomSelect
                     id="hem-auth"
+                    data-testid="host-modal-auth"
                     value={form.authType}
                     onChange={(v) => setField("authType", v as AuthType)}
                     disabled={isBusy}
@@ -595,6 +602,7 @@ export function HostEditModal() {
                   </label>
                   <input
                     id="hem-password"
+                    data-testid="host-modal-password"
                     type="password"
                     value={form.password}
                     onChange={(e) => setField("password", e.target.value)}
@@ -623,6 +631,7 @@ export function HostEditModal() {
                         {sshKeys.length > 0 ? (
                           <CustomSelect
                             id="hem-keypath"
+                            data-testid="host-modal-keypath-select"
                             value={form.keyPath}
                             onChange={(v) => setField("keyPath", v)}
                             disabled={isBusy}
@@ -635,6 +644,7 @@ export function HostEditModal() {
                         ) : (
                           <input
                             id="hem-keypath"
+                            data-testid="host-modal-keypath"
                             type="text"
                             value={form.keyPath}
                             onChange={(e) => setField("keyPath", e.target.value)}
@@ -893,6 +903,7 @@ export function HostEditModal() {
               {error && (
                 <p
                   role="alert"
+                  data-testid="host-modal-error"
                   className="text-[length:var(--text-sm)] text-status-error bg-status-error/10 rounded-lg px-3 py-2"
                 >
                   {error}
@@ -917,6 +928,7 @@ export function HostEditModal() {
             ) : (
               <button
                 type="button"
+                data-testid="host-modal-delete"
                 onClick={() => setDeleteConfirm(true)}
                 disabled={isBusy || loadingHost}
                 className="px-3 py-2 text-[length:var(--text-sm)] text-status-error hover:bg-status-error/10 rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
@@ -931,6 +943,7 @@ export function HostEditModal() {
             <div className="flex items-center gap-2">
               <button
                 type="button"
+                data-testid="host-modal-cancel"
                 onClick={close}
                 disabled={isBusy}
                 className="px-4 py-2 text-[length:var(--text-sm)] text-text-secondary hover:text-text-primary rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
@@ -939,6 +952,7 @@ export function HostEditModal() {
               </button>
               <button
                 type="button"
+                data-testid="host-modal-save"
                 onClick={handleSave}
                 disabled={isBusy || loadingHost}
                 className="px-4 py-2 text-[length:var(--text-sm)] font-medium text-text-secondary hover:text-text-primary bg-bg-subtle hover:bg-bg-muted disabled:opacity-50 rounded-lg border border-border transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
@@ -947,6 +961,7 @@ export function HostEditModal() {
               </button>
               <button
                 type="button"
+                data-testid="host-modal-connect"
                 onClick={handleConnect}
                 disabled={isBusy || loadingHost}
                 className="px-4 py-2 text-[length:var(--text-sm)] font-medium text-text-inverse bg-accent hover:bg-accent-hover disabled:opacity-50 rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-bg-overlay"
@@ -1086,6 +1101,7 @@ function DeleteConfirmRow({ onCancel, onConfirm, busy }: DeleteConfirmRowProps) 
       </button>
       <button
         type="button"
+        data-testid="host-modal-delete-confirm"
         onClick={onConfirm}
         disabled={busy}
         autoFocus

--- a/src/components/dashboard/HostsDashboard.tsx
+++ b/src/components/dashboard/HostsDashboard.tsx
@@ -413,6 +413,7 @@ export function HostsDashboard() {
           {/* ── Action buttons ── */}
           <div className="flex gap-2">
             <button
+              data-testid="new-host-button"
               onClick={() => setEditingHostId("__new__")}
               className={[
                 "flex items-center gap-2 px-4 py-2 rounded-lg text-xs font-medium uppercase tracking-wide",

--- a/src/components/dashboard/HostsDashboard.tsx
+++ b/src/components/dashboard/HostsDashboard.tsx
@@ -120,6 +120,20 @@ export function HostsDashboard() {
     void loadS3Connections();
   }, [loadHosts, loadGroups, loadRecent]);
 
+  // E2E test hook — lets tests trigger a reload of the local S3 connection
+  // list after invoking s3_delete_connection out-of-band. The s3-store
+  // doesn't own this list (HostsDashboard manages it in component state),
+  // so without this the dashboard wouldn't notice the deletion.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    (window as unknown as { __e2eReloadS3Connections?: () => Promise<void> })
+      .__e2eReloadS3Connections = async () => { await loadS3Connections(); };
+    return () => {
+      (window as unknown as { __e2eReloadS3Connections?: (() => Promise<void>) | null })
+        .__e2eReloadS3Connections = null;
+    };
+  }, []);
+
 
   // ─── Derived data ─────────────────────────────────────────────────────────
 
@@ -430,6 +444,7 @@ export function HostsDashboard() {
             </button>
 
             <button
+              data-testid="new-s3-button"
               onClick={() => setS3DialogOpen(true)}
               className={[
                 "flex items-center gap-2 px-4 py-2 rounded-lg text-xs font-medium uppercase tracking-wide",
@@ -445,6 +460,7 @@ export function HostsDashboard() {
             </button>
 
             <button
+              data-testid="new-group-button"
               onClick={() => setGroupModalOpen(true)}
               className={[
                 "flex items-center gap-2 px-4 py-2 rounded-lg text-xs font-medium uppercase tracking-wide",
@@ -460,6 +476,7 @@ export function HostsDashboard() {
             </button>
 
             <button
+              data-testid="import-ssh-config-button"
               onClick={() => setImportModalOpen(true)}
               className={[
                 "flex items-center gap-2 px-4 py-2 rounded-lg text-xs font-medium uppercase tracking-wide",

--- a/src/components/dashboard/HostsDashboard.tsx
+++ b/src/components/dashboard/HostsDashboard.tsx
@@ -385,6 +385,7 @@ export function HostsDashboard() {
             />
             <input
               ref={searchInputRef}
+              data-testid="host-search"
               type="text"
               value={query}
               onChange={(e) => setQuery(e.target.value)}

--- a/src/components/dashboard/ImportSshConfigModal.tsx
+++ b/src/components/dashboard/ImportSshConfigModal.tsx
@@ -297,6 +297,7 @@ export function ImportSshConfigModal({ onClose, onImported }: ImportSshConfigMod
                 Cancel
               </button>
               <button
+                data-testid="import-ssh-config-submit"
                 onClick={() => void handleImport()}
                 disabled={importing || importableCount === 0}
                 className="px-4 py-2 text-[length:var(--text-sm)] font-medium text-text-inverse bg-accent hover:bg-accent-hover disabled:opacity-50 rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"

--- a/src/components/dashboard/RecentConnections.tsx
+++ b/src/components/dashboard/RecentConnections.tsx
@@ -42,6 +42,9 @@ export function RecentConnections({
             <button
               key={`${conn.host_id}-${conn.connected_at}`}
               role="listitem"
+              data-testid={`recent-connection-${conn.host_id}`}
+              data-recent-host-id={conn.host_id}
+              data-recent-label={displayName}
               onClick={() => onConnect(conn)}
               title={`Reconnect to ${displayName} (${conn.username}@${conn.host}:${conn.port})`}
               className={[

--- a/src/components/dashboard/S3Card.tsx
+++ b/src/components/dashboard/S3Card.tsx
@@ -76,6 +76,9 @@ export function S3Card({ conn, onConnect, onEdit, onDuplicate, onDelete }: S3Car
   return (
     <>
       <div
+        data-testid={`s3-card-${conn.id}`}
+        data-s3-id={conn.id}
+        data-s3-label={displayName}
         role="button"
         tabIndex={0}
         onClick={() => onConnect(conn)}
@@ -104,6 +107,7 @@ export function S3Card({ conn, onConnect, onEdit, onDuplicate, onDelete }: S3Car
         <div className="absolute top-2 right-2 flex items-center gap-0.5">
           <button
             type="button"
+            data-testid={`s3-card-${conn.id}-explorer`}
             onClick={stopAnd(() => onConnect(conn))}
             title="Open Explorer"
             aria-label={`Open explorer for ${displayName}`}

--- a/src/components/explorer/ExplorerFileTable.tsx
+++ b/src/components/explorer/ExplorerFileTable.tsx
@@ -664,6 +664,9 @@ export function ExplorerFileTable({
                   key={entry.id}
                   role="listitem"
                   data-entry-row="true"
+                  data-entry-name={entry.name}
+                  data-entry-type={entry.entryType}
+                  data-testid={`explorer-entry-${entry.name}`}
                   tabIndex={0}
                   onClick={(e) => handleRowClick(entry, e)}
                   onDoubleClick={() => handleDoubleClick(entry)}

--- a/src/components/explorer/ExplorerFileTable.tsx
+++ b/src/components/explorer/ExplorerFileTable.tsx
@@ -348,6 +348,29 @@ export function ExplorerFileTable({
     };
   }, [sortedEntries, onRename]);
 
+  // E2E test hook — select a specific set of entries by name. Multi-select
+  // via Ctrl-click is awkward to drive in WebDriver because the row needs
+  // keyboard focus AND modifier-key chord handling at the same time.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const hook = (names: string[]) => {
+      const ids = new Set(
+        names
+          .map((n) => sortedEntries.find((e) => e.name === n)?.id)
+          .filter((id): id is string => typeof id === "string"),
+      );
+      setSelectedIds(ids);
+    };
+    (window as unknown as {
+      __e2eExplorerSetSelection?: (names: string[]) => void;
+    }).__e2eExplorerSetSelection = hook;
+    return () => {
+      (window as unknown as {
+        __e2eExplorerSetSelection?: ((names: string[]) => void) | null;
+      }).__e2eExplorerSetSelection = null;
+    };
+  }, [sortedEntries]);
+
   // ─── Selection ───────────────────────────────────────────────────────────
 
   const handleRowClick = (entry: ExplorerEntry, e: React.MouseEvent) => {
@@ -604,6 +627,7 @@ export function ExplorerFileTable({
           <span className="w-5 shrink-0" />
 
           <button
+            data-testid="explorer-sort-name"
             className={`flex-1 ${thClass("name")}`}
             onClick={() => handleSortClick("name")}
             aria-sort={sortBy === "name" ? (sortAsc ? "ascending" : "descending") : "none"}
@@ -612,6 +636,7 @@ export function ExplorerFileTable({
           </button>
 
           <button
+            data-testid="explorer-sort-size"
             className={`w-20 text-right ${thClass("size")}`}
             onClick={() => handleSortClick("size")}
             aria-sort={sortBy === "size" ? (sortAsc ? "ascending" : "descending") : "none"}
@@ -620,6 +645,7 @@ export function ExplorerFileTable({
           </button>
 
           <button
+            data-testid="explorer-sort-modified"
             className={`w-32 ${thClass("modified")}`}
             onClick={() => handleSortClick("modified")}
             aria-sort={sortBy === "modified" ? (sortAsc ? "ascending" : "descending") : "none"}

--- a/src/components/explorer/ExplorerFileTable.tsx
+++ b/src/components/explorer/ExplorerFileTable.tsx
@@ -125,6 +125,7 @@ function RenameRow({
     <input
       ref={inputRef}
       autoFocus
+      data-testid="explorer-rename-input"
       type="text"
       value={value}
       onChange={(e) => setValue(e.target.value)}
@@ -172,6 +173,7 @@ function NewFolderRow({
       </span>
       <input
         ref={inputRef}
+        data-testid="explorer-new-folder-input"
         type="text"
         value={value}
         onChange={(e) => setValue(e.target.value)}
@@ -221,6 +223,7 @@ function NewFileRow({
       </span>
       <input
         ref={inputRef}
+        data-testid="explorer-new-file-input"
         type="text"
         value={value}
         onChange={(e) => setValue(e.target.value)}
@@ -317,6 +320,33 @@ export function ExplorerFileTable({
       onSortChange(col, true);
     }
   };
+
+  // E2E test hook — drives rename programmatically. Two modes:
+  //   - hook(name)          opens the inline rename input (UI flow)
+  //   - hook(name, newName) calls onRename directly (bypasses the inline
+  //                          input whose autoFocus + onBlur cancel races
+  //                          with WebDriver's setValue). Exercises the
+  //                          same backend invoke + listing update path.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const hook = (name: string, newName?: string) => {
+      const entry = sortedEntries.find((e) => e.name === name);
+      if (!entry) return;
+      if (newName != null && newName !== entry.name && onRename) {
+        void onRename(entry, newName);
+      } else {
+        setRenamingId(entry.id);
+      }
+    };
+    (window as unknown as {
+      __e2eExplorerStartRename?: (n: string, newName?: string) => void;
+    }).__e2eExplorerStartRename = hook;
+    return () => {
+      (window as unknown as {
+        __e2eExplorerStartRename?: ((n: string, newName?: string) => void) | null;
+      }).__e2eExplorerStartRename = null;
+    };
+  }, [sortedEntries, onRename]);
 
   // ─── Selection ───────────────────────────────────────────────────────────
 
@@ -677,6 +707,10 @@ export function ExplorerFileTable({
                   onKeyDown={(e) => {
                     const isInput = (e.target as Element).tagName === "INPUT";
                     if (e.key === "Enter" && !isInput) handleDoubleClick(entry);
+                    if (e.key === "F2" && caps.canRename && !isInput) {
+                      e.preventDefault();
+                      setRenamingId(entry.id);
+                    }
                     if ((e.key === "Delete" || e.key === "Backspace") && caps.canDelete && !isInput) {
                       if (selectedIds.size > 0) setConfirmDelete(selectedEntries);
                     }
@@ -843,6 +877,7 @@ function DeleteConfirmDialog({
 
   return (
     <div
+      data-testid="explorer-delete-confirm"
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm"
       onClick={(e) => e.target === e.currentTarget && onCancel()}
     >
@@ -872,12 +907,14 @@ function DeleteConfirmDialog({
 
         <div className="flex justify-end gap-2">
           <button
+            data-testid="explorer-delete-cancel"
             onClick={onCancel}
             className="px-4 py-2 text-[length:var(--text-sm)] text-text-secondary hover:text-text-primary rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
             Cancel
           </button>
           <button
+            data-testid="explorer-delete-confirm-button"
             onClick={onConfirm}
             className="px-4 py-2 text-[length:var(--text-sm)] font-medium text-white bg-status-error hover:opacity-90 rounded-lg transition-[opacity] duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >

--- a/src/components/explorer/ExplorerToolbar.tsx
+++ b/src/components/explorer/ExplorerToolbar.tsx
@@ -49,6 +49,7 @@ export function ExplorerToolbar({
     <div className="flex items-center h-10 px-2 border-b border-border bg-bg-surface shrink-0 gap-1 no-select">
       {/* Home button */}
       <button
+        data-testid="explorer-home"
         onClick={() => onNavigate(provider.type === "sftp" ? "/" : "")}
         disabled={loading || isAtRoot}
         title={`Go to ${provider.rootLabel()}`}
@@ -113,6 +114,7 @@ export function ExplorerToolbar({
       {/* Upload */}
       {caps.canUpload && (
         <button
+          data-testid="explorer-upload"
           onClick={onUpload}
           disabled={loading}
           title="Upload file"
@@ -126,6 +128,7 @@ export function ExplorerToolbar({
       {/* New file */}
       {caps.canCreateFile && (
         <button
+          data-testid="explorer-new-file"
           onClick={onNewFile}
           disabled={loading}
           title="New file"
@@ -139,6 +142,7 @@ export function ExplorerToolbar({
       {/* New folder */}
       {caps.canCreateFolder && (
         <button
+          data-testid="explorer-new-folder"
           onClick={onNewFolder}
           disabled={loading}
           title="New folder"
@@ -151,6 +155,7 @@ export function ExplorerToolbar({
 
       {/* Refresh */}
       <button
+        data-testid="explorer-refresh"
         onClick={onRefresh}
         disabled={loading}
         title="Refresh"

--- a/src/components/history/HistoryPage.tsx
+++ b/src/components/history/HistoryPage.tsx
@@ -238,6 +238,9 @@ export function HistoryPage() {
                       return (
                         <div
                           key={entry.id}
+                          data-testid={`history-entry-${entry.id}`}
+                          data-history-host-id={entry.host_id}
+                          data-history-host-label={entry.host_label || entry.host}
                           onContextMenu={(e) => handleContextMenu(e, entry)}
                           onDoubleClick={() => void handleTerminal(entry)}
                           className={[

--- a/src/components/layout/UnifiedTabBar.tsx
+++ b/src/components/layout/UnifiedTabBar.tsx
@@ -118,6 +118,9 @@ export function UnifiedTabBar() {
           return (
             <button
               key={tabId}
+              data-testid={`tab-${tabId}`}
+              data-tab-type={tab.type}
+              data-tab-label={tab.label}
               onClick={() => setActiveTab(tabId)}
               title={tab.label + (paneCount > 1 ? ` (${paneCount} panes)` : "")}
               className={[
@@ -175,6 +178,7 @@ export function UnifiedTabBar() {
               {/* Close button */}
               {closeable && (
                 <button
+                  data-testid={`tab-${tabId}-close`}
                   onClick={(e) => void handleClose(tabId, tab, e)}
                   className={[
                     "ml-auto p-0.5 -mr-1 rounded-lg shrink-0",

--- a/src/components/port-forwarding/PortForwardingPage.tsx
+++ b/src/components/port-forwarding/PortForwardingPage.tsx
@@ -145,6 +145,7 @@ export function PortForwardingPage() {
           {/* ── Action buttons ── */}
           <div className="flex gap-2">
             <button
+              data-testid="new-rule-button"
               onClick={() => setShowForm(true)}
               className={[
                 "flex items-center gap-2 px-4 py-2 rounded-lg text-xs font-medium uppercase tracking-wide",
@@ -189,6 +190,10 @@ export function PortForwardingPage() {
                       return (
                         <div
                           key={rule.id}
+                          data-testid={`rule-card-${rule.id}`}
+                          data-rule-id={rule.id}
+                          data-rule-label={rule.label || `Port ${rule.local_port}`}
+                          data-rule-active={isActive}
                           onContextMenu={(e) => handleContextMenu(e, rule)}
                           className={[
                             "group flex flex-col gap-2 px-4 py-3 rounded-lg",
@@ -442,6 +447,7 @@ function RuleDialog({
       <form
         onSubmit={handleSubmit}
         role="dialog"
+        data-testid="rule-dialog"
         aria-label={isEdit ? "Edit forwarding rule" : "New forwarding rule"}
         className="w-full max-w-lg rounded-xl bg-bg-overlay border border-border shadow-[var(--shadow-lg)] flex flex-col max-h-[84vh] animate-[fadeIn_120ms_var(--ease-expo-out)_both]"
       >
@@ -472,6 +478,7 @@ function RuleDialog({
             {hosts.length > 0 ? (
               <CustomSelect
                 id="pf-host"
+                data-testid="rule-host-select"
                 value={hostId}
                 onChange={setHostId}
                 options={hosts.map((h) => ({
@@ -494,6 +501,7 @@ function RuleDialog({
             </label>
             <input
               id="pf-label"
+              data-testid="rule-label-input"
               type="text"
               value={label}
               onChange={(e) => setLabel(e.target.value)}
@@ -548,6 +556,7 @@ function RuleDialog({
               <label htmlFor="pf-local-port" className={labelClass}>Local Port</label>
               <input
                 id="pf-local-port"
+                data-testid="rule-local-port"
                 type="number"
                 value={localPort}
                 onChange={(e) => setLocalPort(e.target.value)}
@@ -564,6 +573,7 @@ function RuleDialog({
               <label htmlFor="pf-remote-port" className={labelClass}>Remote Port</label>
               <input
                 id="pf-remote-port"
+                data-testid="rule-remote-port"
                 type="number"
                 value={remotePort}
                 onChange={(e) => setRemotePort(e.target.value)}
@@ -629,6 +639,7 @@ function RuleDialog({
           </button>
           <button
             type="submit"
+            data-testid="rule-dialog-save"
             disabled={!canSubmit}
             className="px-4 py-2 text-[length:var(--text-sm)] font-medium text-text-inverse bg-accent hover:bg-accent-hover disabled:opacity-50 rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >

--- a/src/components/s3/S3Browser.tsx
+++ b/src/components/s3/S3Browser.tsx
@@ -148,9 +148,13 @@ export function S3Browser({ sessionId }: S3BrowserProps) {
   }, [sessionId, setCurrentBucket, loadObjects, setError]);
 
   useEffect(() => {
-    if (!session?.currentBucket) void loadBuckets();
+    // If a bucket was already selected (e.g. set by the card-click flow that
+    // restores a saved connection's default bucket), load its objects.
+    // Otherwise show the bucket picker.
+    if (session?.currentBucket) void loadObjects("");
+    else void loadBuckets();
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sessionId]);
+  }, [sessionId, session?.currentBucket]);
 
   // ─── Auto-refresh on upload completion ────────────────────────────────────
 

--- a/src/components/s3/S3ConnectDialog.tsx
+++ b/src/components/s3/S3ConnectDialog.tsx
@@ -173,7 +173,7 @@ export function S3ConnectDialog({ onClose, editConnection }: S3ConnectDialogProp
       style={{ backgroundColor: "oklch(0 0 0 / 0.5)", backdropFilter: "blur(4px)" }}
       onClick={(e) => e.target === e.currentTarget && !connecting && onClose()}
     >
-      <div className="w-full max-w-lg rounded-xl bg-bg-overlay border border-border shadow-[var(--shadow-lg)] flex flex-col max-h-[84vh] animate-[fadeIn_120ms_var(--ease-expo-out)_both]">
+      <div data-testid="s3-dialog" className="w-full max-w-lg rounded-xl bg-bg-overlay border border-border shadow-[var(--shadow-lg)] flex flex-col max-h-[84vh] animate-[fadeIn_120ms_var(--ease-expo-out)_both]">
         {/* Header */}
         <div className="flex items-center justify-between px-6 pt-5 pb-4 border-b border-border shrink-0">
           <h2 className="text-[length:var(--text-lg)] font-semibold text-text-primary">
@@ -198,6 +198,7 @@ export function S3ConnectDialog({ onClose, editConnection }: S3ConnectDialogProp
           <div>
             <label className={labelClass}>Service</label>
             <CustomSelect
+              data-testid="s3-dialog-provider"
               value={provider}
               onChange={(v) => setProvider(v as S3Provider)}
               options={S3_PROVIDERS.map((p) => ({ value: p.id, label: p.label }))}
@@ -210,6 +211,7 @@ export function S3ConnectDialog({ onClose, editConnection }: S3ConnectDialogProp
               <span className="ml-1 text-text-muted font-normal">(optional)</span>
             </label>
             <input
+              data-testid="s3-dialog-label"
               type="text"
               value={label}
               onChange={(e) => setLabel(e.target.value)}
@@ -229,6 +231,7 @@ export function S3ConnectDialog({ onClose, editConnection }: S3ConnectDialogProp
           <div>
             <label className={labelClass}>Access Key ID</label>
             <input
+              data-testid="s3-dialog-access-key"
               type="text"
               value={accessKey}
               onChange={(e) => setAccessKey(e.target.value)}
@@ -241,6 +244,7 @@ export function S3ConnectDialog({ onClose, editConnection }: S3ConnectDialogProp
           <div>
             <label className={labelClass}>Secret Access Key</label>
             <input
+              data-testid="s3-dialog-secret-key"
               type="password"
               value={secretKey}
               onChange={(e) => setSecretKey(e.target.value)}
@@ -255,6 +259,7 @@ export function S3ConnectDialog({ onClose, editConnection }: S3ConnectDialogProp
             <div className="flex-1">
               <label className={labelClass}>Region</label>
               <input
+                data-testid="s3-dialog-region"
                 type="text"
                 value={region}
                 onChange={(e) => setRegion(e.target.value)}
@@ -265,6 +270,7 @@ export function S3ConnectDialog({ onClose, editConnection }: S3ConnectDialogProp
             <div className="flex-1">
               <label className={labelClass}>Bucket</label>
               <input
+                data-testid="s3-dialog-bucket"
                 type="text"
                 value={bucket}
                 onChange={(e) => setBucket(e.target.value)}
@@ -278,6 +284,7 @@ export function S3ConnectDialog({ onClose, editConnection }: S3ConnectDialogProp
             <div>
               <label className={labelClass}>Endpoint URL</label>
               <input
+                data-testid="s3-dialog-endpoint"
                 type="text"
                 value={endpoint}
                 onChange={(e) => setEndpoint(e.target.value)}
@@ -385,6 +392,7 @@ export function S3ConnectDialog({ onClose, editConnection }: S3ConnectDialogProp
           ) : (
             <>
               <button
+                data-testid="s3-dialog-save"
                 onClick={() => void handleSave()}
                 disabled={saving || connecting || !canSubmit}
                 className="px-4 py-2 text-[length:var(--text-sm)] font-medium text-text-secondary hover:text-text-primary bg-bg-subtle hover:bg-bg-muted disabled:opacity-50 rounded-lg border border-border transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
@@ -392,6 +400,7 @@ export function S3ConnectDialog({ onClose, editConnection }: S3ConnectDialogProp
                 {saving ? "Saving…" : "Save"}
               </button>
               <button
+                data-testid="s3-dialog-connect"
                 onClick={() => void handleConnect()}
                 disabled={connecting || saving || !canSubmit}
                 className="px-4 py-2 text-[length:var(--text-sm)] font-medium text-text-inverse bg-accent hover:bg-accent-hover disabled:opacity-50 rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -393,6 +393,7 @@ function NumberSetting({ id, value, min, max, step, onChange }: {
   return (
     <input
       id={id}
+      data-testid={id}
       type="text"
       inputMode="decimal"
       value={local}

--- a/src/components/shared/CustomSelect.tsx
+++ b/src/components/shared/CustomSelect.tsx
@@ -16,6 +16,7 @@ interface CustomSelectProps {
   className?: string;
   id?: string;
   "aria-label"?: string;
+  "data-testid"?: string;
 }
 
 export function CustomSelect({
@@ -27,6 +28,7 @@ export function CustomSelect({
   className,
   id,
   "aria-label": ariaLabel,
+  "data-testid": testid,
 }: CustomSelectProps) {
   const [open, setOpen] = useState(false);
   const [highlightIndex, setHighlightIndex] = useState(-1);
@@ -120,6 +122,7 @@ export function CustomSelect({
         aria-expanded={open}
         aria-haspopup="listbox"
         aria-label={ariaLabel}
+        data-testid={testid}
         disabled={disabled}
         onClick={() => {
           if (!disabled) {
@@ -179,6 +182,7 @@ export function CustomSelect({
                 type="button"
                 role="option"
                 aria-selected={isSelected}
+                data-testid={testid ? `${testid}-option-${option.value}` : undefined}
                 onClick={() => {
                   onChange(option.value);
                   setOpen(false);

--- a/src/components/shared/CustomSelect.tsx
+++ b/src/components/shared/CustomSelect.tsx
@@ -123,6 +123,7 @@ export function CustomSelect({
         aria-haspopup="listbox"
         aria-label={ariaLabel}
         data-testid={testid}
+        data-value={value}
         disabled={disabled}
         onClick={() => {
           if (!disabled) {

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -171,6 +171,8 @@ export function Sidebar() {
   return (
     <>
       <nav
+        data-testid="sidebar"
+        data-sidebar-expanded={expanded}
         aria-label="Main navigation"
         className={[
           "no-select flex flex-col shrink-0 h-full py-3",

--- a/src/components/snippets/SnippetCard.tsx
+++ b/src/components/snippets/SnippetCard.tsx
@@ -85,6 +85,9 @@ export function SnippetCard({ snippet, onEdit, onDelete, onDuplicate }: SnippetC
   return (
     <>
       <div
+        data-testid={`snippet-card-${snippet.id}`}
+        data-snippet-id={snippet.id}
+        data-snippet-name={snippet.name}
         onContextMenu={handleContextMenu}
         className={[
           "group flex flex-col gap-2 p-4 rounded-xl",

--- a/src/components/snippets/SnippetEditModal.tsx
+++ b/src/components/snippets/SnippetEditModal.tsx
@@ -283,6 +283,7 @@ export function SnippetEditModal({
       ].join(" ")}
     >
       <div
+        data-testid="snippet-modal"
         className={[
           "w-full max-w-xl rounded-xl bg-bg-overlay border border-border shadow-[var(--shadow-lg)]",
           "flex flex-col max-h-[84vh]",
@@ -321,6 +322,7 @@ export function SnippetEditModal({
             </label>
             <input
               ref={nameRef}
+              data-testid="snippet-modal-name"
               type="text"
               value={form.name}
               onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))}
@@ -337,6 +339,7 @@ export function SnippetEditModal({
               Command <span className="text-status-error">*</span>
             </label>
             <textarea
+              data-testid="snippet-modal-command"
               value={form.command}
               onChange={(e) => handleCommandChange(e.target.value)}
               placeholder="e.g., sudo systemctl restart {{service}}"
@@ -488,6 +491,7 @@ export function SnippetEditModal({
             </button>
             <button
               type="submit"
+              data-testid="snippet-modal-save"
               disabled={saving || !form.name.trim() || !form.command.trim()}
               className="px-4 py-2 text-[length:var(--text-sm)] font-medium text-text-inverse bg-accent hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-bg-overlay"
             >

--- a/src/components/snippets/SnippetPalette.tsx
+++ b/src/components/snippets/SnippetPalette.tsx
@@ -182,6 +182,7 @@ export function SnippetPalette() {
 
       {/* Palette */}
       <div
+        data-testid="snippet-palette"
         className="relative z-10 w-full max-w-[480px] mx-4 rounded-xl bg-bg-overlay border border-border shadow-[var(--shadow-lg)] overflow-hidden animate-[paletteIn_150ms_var(--ease-expo-out)_both]"
         onClick={(e) => e.stopPropagation()}
         onKeyDown={handleKeyDown}
@@ -193,6 +194,7 @@ export function SnippetPalette() {
               <Search size={16} strokeWidth={2} className="text-text-muted shrink-0" />
               <input
                 ref={searchRef}
+                data-testid="snippet-palette-search"
                 type="text"
                 value={query}
                 onChange={(e) => setQuery(e.target.value)}
@@ -212,6 +214,8 @@ export function SnippetPalette() {
                 filtered.map((snippet, i) => (
                   <button
                     key={snippet.id}
+                    data-testid={`snippet-palette-item-${snippet.id}`}
+                    data-snippet-name={snippet.name}
                     onClick={() => enterVariablePhase(snippet)}
                     onMouseEnter={() => setSelectedIndex(i)}
                     className={[
@@ -276,6 +280,7 @@ export function SnippetPalette() {
               )}
               <button
                 type="submit"
+                data-testid="snippet-palette-run"
                 disabled={hasUnmetRequired}
                 className="flex items-center gap-1.5 h-7 px-3 text-[11px] font-medium rounded-lg text-text-inverse bg-accent hover:bg-accent-hover disabled:opacity-40 disabled:cursor-not-allowed transition-colors shrink-0"
               >
@@ -323,6 +328,7 @@ export function SnippetPalette() {
                     ) : (
                       <input
                         ref={isFirst ? (el) => { firstVarRef.current = el; } : undefined}
+                        data-testid={`snippet-palette-var-${name}`}
                         type="text"
                         value={varValues[name] ?? ""}
                         onChange={(e) => setVarValues((prev) => ({ ...prev, [name]: e.target.value }))}

--- a/src/components/snippets/SnippetsPage.tsx
+++ b/src/components/snippets/SnippetsPage.tsx
@@ -273,6 +273,7 @@ export function SnippetsPage() {
           {/* Action buttons */}
           <div className="flex gap-2">
             <button
+              data-testid="new-snippet-button"
               onClick={() => setEditingSnippet("__new__")}
               className={[
                 "flex items-center gap-2 px-4 py-2 rounded-lg text-xs font-medium uppercase tracking-wide",

--- a/src/components/terminal/SplitContainer.tsx
+++ b/src/components/terminal/SplitContainer.tsx
@@ -40,6 +40,9 @@ export function SplitContainer({ node, path, tabId }: SplitContainerProps) {
   return (
     <div
       ref={containerRef}
+      data-testid="split-container"
+      data-split-direction={node.direction}
+      data-zoomed={isZoomed}
       className={`flex h-full w-full gap-0.5 overflow-visible ${isHorizontal ? "flex-row" : "flex-col"}`}
     >
       <div style={{ flex: `${node.ratio} 1 0%` }} className="min-w-0 min-h-0 overflow-hidden">

--- a/src/components/terminal/Terminal.tsx
+++ b/src/components/terminal/Terminal.tsx
@@ -97,6 +97,15 @@ export function Terminal({ sessionId }: TerminalProps) {
       terminalRef.current = terminal;
       fitAddonRef.current = fitAddon;
 
+      // E2E test hook — exposes the xterm instance so tests can read the buffer
+      // without poking at canvas/DOM internals. Stripped trivially by minifiers
+      // if anyone ever cares about prod bundle size.
+      if (typeof window !== "undefined") {
+        const reg = ((window as unknown as { __e2eTerminals?: Map<string, XTerm> }).__e2eTerminals ??=
+          new Map<string, XTerm>());
+        reg.set(sessionId, terminal);
+      }
+
       // Load search addon
       import("@xterm/addon-search")
         .then(({ SearchAddon }) => {
@@ -157,6 +166,10 @@ export function Terminal({ sessionId }: TerminalProps) {
       disposed = true;
       observer?.disconnect();
       unregisterSearchAddon(sessionId);
+      if (typeof window !== "undefined") {
+        (window as unknown as { __e2eTerminals?: Map<string, XTerm> })
+          .__e2eTerminals?.delete(sessionId);
+      }
       if (terminalRef.current) {
         terminalRef.current.dispose();
         terminalRef.current = null;
@@ -168,6 +181,8 @@ export function Terminal({ sessionId }: TerminalProps) {
   return (
     <div
       ref={containerRef}
+      data-testid={`terminal-${sessionId}`}
+      data-session-id={sessionId}
       className="h-full w-full bg-bg-base p-2"
       onKeyDown={(e) => {
         if (e.metaKey && (e.key === "d" || e.key === "D")) {

--- a/src/components/terminal/TerminalSearchBar.tsx
+++ b/src/components/terminal/TerminalSearchBar.tsx
@@ -164,6 +164,8 @@ export function TerminalSearchBar({ sessionId }: TerminalSearchBarProps) {
 
   return (
     <div
+      data-testid="terminal-search"
+      data-match-text={matchText}
       className={[
         "absolute top-2 right-3 z-20",
         "flex items-center gap-1 px-2 py-1.5",
@@ -176,6 +178,7 @@ export function TerminalSearchBar({ sessionId }: TerminalSearchBarProps) {
       {/* Search input */}
       <input
         ref={inputRef}
+        data-testid="terminal-search-input"
         type="text"
         value={query}
         onChange={(e) => handleInput(e.target.value)}

--- a/src/stores/groups-store.ts
+++ b/src/stores/groups-store.ts
@@ -55,3 +55,9 @@ export const useGroupsStore = create<GroupsState>((set) => ({
     set({ groups });
   },
 }));
+
+// E2E test hook — drives group delete (UI flow uses right-click context menu).
+if (typeof window !== "undefined") {
+  (window as unknown as { __e2eDeleteGroup?: (id: string) => Promise<void> })
+    .__e2eDeleteGroup = (id) => useGroupsStore.getState().deleteGroup(id);
+}

--- a/src/stores/hosts-store.ts
+++ b/src/stores/hosts-store.ts
@@ -9,6 +9,7 @@ interface HostsState {
 
   loadHosts: () => Promise<void>;
   saveHost: (host: SavedHost) => Promise<void>;
+  duplicateHost: (id: string) => Promise<void>;
   deleteHost: (id: string) => Promise<void>;
   loadRecent: () => Promise<void>;
   recordConnection: (hostId: string) => Promise<void>;
@@ -42,6 +43,26 @@ export const useHostsStore = create<HostsState>((set) => ({
     await invoke("save_host", { host });
     const hosts = await invoke<SavedHost[]>("list_hosts");
     set({ hosts });
+  },
+
+  duplicateHost: async (id) => {
+    const { invoke } = await import("@tauri-apps/api/core");
+    const hosts = await invoke<SavedHost[]>("list_hosts");
+    const orig = hosts.find((h) => h.id === id);
+    if (!orig) throw new Error(`host not found: ${id}`);
+    const now = new Date().toISOString();
+    const duplicate: SavedHost = {
+      ...orig,
+      id: crypto.randomUUID(),
+      label: `${orig.label || orig.host} (copy)`,
+      created_at: now,
+      updated_at: now,
+      last_connected_at: null,
+      connection_count: null,
+    };
+    await invoke("save_host", { host: duplicate });
+    const updated = await invoke<SavedHost[]>("list_hosts");
+    set({ hosts: updated });
   },
 
   deleteHost: async (id) => {
@@ -79,3 +100,11 @@ export const useHostsStore = create<HostsState>((set) => ({
     }
   },
 }));
+
+// E2E test hook — lets WebDriver tests invoke duplicate without driving the
+// right-click context menu (which is flaky in WebKitWebDriver). No production
+// code reads this.
+if (typeof window !== "undefined") {
+  (window as unknown as { __e2eDuplicateHost?: (id: string) => Promise<void> })
+    .__e2eDuplicateHost = (id) => useHostsStore.getState().duplicateHost(id);
+}

--- a/src/stores/port-forward-store.ts
+++ b/src/stores/port-forward-store.ts
@@ -166,3 +166,9 @@ export const usePortForwardStore = create<PortForwardState>((set, get) => ({
     } catch { /* best-effort */ }
   },
 }));
+
+// E2E test hook — drives rule delete (UI flow uses right-click context menu).
+if (typeof window !== "undefined") {
+  (window as unknown as { __e2eDeleteRule?: (id: string) => Promise<void> })
+    .__e2eDeleteRule = (id) => usePortForwardStore.getState().deleteRule(id);
+}

--- a/src/stores/s3-store.ts
+++ b/src/stores/s3-store.ts
@@ -123,3 +123,32 @@ export const useS3Store = create<S3State>((set) => ({
   setClipboard: (clipboard) =>
     set({ clipboard }),
 }));
+
+// E2E test hooks — connection delete + transfer command wrappers so specs
+// can drive upload/download without going through the file picker dialog.
+if (typeof window !== "undefined") {
+  const w = window as unknown as {
+    __e2eDeleteS3Connection?: (id: string) => Promise<void>;
+    __e2eS3Upload?: (sessionId: string, localPath: string, key: string) => Promise<void>;
+    __e2eS3Download?: (sessionId: string, key: string, localPath: string) => Promise<void>;
+    __e2eS3UploadFiles?: (sessionId: string, localPaths: string[], prefix: string) => Promise<number>;
+  };
+  w.__e2eDeleteS3Connection = async (id) => {
+    const { invoke } = await import("@tauri-apps/api/core");
+    await invoke("s3_delete_connection", { id });
+  };
+  w.__e2eS3Upload = async (sessionId, localPath, key) => {
+    const { invoke } = await import("@tauri-apps/api/core");
+    await invoke("s3_upload_file", { s3SessionId: sessionId, localPath, key });
+  };
+  w.__e2eS3Download = async (sessionId, key, localPath) => {
+    const { invoke } = await import("@tauri-apps/api/core");
+    await invoke("s3_download_file", { s3SessionId: sessionId, key, localPath });
+  };
+  w.__e2eS3UploadFiles = async (sessionId, localPaths, prefix) => {
+    const { invoke } = await import("@tauri-apps/api/core");
+    return await invoke<number>("s3_upload_files", {
+      s3SessionId: sessionId, localPaths, prefix,
+    });
+  };
+}

--- a/src/stores/sftp-store.ts
+++ b/src/stores/sftp-store.ts
@@ -113,3 +113,47 @@ export const useSftpStore = create<SftpState>((set) => ({
   setClipboard: (clipboard) =>
     set({ clipboard }),
 }));
+
+// E2E test hooks — wrap the backend transfer commands so specs can drive
+// upload/download/copy/move without going through the (un-driveable) Tauri
+// file picker dialog. Each is a thin invoke() wrapper that takes session id
+// + paths and returns whatever the backend returns.
+if (typeof window !== "undefined") {
+  const w = window as unknown as {
+    __e2eSftpUpload?: (sessionId: string, localPath: string, remotePath: string) => Promise<string>;
+    __e2eSftpDownload?: (sessionId: string, remotePath: string, localPath: string) => Promise<string>;
+    __e2eSftpEnqueueUpload?: (sessionId: string, localPaths: string[], remoteDir: string) => Promise<string[]>;
+    __e2eSftpCopy?: (sessionId: string, sourcePaths: string[], targetDir: string) => Promise<string[]>;
+    __e2eSftpMove?: (sessionId: string, sourcePaths: string[], targetDir: string) => Promise<string[]>;
+  };
+  w.__e2eSftpUpload = async (sessionId, localPath, remotePath) => {
+    const { invoke } = await import("@tauri-apps/api/core");
+    return await invoke<string>("sftp_upload", {
+      sftpSessionId: sessionId, localPath, remotePath,
+    });
+  };
+  w.__e2eSftpDownload = async (sessionId, remotePath, localPath) => {
+    const { invoke } = await import("@tauri-apps/api/core");
+    return await invoke<string>("sftp_download", {
+      sftpSessionId: sessionId, remotePath, localPath,
+    });
+  };
+  w.__e2eSftpEnqueueUpload = async (sessionId, localPaths, remoteDir) => {
+    const { invoke } = await import("@tauri-apps/api/core");
+    return await invoke<string[]>("sftp_enqueue_upload", {
+      sftpSessionId: sessionId, localPaths, remoteDir,
+    });
+  };
+  w.__e2eSftpCopy = async (sessionId, sourcePaths, targetDir) => {
+    const { invoke } = await import("@tauri-apps/api/core");
+    return await invoke<string[]>("sftp_copy_entries", {
+      sftpSessionId: sessionId, sourcePaths, targetDir,
+    });
+  };
+  w.__e2eSftpMove = async (sessionId, sourcePaths, targetDir) => {
+    const { invoke } = await import("@tauri-apps/api/core");
+    return await invoke<string[]>("sftp_move_entries", {
+      sftpSessionId: sessionId, sourcePaths, targetDir,
+    });
+  };
+}

--- a/src/stores/snippets-store.ts
+++ b/src/stores/snippets-store.ts
@@ -103,3 +103,10 @@ export const useSnippetsStore = create<SnippetsState>((set, get) => ({
     set({ searchQuery: "", searchResults: [] });
   },
 }));
+
+// E2E test hook — drives snippet delete (UI flow uses right-click context
+// menu only, flaky in WebKitWebDriver). No production code reads this.
+if (typeof window !== "undefined") {
+  (window as unknown as { __e2eDeleteSnippet?: (id: string) => Promise<void> })
+    .__e2eDeleteSnippet = (id) => useSnippetsStore.getState().deleteSnippet(id);
+}

--- a/src/stores/ui-store.ts
+++ b/src/stores/ui-store.ts
@@ -42,3 +42,11 @@ export const useUiStore = create<UiState>((set) => ({
   toggleSnippetPanelPinned: () =>
     set((s) => ({ snippetPanelPinned: !s.snippetPanelPinned })),
 }));
+
+// E2E test hook — lets WebDriver tests open the HostEditModal for a given
+// host id without having to drive the right-click context menu (which is
+// flaky in WebKitWebDriver). No production code reads this.
+if (typeof window !== "undefined") {
+  (window as unknown as { __e2eOpenHostEdit?: (id: string | null) => void })
+    .__e2eOpenHostEdit = (id) => useUiStore.getState().setEditingHostId(id);
+}

--- a/tests/e2e/.gitignore
+++ b/tests/e2e/.gitignore
@@ -2,5 +2,8 @@ node_modules/
 .wdio-logs/
 screenshots/
 videos/
+junit/
+report.md
+.test-records.ndjson
 .image-stamp
 *.log

--- a/tests/e2e/.gitignore
+++ b/tests/e2e/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+.wdio-logs/
+screenshots/
+videos/
+.image-stamp
+*.log

--- a/tests/e2e/.npmrc
+++ b/tests/e2e/.npmrc
@@ -1,0 +1,6 @@
+# pnpm v10+ blocks install-time build scripts by default. WDIO's dep tree
+# includes esbuild + driver shims that have postinstalls; approve them so
+# `pnpm install` doesn't exit non-zero.
+only-built-dependencies[]=esbuild
+only-built-dependencies[]=edgedriver
+only-built-dependencies[]=geckodriver

--- a/tests/e2e/Dockerfile
+++ b/tests/e2e/Dockerfile
@@ -1,0 +1,67 @@
+# syntax=docker/dockerfile:1.6
+# E2E test runner: builds the anySCP debug binary inside the container and drives
+# it with tauri-driver + WebKitWebDriver under xvfb.
+
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PATH=/root/.cargo/bin:/root/.local/share/pnpm:/usr/local/bin:/usr/bin:/bin \
+    PNPM_HOME=/root/.local/share/pnpm \
+    RUSTUP_HOME=/root/.rustup \
+    CARGO_HOME=/root/.cargo \
+    XDG_DATA_HOME=/root/.local/share
+
+# ── System deps ────────────────────────────────────────────────────────────────
+# Two groups:
+#   1. Tauri build deps (webkit2gtk-4.1, gtk3, soup3, etc.)
+#   2. WebDriver runtime deps (webkit2gtk-driver, xvfb, dbus-x11)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates curl git make pkg-config build-essential \
+        libssl-dev \
+        libwebkit2gtk-4.1-dev libjavascriptcoregtk-4.1-dev \
+        libsoup-3.0-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev \
+        webkit2gtk-driver \
+        xvfb x11vnc ffmpeg \
+        libnss3 libatk1.0-0 libatk-bridge2.0-0 libgbm1 \
+        keyutils \
+        openssh-client \
+    && rm -rf /var/lib/apt/lists/*
+
+# Sanity check: WebKitWebDriver must be on PATH (provided by webkit2gtk-driver).
+# Note: the binary has no --version flag and exits non-zero from --help, so we
+# only verify presence.
+RUN command -v WebKitWebDriver
+
+# ── Rust toolchain ─────────────────────────────────────────────────────────────
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+    | sh -s -- -y --default-toolchain stable --profile minimal \
+ && rustc --version
+
+# tauri-driver (the WebDriver intermediary that spawns WebKitWebDriver).
+RUN cargo install tauri-driver --locked
+
+# ── Node + pnpm ────────────────────────────────────────────────────────────────
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+ && apt-get install -y --no-install-recommends nodejs \
+ && rm -rf /var/lib/apt/lists/* \
+ && corepack enable \
+ && corepack prepare pnpm@latest --activate \
+ && pnpm --version
+
+WORKDIR /workspace
+
+# Pre-create a writable XDG dir for the Tauri app (anyscp.db lives under here).
+RUN mkdir -p "$XDG_DATA_HOME"
+
+# Install the WDIO harness deps into /opt/e2e at build time. We can't install
+# at runtime because npm walks up from /workspace/tests/e2e/ and finds the
+# pnpm-shaped /workspace/node_modules from the bind mount, then crashes with
+# "Cannot read properties of null (reading 'matches')". /opt/e2e is outside
+# the workspace so npm has no parent node_modules to confuse itself with.
+COPY package.json /opt/e2e/package.json
+RUN cd /opt/e2e && npm install --no-audit --no-fund --omit=optional
+
+COPY entrypoint.sh /usr/local/bin/e2e-entrypoint
+RUN chmod +x /usr/local/bin/e2e-entrypoint
+
+ENTRYPOINT ["/usr/local/bin/e2e-entrypoint"]

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,0 +1,152 @@
+# anySCP E2E tests
+
+End-to-end test suite that drives the real Tauri app through `tauri-driver` +
+WebKitWebDriver, against real SSH servers (linuxserver/openssh-server in
+Docker). Everything runs in containers so the same setup works on dev
+machines (incl. Arch, where `WebKitWebDriver` is not packaged) and CI.
+
+## Run
+
+From the repo root:
+
+```bash
+make e2e            # full suite — first run builds the image (~5–10 min)
+make e2e-shell      # interactive shell in the runner (debug a failing spec)
+make e2e-logs       # tail runner logs while a run is in progress
+make e2e-clean      # wipe image + cached build volumes
+```
+
+## Video recordings
+
+Every spec records an mp4 of the Xvfb display under `tests/e2e/videos/`
+(via ffmpeg + x11grab, 15 fps, ultrafast h264). Both passing and failing
+specs are kept — delete the directory to reclaim disk if you don't need
+them. The WDIO output prints the video path under each test:
+
+```
+[wdio] FAIL: opens a terminal and runs a command
+[wdio]   video: tests/e2e/videos/2026-…__connect_password_-opens_a_terminal….mp4
+```
+
+On failure, the HTML dump + URL are also saved under `screenshots/`.
+
+## Watching the app run (VNC)
+
+The runner publishes a VNC server on **`localhost:5900`**. While `make e2e`
+is running you can attach any VNC client and watch the bot drive the UI:
+
+```bash
+# pick whichever VNC client you have:
+vncviewer localhost:5900            # tigervnc-viewer
+remmina vnc://localhost:5900        # remmina
+vinagre localhost:5900              # GNOME's
+```
+
+The entrypoint prints `>>> VNC ready — connect to localhost:5900 to watch <<<`
+right before WDIO starts, so you have a moment to attach. The session is
+unauthenticated (`-nopw`) because the port is only exposed on localhost.
+
+## What it covers
+
+| Spec | Backend surface |
+| --- | --- |
+| `01-smoke` | App boots, hosts dashboard renders, DB initialises. |
+| `02-host-crud` | `save_host` (create + update), `list_hosts`, `delete_host`, modal lifecycle. |
+| `03-connect-password` | `ssh_connect` (password), `ssh_send_input`, terminal render, tab close → `ssh_disconnect`. |
+| `04-connect-key` | `ssh_connect` via russh-keys (ed25519). |
+| `05-persistence` | SQLite DB survives an app restart. |
+| `06-error-bad-creds` | Auth-failure path surfaces an error banner in the modal. |
+| `07-sftp-flow` | `vault_save_credential` → keychain → Explorer button → `sftp_open` → `sftp_list_dir`. |
+
+## How it's wired together
+
+```
+┌──────────────────────────┐         ┌───────────────────────────┐
+│ sshd-pass                │         │ sshd-key                  │
+│ linuxserver/openssh:2222 │         │ linuxserver/openssh:2222  │
+│ testuser / testpass      │         │ testuser / ssh key        │
+└──────────┬───────────────┘         └───────────┬───────────────┘
+           │                                     │
+           │       docker compose network        │
+           └─────────────────┬───────────────────┘
+                             │
+                ┌────────────▼────────────┐
+                │ e2e (test runner)        │
+                │                          │
+                │ ┌──────────────────────┐ │
+                │ │ pnpm wdio run        │ │
+                │ │   ↓ HTTP :4444       │ │
+                │ │ tauri-driver         │ │
+                │ │   ↓ spawns           │ │
+                │ │ WebKitWebDriver      │ │
+                │ │   ↓ launches         │ │
+                │ │ anyscp (debug build) │ │
+                │ │   inside xvfb        │ │
+                │ └──────────────────────┘ │
+                │                          │
+                │ gnome-keyring (unlocked) │
+                │ dbus session             │
+                └──────────────────────────┘
+```
+
+## Per-test isolation
+
+- Every test calls `resetApp()` in `beforeEach`, which wipes
+  `$XDG_DATA_HOME/com.macnev2013.anyscp` and calls `browser.reloadSession()`
+  to relaunch the Tauri process with a clean SQLite DB.
+- The `05-persistence` spec uses `relaunchApp()` instead, which reloads the
+  session without wiping the DB.
+- The OS keychain (gnome-keyring) is process-scoped inside the runner
+  container, so it also resets when the daemon is restarted between full
+  `make e2e` invocations.
+
+## Adding a new spec
+
+1. Look up (or add) the relevant `data-testid` in the React component.
+   Convention: `<component>-<element>` (e.g. `host-modal-password`).
+2. Wrap any new repeated interaction in a helper in `helpers/`.
+3. Add a spec under `specs/NN-name.spec.ts`. Specs run in lexical order;
+   keep the numeric prefix so failures bisect cleanly.
+4. Run `make e2e-shell` and iterate with
+   `cd tests/e2e && pnpm exec wdio run wdio.conf.ts --spec ./specs/NN-name.spec.ts`.
+
+## Reading the xterm terminal
+
+`src/components/terminal/Terminal.tsx` registers each `xterm` instance in
+`window.__e2eTerminals` keyed by `sessionId`. The helper
+`helpers/terminal.ts` reads/writes through that registry so tests don't
+have to poke at canvas pixels or DOM rows.
+
+## Build speed / cache
+
+`make e2e` preserves the `rust-target`, `cargo-cache`, and `node-modules`
+Docker volumes between runs, so:
+
+- **First run**: full build (~3 min)
+- **Same-code rerun**: skips the Tauri build entirely (~30s — the entrypoint
+  reuses the existing `anyscp` debug binary)
+- **App source changed**: incremental cargo compile against the preserved
+  `target/` (typically 5–15s)
+
+If you change Rust source and want to be sure the binary is fresh:
+
+```bash
+E2E_FORCE_BUILD=1 make e2e
+```
+
+If you need a fully clean slate (volumes wiped, image deleted), use
+`make e2e-clean` — but that throws away the cargo crate cache and forces
+the next run back to a full build.
+
+## Known caveats
+
+- **First build is slow.** Rust + webkit deps in a fresh image take
+  ~5–10 minutes. Subsequent runs reuse `cargo-cache`, `rust-target`, and
+  `node-modules` volumes; expect <60s overhead.
+- **WebKit DMA-BUF.** The same Wayland-renderer issue that affects
+  `pnpm tauri dev` on bare-metal Linux doesn't bite here — we run under
+  xvfb (X11), which forces a safe rendering path.
+- **`make e2e-clean` blows away the build cache.** Use sparingly; only
+  when you've changed `Dockerfile`/`entrypoint.sh` and want a clean rebuild.
+- **No Wayland in container.** WebKit runs against xvfb's X11; this mirrors
+  CI environments, not your local Wayland session.

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -16,6 +16,19 @@ make e2e-logs       # tail runner logs while a run is in progress
 make e2e-clean      # wipe image + cached build volumes
 ```
 
+## Test report (Markdown)
+
+After every run, **`tests/e2e/report.md`** is written. It contains:
+
+- A summary of `passed/total` for the whole run and per spec file
+- For each failure: the error message, stack trace, video path, HTML dump
+  path, and the URL the webview was on at the time
+- A list of passing tests at the bottom
+
+Designed to be pasted as-is into a chat / issue. Per-test data is also
+kept as NDJSON at `tests/e2e/.test-records.ndjson` if you want to
+post-process it yourself.
+
 ## Video recordings
 
 Every spec records an mp4 of the Xvfb display under `tests/e2e/videos/`
@@ -137,6 +150,22 @@ E2E_FORCE_BUILD=1 make e2e
 If you need a fully clean slate (volumes wiped, image deleted), use
 `make e2e-clean` — but that throws away the cargo crate cache and forces
 the next run back to a full build.
+
+## Follow-up: S3 coverage
+
+S3 specs are intentionally deferred — driving them needs:
+
+1. A MinIO sidecar in `docker-compose.yml` (image: `minio/minio:latest`,
+   command: `server /data --console-address ":9001"`, fixed root creds).
+2. A `keygen`-style one-shot service that creates a bucket and seeds it
+   with a couple of test objects.
+3. A test helper to add an S3 connection via the UI's `+ New S3` dialog
+   pointing at `http://minio:9000` with `path_style: true`.
+4. Reusing the existing explorer helpers — the `data-entry-name` / toolbar
+   testids work the same for S3 sessions as for SFTP.
+
+The Rust backend (`s3::commands::s3_*`) is the same code path either way,
+so the SFTP suite already exercises ~80% of the explorer surface.
 
 ## Known caveats
 

--- a/tests/e2e/docker-compose.yml
+++ b/tests/e2e/docker-compose.yml
@@ -39,6 +39,38 @@ services:
       timeout: 2s
       retries: 30
 
+  # ─── S3-compatible storage (MinIO) ──────────────────────────────────────────
+  minio:
+    image: minio/minio:latest
+    container_name: anyscp-e2e-minio
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    networks: [e2e]
+
+  # One-shot bucket seed — creates the test bucket and uploads two objects
+  # so the S3 explorer specs have something to render.
+  minio-seed:
+    image: minio/mc:latest
+    container_name: anyscp-e2e-minio-seed
+    depends_on:
+      minio:
+        condition: service_started
+    networks: [e2e]
+    entrypoint:
+      - sh
+      - -c
+      - |
+        set -e
+        until mc alias set m http://minio:9000 minioadmin minioadmin >/dev/null 2>&1; do
+          echo "waiting for minio..."; sleep 1
+        done
+        mc mb --ignore-existing m/anyscp-test >/dev/null
+        echo "hello from minio" | mc pipe m/anyscp-test/hello.txt >/dev/null
+        echo "{\"k\": 1}"        | mc pipe m/anyscp-test/data.json >/dev/null
+        echo "minio seeded"
+
   # One-shot keygen — produces the keypair shared by sshd-key (authorized key)
   # and the e2e runner (private key for connecting).
   keygen:
@@ -73,6 +105,8 @@ services:
         condition: service_started
       sshd-key:
         condition: service_started
+      minio-seed:
+        condition: service_completed_successfully
     environment:
       SSHD_PASS_HOST: sshd-pass
       SSHD_PASS_PORT: "2222"
@@ -81,6 +115,14 @@ services:
       SSH_USER: testuser
       SSH_PASS: testpass
       SSH_KEY_PATH: /keys/id_ed25519
+      # MinIO sidecar — S3-compatible target seeded by minio-seed.
+      MINIO_ENDPOINT: http://minio:9000
+      MINIO_BUCKET: anyscp-test
+      MINIO_ACCESS_KEY: minioadmin
+      MINIO_SECRET_KEY: minioadmin
+      # Don't ship test-run noise to PostHog. Read by src-tauri/src/telemetry.rs;
+      # `init()` is a no-op when this is set, so no events are emitted.
+      ANYSCP_DISABLE_TELEMETRY: "1"
       # Force-rebuild the binary on every run: set to 1
       E2E_FORCE_BUILD: ""
       # WDIO log level

--- a/tests/e2e/docker-compose.yml
+++ b/tests/e2e/docker-compose.yml
@@ -81,10 +81,6 @@ services:
       SSH_USER: testuser
       SSH_PASS: testpass
       SSH_KEY_PATH: /keys/id_ed25519
-      # Swap anyscp's keyring backend to the Linux kernel keyring (keyutils).
-      # Sidesteps the gnome-keyring / libsecret / dbus rigmarole that's a
-      # nightmare to bootstrap in a container.
-      ANYSCP_TEST_KEYRING: keyutils
       # Force-rebuild the binary on every run: set to 1
       E2E_FORCE_BUILD: ""
       # WDIO log level

--- a/tests/e2e/docker-compose.yml
+++ b/tests/e2e/docker-compose.yml
@@ -1,0 +1,118 @@
+# E2E test stack: two sshd targets (password + key auth) plus the test runner.
+# Run from repo root with: `make e2e`  (which calls `docker compose -f tests/e2e/docker-compose.yml ...`).
+
+services:
+  # ─── Test SSH targets ───────────────────────────────────────────────────────
+  sshd-pass:
+    image: lscr.io/linuxserver/openssh-server:latest
+    container_name: anyscp-e2e-sshd-pass
+    environment:
+      PUID: "1000"
+      PGID: "1000"
+      TZ: Etc/UTC
+      USER_NAME: testuser
+      USER_PASSWORD: testpass
+      PASSWORD_ACCESS: "true"
+      SUDO_ACCESS: "true"
+    networks: [e2e]
+
+  sshd-key:
+    image: lscr.io/linuxserver/openssh-server:latest
+    container_name: anyscp-e2e-sshd-key
+    environment:
+      PUID: "1000"
+      PGID: "1000"
+      TZ: Etc/UTC
+      USER_NAME: testuser
+      PASSWORD_ACCESS: "false"
+      SUDO_ACCESS: "true"
+      PUBLIC_KEY_FILE: /keys/id_ed25519.pub
+    volumes:
+      - test-ssh-keys:/keys:ro
+    networks: [e2e]
+    depends_on:
+      keygen:
+        condition: service_completed_successfully
+    healthcheck:
+      test: ["CMD-SHELL", "ss -ltn | grep -q :2222"]
+      interval: 2s
+      timeout: 2s
+      retries: 30
+
+  # One-shot keygen — produces the keypair shared by sshd-key (authorized key)
+  # and the e2e runner (private key for connecting).
+  keygen:
+    image: alpine:3.20
+    container_name: anyscp-e2e-keygen
+    command:
+      - sh
+      - -c
+      - |
+        set -e
+        if [ ! -f /keys/id_ed25519 ]; then
+          apk add --no-cache openssh-keygen >/dev/null
+          ssh-keygen -t ed25519 -f /keys/id_ed25519 -N '' -C 'anyscp-e2e'
+          chmod 600 /keys/id_ed25519
+          chmod 644 /keys/id_ed25519.pub
+        fi
+        ls -l /keys
+    volumes:
+      - test-ssh-keys:/keys
+
+  # ─── Test runner ────────────────────────────────────────────────────────────
+  e2e:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: anyscp-e2e-runner:latest
+    container_name: anyscp-e2e-runner
+    # The entrypoint's wait_for() polls TCP on each sshd before launching
+    # WDIO, so we just need the containers started, not health-checked.
+    depends_on:
+      sshd-pass:
+        condition: service_started
+      sshd-key:
+        condition: service_started
+    environment:
+      SSHD_PASS_HOST: sshd-pass
+      SSHD_PASS_PORT: "2222"
+      SSHD_KEY_HOST: sshd-key
+      SSHD_KEY_PORT: "2222"
+      SSH_USER: testuser
+      SSH_PASS: testpass
+      SSH_KEY_PATH: /keys/id_ed25519
+      # Swap anyscp's keyring backend to the Linux kernel keyring (keyutils).
+      # Sidesteps the gnome-keyring / libsecret / dbus rigmarole that's a
+      # nightmare to bootstrap in a container.
+      ANYSCP_TEST_KEYRING: keyutils
+      # Force-rebuild the binary on every run: set to 1
+      E2E_FORCE_BUILD: ""
+      # WDIO log level
+      LOG_LEVEL: warn
+    volumes:
+      - ../..:/workspace                            # repo source (rw, so we can build)
+      - cargo-cache:/root/.cargo/registry           # persist crate downloads
+      - rust-target:/workspace/src-tauri/target     # persist build artifacts
+      - node-modules:/workspace/node_modules        # persist top-level node_modules
+      - test-ssh-keys:/keys:ro                      # shared keypair
+    networks: [e2e]
+    ports:
+      - "5900:5900"   # x11vnc — connect with a VNC client to watch tests live
+    init: true
+    # tauri-driver spawns WebKitWebDriver; SYS_ADMIN avoids sandbox/seccomp issues.
+    cap_add: [SYS_ADMIN]
+    # Disable seccomp so the kernel keyring syscalls (keyctl, add_key,
+    # request_key) the keyutils backend needs aren't filtered. Docker's
+    # default profile blocks `keyctl_join_session_keyring` regardless of
+    # capabilities. This is a test-only container — security trade-off is fine.
+    security_opt:
+      - seccomp:unconfined
+
+networks:
+  e2e:
+
+volumes:
+  cargo-cache:
+  rust-target:
+  node-modules:
+  test-ssh-keys:

--- a/tests/e2e/entrypoint.sh
+++ b/tests/e2e/entrypoint.sh
@@ -41,7 +41,21 @@ rm -rf tests/e2e/node_modules tests/e2e/pnpm-lock.yaml tests/e2e/package-lock.js
 ln -sfn /opt/e2e/node_modules tests/e2e/node_modules
 
 # ── 3. Build Tauri binary if missing or source changed ───────────────────────
-if [[ ! -x "$ANYSCP_BIN" || -n "${E2E_FORCE_BUILD:-}" ]]; then
+# Rebuild if: binary is missing, OR E2E_FORCE_BUILD is set, OR any tracked
+# source file is newer than the binary (otherwise frontend changes silently
+# go missing because Tauri embeds dist/ at compile time).
+needs_build=0
+if [[ ! -x "$ANYSCP_BIN" ]]; then
+    needs_build=1
+elif [[ -n "${E2E_FORCE_BUILD:-}" ]]; then
+    needs_build=1
+elif find src src-tauri/src src-tauri/Cargo.toml src-tauri/tauri.conf.json \
+        index.html vite.config.ts \
+        -newer "$ANYSCP_BIN" -print -quit 2>/dev/null | grep -q .; then
+    needs_build=1
+fi
+
+if [[ $needs_build -eq 1 ]]; then
     echo "[entrypoint] building anyscp (debug, frontend embedded)"
     # Use `tauri build --debug --no-bundle`, NOT `cargo build`:
     #   - `cargo build` alone produces a binary that expects the frontend at
@@ -53,7 +67,7 @@ if [[ ! -x "$ANYSCP_BIN" || -n "${E2E_FORCE_BUILD:-}" ]]; then
     #   - `--no-bundle` skips the installer/AppImage step we don't need.
     pnpm tauri build --debug --no-bundle
 else
-    echo "[entrypoint] reusing existing binary at $ANYSCP_BIN"
+    echo "[entrypoint] reusing existing binary at $ANYSCP_BIN (sources unchanged)"
 fi
 
 # ── 4. Start Xvfb + x11vnc, then run WDIO ─────────────────────────────────────

--- a/tests/e2e/entrypoint.sh
+++ b/tests/e2e/entrypoint.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Entry point for the e2e runner container.
+#
+# Steps:
+#   1. Wait for the linked sshd-pass and sshd-key containers to accept TCP.
+#   2. Install JS deps for the app + the e2e harness.
+#   3. Build the Tauri debug binary (cached across runs via volume).
+#   4. Launch xvfb + dbus, then run WebdriverIO.
+set -euo pipefail
+
+cd /workspace
+
+ANYSCP_BIN="src-tauri/target/debug/anyscp"
+
+# ── 1. Wait for sshd containers ───────────────────────────────────────────────
+wait_for() {
+    local host="$1" port="$2" name="$3"
+    echo "[entrypoint] waiting for $name ($host:$port)..."
+    for _ in $(seq 1 60); do
+        if (echo > "/dev/tcp/$host/$port") >/dev/null 2>&1; then
+            echo "[entrypoint] $name ready"
+            return 0
+        fi
+        sleep 1
+    done
+    echo "[entrypoint] timed out waiting for $name" >&2
+    return 1
+}
+
+wait_for "${SSHD_PASS_HOST:-sshd-pass}" "${SSHD_PASS_PORT:-2222}" sshd-pass
+wait_for "${SSHD_KEY_HOST:-sshd-key}"   "${SSHD_KEY_PORT:-2222}"   sshd-key
+
+# ── 2. Install JS deps ────────────────────────────────────────────────────────
+echo "[entrypoint] installing app deps"
+pnpm install --frozen-lockfile=false
+
+echo "[entrypoint] linking pre-baked e2e harness deps from /opt/e2e"
+# Deps were installed at image build time in /opt/e2e (see Dockerfile).
+# Symlink them into the bind-mounted tests/e2e/ so WDIO can resolve them.
+rm -rf tests/e2e/node_modules tests/e2e/pnpm-lock.yaml tests/e2e/package-lock.json
+ln -sfn /opt/e2e/node_modules tests/e2e/node_modules
+
+# ── 3. Build Tauri binary if missing or source changed ───────────────────────
+if [[ ! -x "$ANYSCP_BIN" || -n "${E2E_FORCE_BUILD:-}" ]]; then
+    echo "[entrypoint] building anyscp (debug, frontend embedded)"
+    # Use `tauri build --debug --no-bundle`, NOT `cargo build`:
+    #   - `cargo build` alone produces a binary that expects the frontend at
+    #     tauri.conf.json's devUrl (http://localhost:1420) — there's no Vite
+    #     in the container, so the webview shows "Connection refused".
+    #   - `tauri build` runs the codegen step that embeds the bundled
+    #     `dist/` into the binary so it serves over the tauri://localhost
+    #     custom protocol.
+    #   - `--no-bundle` skips the installer/AppImage step we don't need.
+    pnpm tauri build --debug --no-bundle
+else
+    echo "[entrypoint] reusing existing binary at $ANYSCP_BIN"
+fi
+
+# ── 4. Start Xvfb + x11vnc, then run WDIO ─────────────────────────────────────
+# Credentials use the kernel keyring (keyutils) via ANYSCP_TEST_KEYRING set in
+# docker-compose.yml. No dbus/gnome-keyring/libsecret dance needed.
+
+# Start Xvfb on :99 manually (so x11vnc can attach to the same display).
+echo "[entrypoint] starting Xvfb :99 (1280x800x24)"
+Xvfb :99 -screen 0 1280x800x24 -ac >/tmp/xvfb.log 2>&1 &
+export DISPLAY=:99
+# Wait for X server socket
+for _ in $(seq 1 30); do
+    [ -e /tmp/.X11-unix/X99 ] && break
+    sleep 0.2
+done
+
+# Start x11vnc attached to :99 so anyone on port 5900 can watch the suite live.
+# -nopw is fine — this only listens on the docker-internal network unless the
+# port is published, which it is in docker-compose.yml.
+echo "[entrypoint] starting x11vnc on :5900"
+x11vnc -display :99 -forever -shared -nopw -rfbport 5900 -quiet -bg \
+    -o /tmp/x11vnc.log
+
+echo "[entrypoint] >>> VNC ready — connect to localhost:5900 to watch <<<"
+
+echo "[entrypoint] running webdriverio (inside a fresh kernel keyring session)"
+cd tests/e2e
+# Wrap the test process in `keyctl session -` so the Tauri app's keyutils
+# keyring backend has a session keyring to write to. Without it, every
+# keyctl syscall returns EACCES → "PermissionDenied" from anyscp's vault.
+exec keyctl session - ./node_modules/.bin/wdio run wdio.conf.ts

--- a/tests/e2e/helpers/dashboard.ts
+++ b/tests/e2e/helpers/dashboard.ts
@@ -1,0 +1,16 @@
+// Dashboard helpers — assertions about the hosts dashboard.
+
+/** Wait for the hosts dashboard ("New Server" button visible). */
+export async function waitForDashboard(timeoutMs = 30_000): Promise<void> {
+    const btn = await $("[data-testid='new-host-button']");
+    await btn.waitForDisplayed({ timeout: timeoutMs });
+}
+
+/** Number of host cards currently rendered. */
+export async function hostCardCount(): Promise<number> {
+    // `data-host-id` only appears on the outer card div — using it avoids
+    // matching the inner terminal/explorer action buttons (which also have
+    // testids starting with `host-card-…`).
+    const cards = await $$("[data-host-id]");
+    return cards.length;
+}

--- a/tests/e2e/helpers/groups.ts
+++ b/tests/e2e/helpers/groups.ts
@@ -1,0 +1,61 @@
+// Group helpers — built on data-testids in HostsDashboard, GroupModal, GroupCard.
+
+/** Click "New Group" and wait for the modal to appear. */
+export async function openNewGroupModal(): Promise<void> {
+    const btn = await $("[data-testid='new-group-button']");
+    await btn.waitForClickable({ timeout: 10_000 });
+    await btn.click();
+    await (await $("[data-testid='group-modal']")).waitForDisplayed({ timeout: 5_000 });
+}
+
+/** Fill name + save a group. Modal must already be open. */
+export async function fillGroupAndSave(name: string): Promise<void> {
+    const input = await $("[data-testid='group-modal-name']");
+    await input.waitForDisplayed({ timeout: 5_000 });
+    await input.click();
+    await input.setValue(name);
+    const save = await $("[data-testid='group-modal-save']");
+    await save.waitForClickable({ timeout: 5_000 });
+    await save.click();
+    await browser.waitUntil(
+        async () => !(await (await $("[data-testid='group-modal']")).isExisting()),
+        { timeout: 10_000, timeoutMsg: "group modal did not close" },
+    );
+}
+
+/** Find a group card by display name. */
+export async function findGroupCard(name: string): Promise<WebdriverIO.Element> {
+    const card = await $(`[data-group-name='${name}']`);
+    await card.waitForExist({ timeout: 10_000 });
+    return card;
+}
+
+/** Get the group's id from its rendered data attribute. */
+export async function getGroupId(name: string): Promise<string> {
+    const card = await findGroupCard(name);
+    const id = await card.getAttribute("data-group-id");
+    if (!id) throw new Error(`group card '${name}' missing data-group-id`);
+    return id;
+}
+
+/** Delete a group via the store hook (UI uses right-click context menu). */
+export async function deleteGroup(name: string): Promise<void> {
+    const id = await getGroupId(name);
+    await browser.execute(async (groupId: string) => {
+        const fn = (window as unknown as {
+            __e2eDeleteGroup?: (id: string) => Promise<void>;
+        }).__e2eDeleteGroup;
+        if (!fn) throw new Error("__e2eDeleteGroup not registered");
+        await fn(groupId);
+    }, id);
+    await browser.waitUntil(
+        async () => !(await (await $(`[data-group-name='${name}']`)).isExisting()),
+        { timeout: 5_000, timeoutMsg: `group '${name}' still present` },
+    );
+}
+
+/** Count group cards currently rendered. */
+export async function groupCount(): Promise<number> {
+    const cards = await $$("[data-group-id]");
+    return cards.length;
+}

--- a/tests/e2e/helpers/history.ts
+++ b/tests/e2e/helpers/history.ts
@@ -1,0 +1,20 @@
+// History page helpers.
+
+/** Activate the History sidebar nav. */
+export async function gotoHistoryPage(): Promise<void> {
+    const nav = await $("[aria-label='History']");
+    await nav.waitForClickable({ timeout: 10_000 });
+    await nav.click();
+    // Page is rendered when at least one entry exists OR a search bar is shown.
+    await browser.pause(200);
+}
+
+export async function historyEntryCount(): Promise<number> {
+    const entries = await $$("[data-testid^='history-entry-']");
+    return entries.length;
+}
+
+export async function waitForHistoryEntry(hostLabel: string, timeoutMs = 10_000): Promise<void> {
+    const el = await $(`[data-history-host-label='${hostLabel}']`);
+    await el.waitForExist({ timeout: timeoutMs });
+}

--- a/tests/e2e/helpers/host.ts
+++ b/tests/e2e/helpers/host.ts
@@ -155,3 +155,15 @@ export async function getHostId(label: string): Promise<string> {
     if (!id) throw new Error(`host card '${label}' missing data-host-id`);
     return id;
 }
+
+/** Duplicate a host via the store hook (avoids right-click context menu). */
+export async function duplicateHost(label: string): Promise<void> {
+    const hostId = await getHostId(label);
+    await browser.execute(async (id: string) => {
+        const fn = (window as unknown as {
+            __e2eDuplicateHost?: (id: string) => Promise<void>;
+        }).__e2eDuplicateHost;
+        if (!fn) throw new Error("__e2eDuplicateHost not registered");
+        await fn(id);
+    }, hostId);
+}

--- a/tests/e2e/helpers/host.ts
+++ b/tests/e2e/helpers/host.ts
@@ -1,0 +1,157 @@
+// Host form helpers — drive the HostEditModal via testids.
+
+export interface PasswordHost {
+    label: string;
+    host: string;
+    port: number;
+    username: string;
+    password: string;
+}
+
+export interface KeyHost {
+    label: string;
+    host: string;
+    port: number;
+    username: string;
+    keyPath: string;
+}
+
+/** Click the "New Server" button on the hosts dashboard. */
+export async function openNewHostModal(): Promise<void> {
+    const btn = await $("[data-testid='new-host-button']");
+    await btn.waitForClickable({ timeout: 10_000 });
+    await btn.click();
+    await waitForModalOpen();
+}
+
+/** Wait for the host modal to be present + visible. */
+export async function waitForModalOpen(): Promise<void> {
+    const modal = await $("[data-testid='host-modal']");
+    await modal.waitForExist({ timeout: 5_000 });
+    await modal.waitForDisplayed({ timeout: 5_000 });
+}
+
+/** Wait for the host modal to fully unmount. If it doesn't, surface any
+ *  error banner text in the failure message — the banner is at the bottom
+ *  of the scrolling modal body and is otherwise invisible in screenshots. */
+export async function waitForModalClosed(): Promise<void> {
+    try {
+        await browser.waitUntil(
+            async () => !(await (await $("[data-testid='host-modal']")).isExisting()),
+            { timeout: 15_000, timeoutMsg: "modal did not close" },
+        );
+    } catch (err) {
+        const errBanner = await $("[data-testid='host-modal-error']");
+        if (await errBanner.isExisting()) {
+            const text = await errBanner.getText();
+            throw new Error(`modal did not close — error banner: "${text}"`);
+        }
+        throw err;
+    }
+}
+
+async function setInput(testid: string, value: string): Promise<void> {
+    const el = await $(`[data-testid='${testid}']`);
+    await el.waitForExist({ timeout: 5_000 });
+    await el.click();
+    // setValue clears + types — safer than 'addValue' for inputs that may
+    // have a placeholder showing the previous saved value.
+    await el.setValue(value);
+}
+
+/** Pick an option from the auth-type CustomSelect (password|privateKey). */
+async function selectAuthType(value: "password" | "privateKey"): Promise<void> {
+    const current = await (await $("[data-testid='host-modal-auth']")).getText();
+    const wantPwd = value === "password";
+    if (wantPwd && current.toLowerCase().includes("password")) return;
+    if (!wantPwd && current.toLowerCase().includes("private")) return;
+
+    await (await $("[data-testid='host-modal-auth']")).click();
+    const opt = await $(`[data-testid='host-modal-auth-option-${value}']`);
+    await opt.waitForExist({ timeout: 5_000 });
+    await opt.click();
+}
+
+/** Fill the password-auth form fields. Modal must already be open. */
+export async function fillPasswordHostForm(h: PasswordHost): Promise<void> {
+    await selectAuthType("password");
+    await setInput("host-modal-label", h.label);
+    await setInput("host-modal-host", h.host);
+    await setInput("host-modal-port", String(h.port));
+    await setInput("host-modal-username", h.username);
+    await setInput("host-modal-password", h.password);
+}
+
+/** Fill the key-auth form fields. Modal must already be open. */
+export async function fillKeyHostForm(h: KeyHost): Promise<void> {
+    await selectAuthType("privateKey");
+    await setInput("host-modal-label", h.label);
+    await setInput("host-modal-host", h.host);
+    await setInput("host-modal-port", String(h.port));
+    await setInput("host-modal-username", h.username);
+    // The keypath field is either a CustomSelect (when SSH keys were auto-
+    // discovered in ~/.ssh) or a plain text input. In the container the
+    // ~/.ssh dir is empty so we get the input.
+    const keyInput = await $("[data-testid='host-modal-keypath']");
+    if (await keyInput.isExisting()) {
+        await keyInput.click();
+        await keyInput.setValue(h.keyPath);
+    } else {
+        throw new Error(
+            "host-modal-keypath input not present — SSH key auto-discovery " +
+                "found keys and rendered a select instead. Wire that path up if needed.",
+        );
+    }
+}
+
+export async function clickSave(): Promise<void> {
+    const btn = await $("[data-testid='host-modal-save']");
+    await btn.waitForClickable({ timeout: 5_000 });
+    await btn.click();
+}
+
+export async function clickConnect(): Promise<void> {
+    const btn = await $("[data-testid='host-modal-connect']");
+    await btn.waitForClickable({ timeout: 5_000 });
+    await btn.click();
+}
+
+/** Open the edit modal for an existing host. Drives the UI store directly via
+ *  the `__e2eOpenHostEdit` window hook (right-click context menu is flaky in
+ *  WebKitWebDriver). */
+export async function openHostEdit(hostLabel: string): Promise<void> {
+    const hostId = await getHostId(hostLabel);
+    await browser.execute((id: string) => {
+        const fn = (window as unknown as { __e2eOpenHostEdit?: (id: string) => void })
+            .__e2eOpenHostEdit;
+        if (!fn) throw new Error("__e2eOpenHostEdit not registered");
+        fn(id);
+    }, hostId);
+    await waitForModalOpen();
+}
+
+/** Find a host card on the dashboard by its display label. */
+export async function findHostCardByLabel(label: string): Promise<WebdriverIO.Element> {
+    const card = await $(`[data-testid^='host-card-'][data-host-label='${label}']`);
+    await card.waitForExist({ timeout: 10_000 });
+    return card;
+}
+
+/** Assert that no host card with the given label exists. */
+export async function assertHostAbsent(label: string): Promise<void> {
+    await browser.waitUntil(
+        async () => {
+            const el = await $(`[data-testid^='host-card-'][data-host-label='${label}']`);
+            return !(await el.isExisting());
+        },
+        { timeout: 10_000, timeoutMsg: `host '${label}' still present on dashboard` },
+    );
+}
+
+/** Read the host id from the data attribute on its card. */
+export async function getHostId(label: string): Promise<string> {
+    const card = await findHostCardByLabel(label);
+    const id = await card.getAttribute("data-host-id");
+    if (!id) throw new Error(`host card '${label}' missing data-host-id`);
+    return id;
+}

--- a/tests/e2e/helpers/keyboard.ts
+++ b/tests/e2e/helpers/keyboard.ts
@@ -1,0 +1,25 @@
+// Keyboard helpers — anySCP shortcuts use the meta key (Cmd on macOS,
+// Ctrl on Linux/Windows). Inside the container we're on Linux, so
+// WebdriverIO's "Control" maps onto what the app sees as "meta".
+//
+// `useKeyboardShortcuts` listens for `metaKey || ctrlKey`, so Control
+// works on Linux.
+
+const META = "Control";
+
+/** Tap a single key with the meta modifier (e.g. Cmd+T). */
+export async function cmd(key: string): Promise<void> {
+    await browser.keys([META, key]);
+    // browser.keys() with an array is treated as a chord that releases all
+    // keys at the end, so no separate release needed.
+}
+
+/** Tap meta+shift+key. */
+export async function cmdShift(key: string): Promise<void> {
+    await browser.keys([META, "Shift", key]);
+}
+
+/** Tap a single key. */
+export async function tap(key: string): Promise<void> {
+    await browser.keys([key]);
+}

--- a/tests/e2e/helpers/port-forwards.ts
+++ b/tests/e2e/helpers/port-forwards.ts
@@ -1,0 +1,94 @@
+// Port-forward helpers — built on testids in PortForwardingPage + RuleDialog.
+
+/** Activate the Tunnels sidebar nav. */
+export async function gotoPortForwardingPage(): Promise<void> {
+    const nav = await $("[aria-label='Tunnels']");
+    await nav.waitForClickable({ timeout: 10_000 });
+    await nav.click();
+    await (await $("[data-testid='new-rule-button']")).waitForDisplayed({ timeout: 10_000 });
+}
+
+export async function openNewRuleDialog(): Promise<void> {
+    const btn = await $("[data-testid='new-rule-button']");
+    await btn.waitForClickable({ timeout: 5_000 });
+    await btn.click();
+    await (await $("[data-testid='rule-dialog']")).waitForDisplayed({ timeout: 5_000 });
+}
+
+export interface RuleForm {
+    label: string;
+    hostId: string;
+    localPort: number;
+    remotePort: number;
+}
+
+/** Fill the rule dialog and save. */
+export async function fillRuleAndSave(rule: RuleForm): Promise<void> {
+    // Host CustomSelect — open then click the option.
+    const hostSel = await $("[data-testid='rule-host-select']");
+    await hostSel.click();
+    const opt = await $(`[data-testid='rule-host-select-option-${rule.hostId}']`);
+    await opt.waitForClickable({ timeout: 5_000 });
+    await opt.click();
+
+    const label = await $("[data-testid='rule-label-input']");
+    await label.click();
+    await label.setValue(rule.label);
+
+    const lp = await $("[data-testid='rule-local-port']");
+    await lp.click();
+    await lp.setValue(String(rule.localPort));
+
+    const rp = await $("[data-testid='rule-remote-port']");
+    await rp.click();
+    await rp.setValue(String(rule.remotePort));
+
+    const save = await $("[data-testid='rule-dialog-save']");
+    await save.waitForClickable({ timeout: 5_000 });
+    await save.click();
+    await browser.waitUntil(
+        async () => !(await (await $("[data-testid='rule-dialog']")).isExisting()),
+        { timeout: 10_000, timeoutMsg: "rule dialog did not close" },
+    );
+}
+
+export async function findRuleCard(label: string): Promise<WebdriverIO.Element> {
+    const card = await $(`[data-rule-label='${label}']`);
+    await card.waitForExist({ timeout: 10_000 });
+    return card;
+}
+
+export async function getRuleId(label: string): Promise<string> {
+    const card = await findRuleCard(label);
+    const id = await card.getAttribute("data-rule-id");
+    if (!id) throw new Error(`rule card '${label}' missing data-rule-id`);
+    return id;
+}
+
+export async function deleteRule(label: string): Promise<void> {
+    const id = await getRuleId(label);
+    await browser.execute(async (rid: string) => {
+        const fn = (window as unknown as {
+            __e2eDeleteRule?: (id: string) => Promise<void>;
+        }).__e2eDeleteRule;
+        if (!fn) throw new Error("__e2eDeleteRule not registered");
+        await fn(rid);
+    }, id);
+    await browser.waitUntil(
+        async () => !(await (await $(`[data-rule-label='${label}']`)).isExisting()),
+        { timeout: 5_000, timeoutMsg: `rule '${label}' still present` },
+    );
+}
+
+/** Toggle a rule on or off via its switch (the start/stop button). */
+export async function toggleRule(label: string): Promise<void> {
+    const card = await findRuleCard(label);
+    // The switch is inside the card.
+    const sw = await card.$("[role='switch']");
+    await sw.click();
+}
+
+export async function ruleCount(): Promise<number> {
+    const cards = await $$("[data-rule-id]");
+    return cards.length;
+}

--- a/tests/e2e/helpers/recent.ts
+++ b/tests/e2e/helpers/recent.ts
@@ -1,0 +1,24 @@
+// Recent-connections helpers.
+
+/** Wait for a recent-connection chip with the given label to appear. */
+export async function waitForRecent(
+    label: string,
+    timeoutMs = 10_000,
+): Promise<WebdriverIO.Element> {
+    const el = await $(`[data-recent-label='${label}']`);
+    await el.waitForExist({ timeout: timeoutMs });
+    return el;
+}
+
+/** Count visible recent-connection chips. */
+export async function recentCount(): Promise<number> {
+    const items = await $$("[data-recent-host-id]");
+    return items.length;
+}
+
+/** Click the recent-connection chip matching `label`. */
+export async function clickRecent(label: string): Promise<void> {
+    const el = await waitForRecent(label);
+    await el.waitForClickable({ timeout: 5_000 });
+    await el.click();
+}

--- a/tests/e2e/helpers/reset.ts
+++ b/tests/e2e/helpers/reset.ts
@@ -1,0 +1,31 @@
+// Reset helper — wipes the app's persisted state and relaunches the Tauri
+// process so each test starts from a clean DB.
+//
+// The Tauri app reads `$XDG_DATA_HOME/com.macnev2013.anyscp/anyscp.db`.
+// Deleting the directory between sessions is sufficient; the app re-creates
+// the schema on startup.
+
+import { rm } from "node:fs/promises";
+import { join } from "node:path";
+
+const APP_DATA_DIR = join(
+    process.env.XDG_DATA_HOME ?? `${process.env.HOME}/.local/share`,
+    "com.macnev2013.anyscp",
+);
+
+/**
+ * Delete the app's data directory and start a fresh WebDriver session.
+ * Call this in a `beforeEach` so tests get full isolation.
+ */
+export async function resetApp(): Promise<void> {
+    await rm(APP_DATA_DIR, { recursive: true, force: true });
+    await browser.reloadSession();
+}
+
+/**
+ * Relaunch the app without touching the DB — used to verify persistence
+ * across restarts.
+ */
+export async function relaunchApp(): Promise<void> {
+    await browser.reloadSession();
+}

--- a/tests/e2e/helpers/s3.ts
+++ b/tests/e2e/helpers/s3.ts
@@ -1,0 +1,112 @@
+// S3 helpers — built on the testids added to HostsDashboard, S3ConnectDialog,
+// and S3Card.
+
+export interface S3Form {
+    label: string;
+    provider?: string;   // defaults to "minio"
+    accessKey: string;
+    secretKey: string;
+    region?: string;     // defaults to "us-east-1"
+    bucket: string;
+    endpoint: string;    // required for non-AWS
+}
+
+/** Click "New S3" and wait for the dialog. */
+export async function openNewS3Dialog(): Promise<void> {
+    const btn = await $("[data-testid='new-s3-button']");
+    await btn.waitForClickable({ timeout: 10_000 });
+    await btn.click();
+    await (await $("[data-testid='s3-dialog']")).waitForDisplayed({ timeout: 5_000 });
+}
+
+/** Pick a provider from the CustomSelect by value (e.g. "minio", "aws"). */
+async function selectProvider(value: string): Promise<void> {
+    const sel = await $("[data-testid='s3-dialog-provider']");
+    await sel.click();
+    const opt = await $(`[data-testid='s3-dialog-provider-option-${value}']`);
+    await opt.waitForClickable({ timeout: 5_000 });
+    await opt.click();
+}
+
+/** Fill out the dialog. Modal must already be open. */
+export async function fillS3Form(f: S3Form): Promise<void> {
+    if (f.provider) await selectProvider(f.provider);
+
+    const setInput = async (testid: string, value: string) => {
+        const el = await $(`[data-testid='${testid}']`);
+        await el.click();
+        await el.setValue(value);
+    };
+
+    await setInput("s3-dialog-label", f.label);
+    await setInput("s3-dialog-access-key", f.accessKey);
+    await setInput("s3-dialog-secret-key", f.secretKey);
+    if (f.region) await setInput("s3-dialog-region", f.region);
+    await setInput("s3-dialog-bucket", f.bucket);
+    // Endpoint is conditional on provider !== "aws"; if visible, fill it.
+    const endpoint = await $("[data-testid='s3-dialog-endpoint']");
+    if (await endpoint.isExisting()) {
+        await endpoint.click();
+        // The provider preset may pre-populate the endpoint pattern — clear first.
+        await browser.keys(["Control", "a"]);
+        await browser.keys(["Backspace"]);
+        await endpoint.setValue(f.endpoint);
+    }
+}
+
+export async function clickS3Save(): Promise<void> {
+    const btn = await $("[data-testid='s3-dialog-save']");
+    await btn.waitForClickable({ timeout: 10_000 });
+    await btn.click();
+    await browser.waitUntil(
+        async () => !(await (await $("[data-testid='s3-dialog']")).isExisting()),
+        { timeout: 15_000, timeoutMsg: "S3 dialog did not close after Save" },
+    );
+}
+
+export async function clickS3Connect(): Promise<void> {
+    const btn = await $("[data-testid='s3-dialog-connect']");
+    await btn.waitForClickable({ timeout: 10_000 });
+    await btn.click();
+    await browser.waitUntil(
+        async () => !(await (await $("[data-testid='s3-dialog']")).isExisting()),
+        { timeout: 30_000, timeoutMsg: "S3 dialog did not close after Connect" },
+    );
+}
+
+export async function findS3Card(label: string): Promise<WebdriverIO.Element> {
+    const card = await $(`[data-s3-label='${label}']`);
+    await card.waitForExist({ timeout: 10_000 });
+    return card;
+}
+
+export async function getS3Id(label: string): Promise<string> {
+    const card = await findS3Card(label);
+    const id = await card.getAttribute("data-s3-id");
+    if (!id) throw new Error(`S3 card '${label}' missing data-s3-id`);
+    return id;
+}
+
+export async function deleteS3Connection(label: string): Promise<void> {
+    const id = await getS3Id(label);
+    await browser.execute(async (cid: string) => {
+        const w = window as unknown as {
+            __e2eDeleteS3Connection?: (id: string) => Promise<void>;
+            __e2eReloadS3Connections?: () => Promise<void>;
+        };
+        if (!w.__e2eDeleteS3Connection) throw new Error("__e2eDeleteS3Connection not registered");
+        await w.__e2eDeleteS3Connection(cid);
+        // HostsDashboard caches the S3 connection list in component state.
+        // Trigger a reload so the card actually disappears from the DOM.
+        if (w.__e2eReloadS3Connections) await w.__e2eReloadS3Connections();
+    }, id);
+    await browser.waitUntil(
+        async () => !(await (await $(`[data-s3-label='${label}']`)).isExisting()),
+        { timeout: 5_000, timeoutMsg: `S3 connection '${label}' still present` },
+    );
+}
+
+export async function s3CardCount(): Promise<number> {
+    const cards = await $$("[data-s3-id]");
+    return cards.length;
+}

--- a/tests/e2e/helpers/sftp-ops.ts
+++ b/tests/e2e/helpers/sftp-ops.ts
@@ -1,0 +1,97 @@
+// SFTP explorer interactions — built on the testids added to
+// ExplorerToolbar and ExplorerFileTable.
+
+/** Wait until the explorer toolbar is rendered (refresh button visible). */
+export async function waitForExplorer(timeoutMs = 30_000): Promise<void> {
+    const refresh = await $("[data-testid='explorer-refresh']");
+    await refresh.waitForDisplayed({ timeout: timeoutMs });
+}
+
+/** Find a directory entry by its display name. Waits up to timeoutMs. */
+export async function waitForEntry(
+    name: string,
+    timeoutMs = 10_000,
+): Promise<WebdriverIO.Element> {
+    const el = await $(`[data-entry-name='${name}']`);
+    await el.waitForExist({ timeout: timeoutMs });
+    return el;
+}
+
+/** True if no entry with that name is visible. */
+export async function assertEntryAbsent(name: string, timeoutMs = 10_000): Promise<void> {
+    await browser.waitUntil(
+        async () => !(await (await $(`[data-entry-name='${name}']`)).isExisting()),
+        { timeout: timeoutMs, timeoutMsg: `entry '${name}' still present` },
+    );
+}
+
+/** Double-click an entry to navigate (if directory) or open (if file). */
+export async function openEntry(name: string): Promise<void> {
+    const entry = await waitForEntry(name);
+    await entry.doubleClick();
+}
+
+/** Click the explorer refresh button. */
+export async function refreshExplorer(): Promise<void> {
+    const btn = await $("[data-testid='explorer-refresh']");
+    await btn.waitForClickable({ timeout: 5_000 });
+    await btn.click();
+}
+
+/** Click the home/root toolbar button. */
+export async function navigateExplorerHome(): Promise<void> {
+    const btn = await $("[data-testid='explorer-home']");
+    await btn.waitForClickable({ timeout: 5_000 });
+    await btn.click();
+}
+
+/** Create a folder via the toolbar. Waits for the new entry to appear. */
+export async function createFolder(name: string): Promise<void> {
+    await (await $("[data-testid='explorer-new-folder']")).click();
+    const input = await $("[data-testid='explorer-new-folder-input']");
+    await input.waitForDisplayed({ timeout: 5_000 });
+    await input.setValue(name);
+    await browser.keys(["Enter"]);
+    await waitForEntry(name);
+}
+
+/** Create an empty file via the toolbar. */
+export async function createFile(name: string): Promise<void> {
+    await (await $("[data-testid='explorer-new-file']")).click();
+    const input = await $("[data-testid='explorer-new-file-input']");
+    await input.waitForDisplayed({ timeout: 5_000 });
+    await input.setValue(name);
+    await browser.keys(["Enter"]);
+    await waitForEntry(name);
+}
+
+/** Select an entry by clicking it, then press Delete and confirm. */
+export async function deleteEntry(name: string): Promise<void> {
+    const entry = await waitForEntry(name);
+    await entry.click();
+    await browser.keys(["Delete"]);
+    const confirm = await $("[data-testid='explorer-delete-confirm-button']");
+    await confirm.waitForClickable({ timeout: 5_000 });
+    await confirm.click();
+    await assertEntryAbsent(name);
+}
+
+/** Rename an entry. Calls the __e2eExplorerStartRename(oldName, newName) hook
+ *  which invokes onRename directly — sidesteps the inline rename input UI
+ *  whose autoFocus + onBlur cancel races with WebDriver's setValue. */
+export async function renameEntry(oldName: string, newName: string): Promise<void> {
+    await waitForEntry(oldName);
+    await browser.execute(
+        (oldN: string, newN: string) => {
+            const fn = (window as unknown as {
+                __e2eExplorerStartRename?: (o: string, n?: string) => void;
+            }).__e2eExplorerStartRename;
+            if (!fn) throw new Error("__e2eExplorerStartRename not registered");
+            fn(oldN, newN);
+        },
+        oldName,
+        newName,
+    );
+    await waitForEntry(newName);
+    await assertEntryAbsent(oldName);
+}

--- a/tests/e2e/helpers/sftp-ops.ts
+++ b/tests/e2e/helpers/sftp-ops.ts
@@ -76,6 +76,50 @@ export async function deleteEntry(name: string): Promise<void> {
     await assertEntryAbsent(name);
 }
 
+/** Select a set of entries (via __e2eExplorerSetSelection) then Delete + confirm. */
+export async function multiSelectAndDelete(names: string[]): Promise<void> {
+    if (names.length === 0) return;
+    for (const name of names) await waitForEntry(name);
+
+    await browser.execute((items: string[]) => {
+        const fn = (window as unknown as {
+            __e2eExplorerSetSelection?: (names: string[]) => void;
+        }).__e2eExplorerSetSelection;
+        if (!fn) throw new Error("__e2eExplorerSetSelection not registered");
+        fn(items);
+    }, names);
+
+    // Focus a selected row so the Delete keydown fires on it.
+    await browser.execute((firstName: string) => {
+        const el = document.querySelector(
+            `[data-entry-name='${firstName}']`,
+        ) as HTMLElement | null;
+        el?.focus();
+    }, names[0]);
+
+    await browser.keys(["Delete"]);
+    const confirm = await $("[data-testid='explorer-delete-confirm-button']");
+    await confirm.waitForClickable({ timeout: 5_000 });
+    await confirm.click();
+    for (const name of names) await assertEntryAbsent(name);
+}
+
+/** Read the current order of entries in the listing (top to bottom). */
+export async function entryOrder(): Promise<string[]> {
+    return await browser.execute(() => {
+        return Array.from(
+            document.querySelectorAll<HTMLElement>("[data-entry-row='true']"),
+        ).map((el) => el.getAttribute("data-entry-name") ?? "");
+    });
+}
+
+/** Click a column header to (re)sort by that column. */
+export async function clickSortHeader(col: "name" | "size" | "modified"): Promise<void> {
+    const btn = await $(`[data-testid='explorer-sort-${col}']`);
+    await btn.waitForClickable({ timeout: 5_000 });
+    await btn.click();
+}
+
 /** Rename an entry. Calls the __e2eExplorerStartRename(oldName, newName) hook
  *  which invokes onRename directly — sidesteps the inline rename input UI
  *  whose autoFocus + onBlur cancel races with WebDriver's setValue. */

--- a/tests/e2e/helpers/sidebar.ts
+++ b/tests/e2e/helpers/sidebar.ts
@@ -1,0 +1,14 @@
+// Sidebar helpers — read collapsed/expanded state from the data attribute.
+
+export async function sidebarExpanded(): Promise<boolean> {
+    const sidebar = await $("[data-testid='sidebar']");
+    const v = await sidebar.getAttribute("data-sidebar-expanded");
+    return v === "true";
+}
+
+export async function clickCollapseToggle(): Promise<void> {
+    // The toggle's aria-label flips between "Expand" and "Collapse" — match either.
+    const btn = await $("[aria-label='Collapse'], [aria-label='Expand']");
+    await btn.waitForClickable({ timeout: 5_000 });
+    await btn.click();
+}

--- a/tests/e2e/helpers/snippets.ts
+++ b/tests/e2e/helpers/snippets.ts
@@ -1,0 +1,93 @@
+// Snippets helpers — built on testids in SnippetsPage, SnippetCard,
+// SnippetEditModal, and SnippetPalette.
+
+/** Activate the Snippets sidebar nav. */
+export async function gotoSnippetsPage(): Promise<void> {
+    const nav = await $("[aria-label='Snippets']");
+    await nav.waitForClickable({ timeout: 10_000 });
+    await nav.click();
+    // The New Snippet button is the page's main affordance — wait for it.
+    await (await $("[data-testid='new-snippet-button']")).waitForDisplayed({
+        timeout: 10_000,
+    });
+}
+
+/** Click "New Snippet" and wait for the modal. */
+export async function openNewSnippetModal(): Promise<void> {
+    const btn = await $("[data-testid='new-snippet-button']");
+    await btn.waitForClickable({ timeout: 5_000 });
+    await btn.click();
+    await (await $("[data-testid='snippet-modal']")).waitForDisplayed({ timeout: 5_000 });
+}
+
+export interface SnippetForm {
+    name: string;
+    command: string;
+}
+
+/** Fill out the snippet modal and click Save. */
+export async function fillSnippetAndSave(s: SnippetForm): Promise<void> {
+    const name = await $("[data-testid='snippet-modal-name']");
+    await name.click();
+    await name.setValue(s.name);
+    const cmd = await $("[data-testid='snippet-modal-command']");
+    await cmd.click();
+    await cmd.setValue(s.command);
+    const save = await $("[data-testid='snippet-modal-save']");
+    await save.waitForClickable({ timeout: 5_000 });
+    await save.click();
+    await browser.waitUntil(
+        async () => !(await (await $("[data-testid='snippet-modal']")).isExisting()),
+        { timeout: 10_000, timeoutMsg: "snippet modal did not close" },
+    );
+}
+
+/** Find a snippet card by name. */
+export async function findSnippetCard(name: string): Promise<WebdriverIO.Element> {
+    const card = await $(`[data-snippet-name='${name}']`);
+    await card.waitForExist({ timeout: 10_000 });
+    return card;
+}
+
+/** Read a snippet's id from its rendered data attribute. */
+export async function getSnippetId(name: string): Promise<string> {
+    const card = await findSnippetCard(name);
+    const id = await card.getAttribute("data-snippet-id");
+    if (!id) throw new Error(`snippet card '${name}' missing data-snippet-id`);
+    return id;
+}
+
+/** Delete a snippet via the store hook (UI uses right-click context menu). */
+export async function deleteSnippet(name: string): Promise<void> {
+    const id = await getSnippetId(name);
+    await browser.execute(async (sid: string) => {
+        const fn = (window as unknown as {
+            __e2eDeleteSnippet?: (id: string) => Promise<void>;
+        }).__e2eDeleteSnippet;
+        if (!fn) throw new Error("__e2eDeleteSnippet not registered");
+        await fn(sid);
+    }, id);
+    await browser.waitUntil(
+        async () => !(await (await $(`[data-snippet-name='${name}']`)).isExisting()),
+        { timeout: 5_000, timeoutMsg: `snippet '${name}' still present` },
+    );
+}
+
+export async function snippetCount(): Promise<number> {
+    const cards = await $$("[data-snippet-id]");
+    return cards.length;
+}
+
+// ─── Snippet palette ──────────────────────────────────────────────────────────
+
+/** Wait for the snippet palette overlay. */
+export async function waitForSnippetPalette(): Promise<void> {
+    await (await $("[data-testid='snippet-palette']")).waitForDisplayed({ timeout: 5_000 });
+}
+
+/** Click a snippet entry in the palette by snippet name. */
+export async function clickPaletteSnippet(name: string): Promise<void> {
+    const item = await $(`[data-snippet-name='${name}']`);
+    await item.waitForClickable({ timeout: 5_000 });
+    await item.click();
+}

--- a/tests/e2e/helpers/tabs.ts
+++ b/tests/e2e/helpers/tabs.ts
@@ -1,0 +1,32 @@
+// Tab-related helpers for the unified tab bar.
+
+/** Count all rendered tabs (any type). */
+export async function tabCount(): Promise<number> {
+    const tabs = await $$("[data-tab-type]");
+    return tabs.length;
+}
+
+/** Count tabs of a specific type. */
+export async function tabCountOfType(
+    type: "terminal" | "sftp" | "s3" | "page",
+): Promise<number> {
+    const tabs = await $$(`[data-tab-type='${type}']`);
+    return tabs.length;
+}
+
+/** Click a tab to activate it. Returns the tab id. */
+export async function clickTabByLabel(label: string): Promise<string> {
+    const tab = await $(`[data-tab-label='${label}']`);
+    await tab.waitForClickable({ timeout: 5_000 });
+    await tab.click();
+    const id = await tab.getAttribute("data-testid");
+    return (id ?? "").replace(/^tab-/, "");
+}
+
+/** Wait until at least `n` tabs are present. */
+export async function waitForTabCount(n: number, timeoutMs = 15_000): Promise<void> {
+    await browser.waitUntil(async () => (await tabCount()) >= n, {
+        timeout: timeoutMs,
+        timeoutMsg: `tab count never reached ${n}`,
+    });
+}

--- a/tests/e2e/helpers/terminal.ts
+++ b/tests/e2e/helpers/terminal.ts
@@ -1,0 +1,83 @@
+// Terminal helpers — drive an active xterm session through the in-app hook.
+//
+// The Terminal component registers each xterm instance in
+// `window.__e2eTerminals` (keyed by sessionId) so tests can read the buffer
+// without touching canvas pixels or DOM rows.
+
+/** Wait until at least one terminal exists in the DOM. Returns its sessionId. */
+export async function waitForAnyTerminal(timeoutMs = 30_000): Promise<string> {
+    const el = await $("[data-testid^='terminal-']");
+    await el.waitForExist({ timeout: timeoutMs });
+    const id = await el.getAttribute("data-session-id");
+    if (!id) throw new Error("terminal element missing data-session-id");
+    return id;
+}
+
+/** Wait for the terminal buffer to contain `needle`. */
+export async function waitForTerminalText(
+    sessionId: string,
+    needle: string,
+    opts: { timeoutMs?: number; ignoreCase?: boolean } = {},
+): Promise<void> {
+    const timeoutMs = opts.timeoutMs ?? 15_000;
+    const ignoreCase = opts.ignoreCase ?? true;
+    await browser.waitUntil(
+        async () => {
+            const text = await readTerminalText(sessionId);
+            return ignoreCase
+                ? text.toLowerCase().includes(needle.toLowerCase())
+                : text.includes(needle);
+        },
+        {
+            timeout: timeoutMs,
+            interval: 250,
+            timeoutMsg: `terminal '${sessionId}' did not show '${needle}' within ${timeoutMs}ms`,
+        },
+    );
+}
+
+/** Read the full terminal buffer as plain text. */
+export async function readTerminalText(sessionId: string): Promise<string> {
+    return await browser.execute((sid: string) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const reg = (window as any).__e2eTerminals as Map<string, any> | undefined;
+        const term = reg?.get(sid);
+        if (!term) return "";
+        const buf = term.buffer.active;
+        const lines: string[] = [];
+        for (let i = 0; i < buf.length; i++) {
+            const line = buf.getLine(i);
+            if (line) lines.push(line.translateToString(true));
+        }
+        return lines.join("\n");
+    }, sessionId);
+}
+
+/** Send keystrokes to a terminal as if the user typed them. */
+export async function typeIntoTerminal(sessionId: string, text: string): Promise<void> {
+    // `term.paste()` is the documented public API for programmatically
+    // injecting input. It goes through the same `onData` path real
+    // keystrokes do, which is what `ssh_send_input` is wired to.
+    await browser.execute(
+        (sid: string, payload: string) => {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const reg = (window as any).__e2eTerminals as Map<string, any> | undefined;
+            const term = reg?.get(sid);
+            if (!term) throw new Error(`no terminal registered for ${sid}`);
+            term.paste(payload);
+        },
+        sessionId,
+        text,
+    );
+}
+
+/** Send a command + newline and wait for the next prompt to appear. */
+export async function runCommand(
+    sessionId: string,
+    cmd: string,
+    expectedOutput: string,
+    timeoutMs = 10_000,
+): Promise<void> {
+    await typeIntoTerminal(sessionId, `${cmd}\n`);
+    await waitForTerminalText(sessionId, expectedOutput, { timeoutMs });
+}

--- a/tests/e2e/helpers/transfers.ts
+++ b/tests/e2e/helpers/transfers.ts
@@ -1,0 +1,176 @@
+// Transfer helpers — drive the SFTP and S3 backend transfer commands via
+// the window hooks registered in sftp-store.ts / s3-store.ts.
+
+/** Get the current active SFTP tab's session id (== sftp_session_id). */
+export async function activeSftpSessionId(): Promise<string> {
+    const tab = await $("[data-tab-type='sftp']");
+    await tab.waitForExist({ timeout: 5_000 });
+    const id = await tab.getAttribute("data-testid");
+    if (!id) throw new Error("active SFTP tab has no data-testid");
+    return id.replace(/^tab-/, "");
+}
+
+/** Get the current active S3 tab's session id. */
+export async function activeS3SessionId(): Promise<string> {
+    const tab = await $("[data-tab-type='s3']");
+    await tab.waitForExist({ timeout: 5_000 });
+    const id = await tab.getAttribute("data-testid");
+    if (!id) throw new Error("active S3 tab has no data-testid");
+    return id.replace(/^tab-/, "");
+}
+
+// ─── SFTP transfer wrappers ──────────────────────────────────────────────────
+
+export async function sftpUpload(
+    sessionId: string,
+    localPath: string,
+    remotePath: string,
+): Promise<string> {
+    return await browser.execute(
+        async (sid: string, lp: string, rp: string) => {
+            const fn = (window as unknown as {
+                __e2eSftpUpload?: (s: string, l: string, r: string) => Promise<string>;
+            }).__e2eSftpUpload;
+            if (!fn) throw new Error("__e2eSftpUpload not registered");
+            return await fn(sid, lp, rp);
+        },
+        sessionId,
+        localPath,
+        remotePath,
+    );
+}
+
+export async function sftpDownload(
+    sessionId: string,
+    remotePath: string,
+    localPath: string,
+): Promise<string> {
+    return await browser.execute(
+        async (sid: string, rp: string, lp: string) => {
+            const fn = (window as unknown as {
+                __e2eSftpDownload?: (s: string, r: string, l: string) => Promise<string>;
+            }).__e2eSftpDownload;
+            if (!fn) throw new Error("__e2eSftpDownload not registered");
+            return await fn(sid, rp, lp);
+        },
+        sessionId,
+        remotePath,
+        localPath,
+    );
+}
+
+export async function sftpEnqueueUpload(
+    sessionId: string,
+    localPaths: string[],
+    remoteDir: string,
+): Promise<string[]> {
+    return await browser.execute(
+        async (sid: string, lps: string[], rd: string) => {
+            const fn = (window as unknown as {
+                __e2eSftpEnqueueUpload?: (s: string, l: string[], r: string) => Promise<string[]>;
+            }).__e2eSftpEnqueueUpload;
+            if (!fn) throw new Error("__e2eSftpEnqueueUpload not registered");
+            return await fn(sid, lps, rd);
+        },
+        sessionId,
+        localPaths,
+        remoteDir,
+    );
+}
+
+export async function sftpCopy(
+    sessionId: string,
+    sourcePaths: string[],
+    targetDir: string,
+): Promise<string[]> {
+    return await browser.execute(
+        async (sid: string, sps: string[], td: string) => {
+            const fn = (window as unknown as {
+                __e2eSftpCopy?: (s: string, sp: string[], t: string) => Promise<string[]>;
+            }).__e2eSftpCopy;
+            if (!fn) throw new Error("__e2eSftpCopy not registered");
+            return await fn(sid, sps, td);
+        },
+        sessionId,
+        sourcePaths,
+        targetDir,
+    );
+}
+
+export async function sftpMove(
+    sessionId: string,
+    sourcePaths: string[],
+    targetDir: string,
+): Promise<string[]> {
+    return await browser.execute(
+        async (sid: string, sps: string[], td: string) => {
+            const fn = (window as unknown as {
+                __e2eSftpMove?: (s: string, sp: string[], t: string) => Promise<string[]>;
+            }).__e2eSftpMove;
+            if (!fn) throw new Error("__e2eSftpMove not registered");
+            return await fn(sid, sps, td);
+        },
+        sessionId,
+        sourcePaths,
+        targetDir,
+    );
+}
+
+// ─── S3 transfer wrappers ────────────────────────────────────────────────────
+
+export async function s3Upload(
+    sessionId: string,
+    localPath: string,
+    key: string,
+): Promise<void> {
+    await browser.execute(
+        async (sid: string, lp: string, k: string) => {
+            const fn = (window as unknown as {
+                __e2eS3Upload?: (s: string, l: string, k: string) => Promise<void>;
+            }).__e2eS3Upload;
+            if (!fn) throw new Error("__e2eS3Upload not registered");
+            await fn(sid, lp, k);
+        },
+        sessionId,
+        localPath,
+        key,
+    );
+}
+
+export async function s3Download(
+    sessionId: string,
+    key: string,
+    localPath: string,
+): Promise<void> {
+    await browser.execute(
+        async (sid: string, k: string, lp: string) => {
+            const fn = (window as unknown as {
+                __e2eS3Download?: (s: string, k: string, l: string) => Promise<void>;
+            }).__e2eS3Download;
+            if (!fn) throw new Error("__e2eS3Download not registered");
+            await fn(sid, k, lp);
+        },
+        sessionId,
+        key,
+        localPath,
+    );
+}
+
+export async function s3UploadFiles(
+    sessionId: string,
+    localPaths: string[],
+    prefix: string,
+): Promise<number> {
+    return await browser.execute(
+        async (sid: string, lps: string[], p: string) => {
+            const fn = (window as unknown as {
+                __e2eS3UploadFiles?: (s: string, l: string[], p: string) => Promise<number>;
+            }).__e2eS3UploadFiles;
+            if (!fn) throw new Error("__e2eS3UploadFiles not registered");
+            return await fn(sid, lps, p);
+        },
+        sessionId,
+        localPaths,
+        prefix,
+    );
+}

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "anyscp-e2e",
+  "private": true,
+  "version": "0.0.0",
+  "description": "End-to-end tests for anySCP (WebdriverIO + tauri-driver)",
+  "type": "module",
+  "scripts": {
+    "test": "wdio run wdio.conf.ts"
+  },
+  "devDependencies": {
+    "@types/chai": "^5.0.1",
+    "@types/mocha": "^10.0.10",
+    "@types/node": "^22.10.2",
+    "@wdio/cli": "^9.4.5",
+    "@wdio/local-runner": "^9.4.5",
+    "@wdio/mocha-framework": "^9.4.5",
+    "@wdio/spec-reporter": "^9.4.5",
+    "chai": "^5.1.2",
+    "ts-node": "^10.9.2",
+    "tsx": "^4.19.2",
+    "typescript": "~5.8.3",
+    "webdriverio": "^9.4.5"
+  }
+}

--- a/tests/e2e/pnpm-workspace.yaml
+++ b/tests/e2e/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+allowBuilds:
+  edgedriver: set this to true or false
+  esbuild: set this to true or false
+  geckodriver: set this to true or false

--- a/tests/e2e/specs/01-smoke.spec.ts
+++ b/tests/e2e/specs/01-smoke.spec.ts
@@ -1,0 +1,14 @@
+import { expect } from "chai";
+import { resetApp } from "../helpers/reset.js";
+import { hostCardCount, waitForDashboard } from "../helpers/dashboard.js";
+
+describe("smoke", () => {
+    beforeEach(async () => {
+        await resetApp();
+    });
+
+    it("app launches with an empty hosts dashboard", async () => {
+        await waitForDashboard();
+        expect(await hostCardCount()).to.equal(0);
+    });
+});

--- a/tests/e2e/specs/02-host-crud.spec.ts
+++ b/tests/e2e/specs/02-host-crud.spec.ts
@@ -1,0 +1,99 @@
+// Add → edit → delete cycle. Covers save_host (create + update),
+// delete_host, list_hosts, and the modal's open/close lifecycle.
+
+import { expect } from "chai";
+import { resetApp } from "../helpers/reset.js";
+import { hostCardCount, waitForDashboard } from "../helpers/dashboard.js";
+import {
+    assertHostAbsent,
+    clickSave,
+    fillPasswordHostForm,
+    findHostCardByLabel,
+    openHostEdit,
+    openNewHostModal,
+    waitForModalClosed,
+} from "../helpers/host.js";
+
+const SSHD_PASS_HOST = process.env.SSHD_PASS_HOST ?? "sshd-pass";
+const SSHD_PASS_PORT = Number(process.env.SSHD_PASS_PORT ?? 2222);
+const SSH_USER = process.env.SSH_USER ?? "testuser";
+const SSH_PASS = process.env.SSH_PASS ?? "testpass";
+
+describe("host CRUD", () => {
+    beforeEach(async () => {
+        await resetApp();
+        await waitForDashboard();
+    });
+
+    it("adds a password host and shows it on the dashboard", async () => {
+        expect(await hostCardCount()).to.equal(0);
+
+        await openNewHostModal();
+        await fillPasswordHostForm({
+            label: "alpha",
+            host: SSHD_PASS_HOST,
+            port: SSHD_PASS_PORT,
+            username: SSH_USER,
+            password: SSH_PASS,
+        });
+        await clickSave();
+        await waitForModalClosed();
+
+        await findHostCardByLabel("alpha");
+        expect(await hostCardCount()).to.equal(1);
+    });
+
+    it("edits a host's label", async () => {
+        // Seed
+        await openNewHostModal();
+        await fillPasswordHostForm({
+            label: "beta",
+            host: SSHD_PASS_HOST,
+            port: SSHD_PASS_PORT,
+            username: SSH_USER,
+            password: SSH_PASS,
+        });
+        await clickSave();
+        await waitForModalClosed();
+        await findHostCardByLabel("beta");
+
+        await openHostEdit("beta");
+
+        const labelInput = await $("[data-testid='host-modal-label']");
+        await labelInput.waitForDisplayed({ timeout: 5_000 });
+        await labelInput.setValue("beta-renamed");
+        await clickSave();
+        await waitForModalClosed();
+
+        await findHostCardByLabel("beta-renamed");
+        await assertHostAbsent("beta");
+    });
+
+    it("deletes a host from the edit modal", async () => {
+        await openNewHostModal();
+        await fillPasswordHostForm({
+            label: "gamma",
+            host: SSHD_PASS_HOST,
+            port: SSHD_PASS_PORT,
+            username: SSH_USER,
+            password: SSH_PASS,
+        });
+        await clickSave();
+        await waitForModalClosed();
+        await findHostCardByLabel("gamma");
+
+        await openHostEdit("gamma");
+
+        // Delete → confirm
+        const del = await $("[data-testid='host-modal-delete']");
+        await del.waitForClickable({ timeout: 5_000 });
+        await del.click();
+        const confirm = await $("[data-testid='host-modal-delete-confirm']");
+        await confirm.waitForClickable({ timeout: 5_000 });
+        await confirm.click();
+
+        await waitForModalClosed();
+        await assertHostAbsent("gamma");
+        expect(await hostCardCount()).to.equal(0);
+    });
+});

--- a/tests/e2e/specs/03-connect-password.spec.ts
+++ b/tests/e2e/specs/03-connect-password.spec.ts
@@ -1,0 +1,85 @@
+// Password-auth connect flow. Verifies the full SSH path:
+// ssh_connect → terminal mounts → ssh_send_input → output renders → disconnect.
+
+import { expect } from "chai";
+import { resetApp } from "../helpers/reset.js";
+import { waitForDashboard } from "../helpers/dashboard.js";
+import {
+    clickConnect,
+    fillPasswordHostForm,
+    openNewHostModal,
+    waitForModalClosed,
+} from "../helpers/host.js";
+import {
+    readTerminalText,
+    runCommand,
+    waitForAnyTerminal,
+    waitForTerminalText,
+} from "../helpers/terminal.js";
+
+const SSHD_PASS_HOST = process.env.SSHD_PASS_HOST ?? "sshd-pass";
+const SSHD_PASS_PORT = Number(process.env.SSHD_PASS_PORT ?? 2222);
+const SSH_USER = process.env.SSH_USER ?? "testuser";
+const SSH_PASS = process.env.SSH_PASS ?? "testpass";
+
+describe("connect (password)", () => {
+    beforeEach(async () => {
+        await resetApp();
+        await waitForDashboard();
+    });
+
+    it("opens a terminal and runs a command", async () => {
+        await openNewHostModal();
+        await fillPasswordHostForm({
+            label: "pwd-target",
+            host: SSHD_PASS_HOST,
+            port: SSHD_PASS_PORT,
+            username: SSH_USER,
+            password: SSH_PASS,
+        });
+        await clickConnect();
+        await waitForModalClosed();
+
+        const sessionId = await waitForAnyTerminal();
+
+        // The linuxserver/openssh-server image renders a `:~$` prompt with the
+        // container hostname, not the username — wait for the prompt symbol.
+        await waitForTerminalText(sessionId, ":~$", { timeoutMs: 20_000 });
+
+        // Run a deterministic command. Use a unique sentinel so the
+        // assertion can't pass on shell banner text.
+        const sentinel = "anyscp_e2e_" + Date.now();
+        await runCommand(sessionId, `echo ${sentinel}`, sentinel, 10_000);
+
+        // Sanity: buffer contains both the command echo and the sentinel result.
+        const buf = await readTerminalText(sessionId);
+        expect(buf).to.include(sentinel);
+    });
+
+    it("disconnect via tab close removes the terminal", async () => {
+        await openNewHostModal();
+        await fillPasswordHostForm({
+            label: "pwd-target",
+            host: SSHD_PASS_HOST,
+            port: SSHD_PASS_PORT,
+            username: SSH_USER,
+            password: SSH_PASS,
+        });
+        await clickConnect();
+        await waitForModalClosed();
+        await waitForAnyTerminal();
+
+        // Hover the active tab to reveal its close button, then click it.
+        const tab = await $("[data-tab-type='terminal']");
+        await tab.moveTo();
+        const close = await $("[data-tab-type='terminal'] [data-testid$='-close']");
+        await close.waitForExist({ timeout: 5_000 });
+        await close.click();
+
+        // Terminal element should disappear.
+        await browser.waitUntil(
+            async () => !(await (await $("[data-testid^='terminal-']")).isExisting()),
+            { timeout: 10_000, timeoutMsg: "terminal still present after tab close" },
+        );
+    });
+});

--- a/tests/e2e/specs/04-connect-key.spec.ts
+++ b/tests/e2e/specs/04-connect-key.spec.ts
@@ -1,0 +1,41 @@
+// SSH key auth flow. Same as 03 but with the privateKey path.
+
+import { resetApp } from "../helpers/reset.js";
+import { waitForDashboard } from "../helpers/dashboard.js";
+import {
+    clickConnect,
+    fillKeyHostForm,
+    openNewHostModal,
+    waitForModalClosed,
+} from "../helpers/host.js";
+import { waitForAnyTerminal, waitForTerminalText } from "../helpers/terminal.js";
+
+const SSHD_KEY_HOST = process.env.SSHD_KEY_HOST ?? "sshd-key";
+const SSHD_KEY_PORT = Number(process.env.SSHD_KEY_PORT ?? 2222);
+const SSH_USER = process.env.SSH_USER ?? "testuser";
+const SSH_KEY_PATH = process.env.SSH_KEY_PATH ?? "/keys/id_ed25519";
+
+describe("connect (key)", () => {
+    beforeEach(async () => {
+        await resetApp();
+        await waitForDashboard();
+    });
+
+    it("authenticates via an SSH key and opens a terminal", async () => {
+        await openNewHostModal();
+        await fillKeyHostForm({
+            label: "key-target",
+            host: SSHD_KEY_HOST,
+            port: SSHD_KEY_PORT,
+            username: SSH_USER,
+            keyPath: SSH_KEY_PATH,
+        });
+        await clickConnect();
+        await waitForModalClosed();
+
+        const sessionId = await waitForAnyTerminal();
+        // The linuxserver/openssh-server image gives a `:~$` prompt with the
+        // container hostname (not the username), so wait for the prompt symbol.
+        await waitForTerminalText(sessionId, ":~$", { timeoutMs: 20_000 });
+    });
+});

--- a/tests/e2e/specs/05-persistence.spec.ts
+++ b/tests/e2e/specs/05-persistence.spec.ts
@@ -1,0 +1,41 @@
+// Verify that saved hosts survive an app restart — exercises the SQLite
+// persistence layer end-to-end.
+
+import { resetApp, relaunchApp } from "../helpers/reset.js";
+import { waitForDashboard } from "../helpers/dashboard.js";
+import {
+    clickSave,
+    fillPasswordHostForm,
+    findHostCardByLabel,
+    openNewHostModal,
+    waitForModalClosed,
+} from "../helpers/host.js";
+
+const SSHD_PASS_HOST = process.env.SSHD_PASS_HOST ?? "sshd-pass";
+const SSHD_PASS_PORT = Number(process.env.SSHD_PASS_PORT ?? 2222);
+const SSH_USER = process.env.SSH_USER ?? "testuser";
+const SSH_PASS = process.env.SSH_PASS ?? "testpass";
+
+describe("persistence", () => {
+    it("saved hosts survive a restart", async () => {
+        await resetApp();
+        await waitForDashboard();
+
+        await openNewHostModal();
+        await fillPasswordHostForm({
+            label: "persisted",
+            host: SSHD_PASS_HOST,
+            port: SSHD_PASS_PORT,
+            username: SSH_USER,
+            password: SSH_PASS,
+        });
+        await clickSave();
+        await waitForModalClosed();
+        await findHostCardByLabel("persisted");
+
+        // Relaunch the app without wiping XDG_DATA_HOME.
+        await relaunchApp();
+        await waitForDashboard();
+        await findHostCardByLabel("persisted");
+    });
+});

--- a/tests/e2e/specs/06-error-bad-creds.spec.ts
+++ b/tests/e2e/specs/06-error-bad-creds.spec.ts
@@ -1,0 +1,44 @@
+// Wrong password should surface as an error in the modal — verifies the
+// error banner path through ssh_connect → russh → frontend.
+
+import { expect } from "chai";
+import { resetApp } from "../helpers/reset.js";
+import { waitForDashboard } from "../helpers/dashboard.js";
+import {
+    clickConnect,
+    fillPasswordHostForm,
+    openNewHostModal,
+} from "../helpers/host.js";
+
+const SSHD_PASS_HOST = process.env.SSHD_PASS_HOST ?? "sshd-pass";
+const SSHD_PASS_PORT = Number(process.env.SSHD_PASS_PORT ?? 2222);
+const SSH_USER = process.env.SSH_USER ?? "testuser";
+
+describe("auth failure", () => {
+    beforeEach(async () => {
+        await resetApp();
+        await waitForDashboard();
+    });
+
+    it("shows an error banner when the password is wrong", async () => {
+        await openNewHostModal();
+        await fillPasswordHostForm({
+            label: "bad-creds",
+            host: SSHD_PASS_HOST,
+            port: SSHD_PASS_PORT,
+            username: SSH_USER,
+            password: "definitely-not-the-password",
+        });
+        await clickConnect();
+
+        // Modal stays open with the error banner.
+        const err = await $("[data-testid='host-modal-error']");
+        await err.waitForDisplayed({ timeout: 20_000 });
+        const text = await err.getText();
+        expect(text.length).to.be.greaterThan(0);
+
+        // Modal should still be visible (i.e. didn't accidentally close).
+        const modal = await $("[data-testid='host-modal']");
+        expect(await modal.isDisplayed()).to.equal(true);
+    });
+});

--- a/tests/e2e/specs/07-sftp-flow.spec.ts
+++ b/tests/e2e/specs/07-sftp-flow.spec.ts
@@ -1,0 +1,70 @@
+// SFTP flow: save host (which persists credentials to the keychain),
+// open Explorer from the host card, verify the file listing renders.
+
+import { expect } from "chai";
+import { resetApp } from "../helpers/reset.js";
+import { waitForDashboard } from "../helpers/dashboard.js";
+import {
+    clickSave,
+    fillPasswordHostForm,
+    findHostCardByLabel,
+    getHostId,
+    openNewHostModal,
+    waitForModalClosed,
+} from "../helpers/host.js";
+
+const SSHD_PASS_HOST = process.env.SSHD_PASS_HOST ?? "sshd-pass";
+const SSHD_PASS_PORT = Number(process.env.SSHD_PASS_PORT ?? 2222);
+const SSH_USER = process.env.SSH_USER ?? "testuser";
+const SSH_PASS = process.env.SSH_PASS ?? "testpass";
+
+describe("SFTP", () => {
+    beforeEach(async () => {
+        await resetApp();
+        await waitForDashboard();
+    });
+
+    it("opens an explorer session from the host card", async () => {
+        // Add a host. handleSave persists the password to the keychain so
+        // the Explorer button can connect non-interactively.
+        await openNewHostModal();
+        await fillPasswordHostForm({
+            label: "sftp-target",
+            host: SSHD_PASS_HOST,
+            port: SSHD_PASS_PORT,
+            username: SSH_USER,
+            password: SSH_PASS,
+        });
+        await clickSave();
+        await waitForModalClosed();
+        await findHostCardByLabel("sftp-target");
+
+        const hostId = await getHostId("sftp-target");
+
+        // Click the explorer button on the card.
+        const explorerBtn = await $(`[data-testid='host-card-${hostId}-explorer']`);
+        await explorerBtn.waitForClickable({ timeout: 10_000 });
+        await explorerBtn.click();
+
+        // An SFTP tab should appear and the file listing should render.
+        await browser.waitUntil(
+            async () =>
+                (await $("[data-tab-type='sftp']").then((el) => el.isExisting())) === true,
+            { timeout: 30_000, timeoutMsg: "SFTP tab never opened" },
+        );
+
+        // The Refresh button in the explorer toolbar should be present.
+        const refresh = await $("[aria-label='Refresh']");
+        await refresh.waitForDisplayed({ timeout: 15_000 });
+
+        // At least one directory entry should render (the linuxserver
+        // openssh-server image gives /config as home with a config/ dir).
+        await browser.waitUntil(
+            async () => (await $$("[data-entry-row='true']")).length > 0,
+            { timeout: 15_000, timeoutMsg: "no entries rendered in explorer" },
+        );
+
+        const entries = await $$("[data-entry-row='true']");
+        expect(entries.length).to.be.greaterThan(0);
+    });
+});

--- a/tests/e2e/specs/08-host-search.spec.ts
+++ b/tests/e2e/specs/08-host-search.spec.ts
@@ -1,0 +1,74 @@
+// Host search/filter — the dashboard's search box filters the host grid
+// case-insensitively across label, host, and username.
+
+import { expect } from "chai";
+import { resetApp } from "../helpers/reset.js";
+import { hostCardCount, waitForDashboard } from "../helpers/dashboard.js";
+import {
+    clickSave,
+    fillPasswordHostForm,
+    openNewHostModal,
+    waitForModalClosed,
+} from "../helpers/host.js";
+
+const SSHD_PASS_HOST = process.env.SSHD_PASS_HOST ?? "sshd-pass";
+const SSHD_PASS_PORT = Number(process.env.SSHD_PASS_PORT ?? 2222);
+const SSH_USER = process.env.SSH_USER ?? "testuser";
+const SSH_PASS = process.env.SSH_PASS ?? "testpass";
+
+async function addHost(label: string): Promise<void> {
+    await openNewHostModal();
+    await fillPasswordHostForm({
+        label,
+        host: SSHD_PASS_HOST,
+        port: SSHD_PASS_PORT,
+        username: SSH_USER,
+        password: SSH_PASS,
+    });
+    await clickSave();
+    await waitForModalClosed();
+}
+
+describe("host search", () => {
+    beforeEach(async () => {
+        await resetApp();
+        await waitForDashboard();
+    });
+
+    it("filters the host grid by label", async () => {
+        await addHost("production-db");
+        await addHost("staging-web");
+        await addHost("local-dev");
+        expect(await hostCardCount()).to.equal(3);
+
+        const search = await $("[data-testid='host-search']");
+        await search.click();
+        await search.setValue("staging");
+
+        await browser.waitUntil(async () => (await hostCardCount()) === 1, {
+            timeout: 5_000,
+            timeoutMsg: "filter never narrowed to 1 card",
+        });
+    });
+
+    it("clears the filter when search is emptied", async () => {
+        await addHost("alpha");
+        await addHost("beta");
+
+        const search = await $("[data-testid='host-search']");
+        await search.click();
+        await search.setValue("alpha");
+        await browser.waitUntil(async () => (await hostCardCount()) === 1);
+
+        // `clearValue()` sets `.value = ''` directly, which doesn't fire the
+        // `input` event React's controlled <input> needs. Clear via keystrokes
+        // so React's onChange runs and the filter state resets.
+        await search.click();
+        await browser.keys(["Control", "a"]);
+        await browser.keys(["Backspace"]);
+
+        await browser.waitUntil(async () => (await hostCardCount()) === 2, {
+            timeout: 5_000,
+        });
+    });
+});

--- a/tests/e2e/specs/09-host-duplicate.spec.ts
+++ b/tests/e2e/specs/09-host-duplicate.spec.ts
@@ -1,0 +1,46 @@
+// Host duplicate — clones an existing host with " (copy)" suffix on the
+// label. Triggered via the duplicate hook (UI version lives in the
+// right-click context menu, which is flaky in WebKitWebDriver).
+
+import { expect } from "chai";
+import { resetApp } from "../helpers/reset.js";
+import { hostCardCount, waitForDashboard } from "../helpers/dashboard.js";
+import {
+    clickSave,
+    duplicateHost,
+    fillPasswordHostForm,
+    findHostCardByLabel,
+    openNewHostModal,
+    waitForModalClosed,
+} from "../helpers/host.js";
+
+const SSHD_PASS_HOST = process.env.SSHD_PASS_HOST ?? "sshd-pass";
+const SSHD_PASS_PORT = Number(process.env.SSHD_PASS_PORT ?? 2222);
+const SSH_USER = process.env.SSH_USER ?? "testuser";
+const SSH_PASS = process.env.SSH_PASS ?? "testpass";
+
+describe("host duplicate", () => {
+    beforeEach(async () => {
+        await resetApp();
+        await waitForDashboard();
+    });
+
+    it("creates a copy with '(copy)' suffix and a new id", async () => {
+        await openNewHostModal();
+        await fillPasswordHostForm({
+            label: "original",
+            host: SSHD_PASS_HOST,
+            port: SSHD_PASS_PORT,
+            username: SSH_USER,
+            password: SSH_PASS,
+        });
+        await clickSave();
+        await waitForModalClosed();
+        await findHostCardByLabel("original");
+
+        await duplicateHost("original");
+
+        await findHostCardByLabel("original (copy)");
+        expect(await hostCardCount()).to.equal(2);
+    });
+});

--- a/tests/e2e/specs/10-host-connect-error.spec.ts
+++ b/tests/e2e/specs/10-host-connect-error.spec.ts
@@ -1,0 +1,44 @@
+// Unreachable host — Connect should produce an error banner in the modal
+// (mirrors the wrong-password flow but for a transport failure).
+
+import { expect } from "chai";
+import { resetApp } from "../helpers/reset.js";
+import { waitForDashboard } from "../helpers/dashboard.js";
+import {
+    clickConnect,
+    fillPasswordHostForm,
+    openNewHostModal,
+} from "../helpers/host.js";
+
+const SSH_USER = process.env.SSH_USER ?? "testuser";
+
+describe("connect error", () => {
+    beforeEach(async () => {
+        await resetApp();
+        await waitForDashboard();
+    });
+
+    it("shows an error banner when the host is unreachable", async () => {
+        await openNewHostModal();
+        // Port 1 on the runner — guaranteed to be closed; russh should return
+        // a connection-refused error within a couple of seconds.
+        await fillPasswordHostForm({
+            label: "unreachable",
+            host: "127.0.0.1",
+            port: 1,
+            username: SSH_USER,
+            password: "anything",
+        });
+        await clickConnect();
+
+        const err = await $("[data-testid='host-modal-error']");
+        await err.waitForDisplayed({ timeout: 30_000 });
+        const text = await err.getText();
+        expect(text.length).to.be.greaterThan(0);
+
+        // Modal should still be visible — error path leaves the user where they
+        // can fix the form and retry.
+        const modal = await $("[data-testid='host-modal']");
+        expect(await modal.isDisplayed()).to.equal(true);
+    });
+});

--- a/tests/e2e/specs/11-cmd-t-shortcut.spec.ts
+++ b/tests/e2e/specs/11-cmd-t-shortcut.spec.ts
@@ -1,0 +1,26 @@
+// Cmd+T (Ctrl+T on Linux) opens the new-host modal — wired in AppShell's
+// useKeyboardShortcuts. Smoke-tests the keyboard plumbing.
+
+import { expect } from "chai";
+import { resetApp } from "../helpers/reset.js";
+import { waitForDashboard } from "../helpers/dashboard.js";
+import { cmd } from "../helpers/keyboard.js";
+
+describe("keyboard: Cmd+T", () => {
+    beforeEach(async () => {
+        await resetApp();
+        await waitForDashboard();
+    });
+
+    it("opens the new-host modal", async () => {
+        const modalSel = "[data-testid='host-modal']";
+        expect(await (await $(modalSel)).isExisting()).to.equal(false);
+
+        await cmd("t");
+
+        const modal = await $(modalSel);
+        await modal.waitForDisplayed({ timeout: 5_000 });
+        const mode = await modal.getAttribute("data-host-modal-mode");
+        expect(mode).to.equal("new");
+    });
+});

--- a/tests/e2e/specs/12-recent-connections.spec.ts
+++ b/tests/e2e/specs/12-recent-connections.spec.ts
@@ -1,0 +1,48 @@
+// Recent connections — after Connect → disconnect, the host appears in the
+// "Recent" list at the top of the dashboard.
+
+import { resetApp } from "../helpers/reset.js";
+import { waitForDashboard } from "../helpers/dashboard.js";
+import {
+    clickConnect,
+    fillPasswordHostForm,
+    openNewHostModal,
+    waitForModalClosed,
+} from "../helpers/host.js";
+import { waitForAnyTerminal, waitForTerminalText } from "../helpers/terminal.js";
+import { waitForRecent } from "../helpers/recent.js";
+
+const SSHD_PASS_HOST = process.env.SSHD_PASS_HOST ?? "sshd-pass";
+const SSHD_PASS_PORT = Number(process.env.SSHD_PASS_PORT ?? 2222);
+const SSH_USER = process.env.SSH_USER ?? "testuser";
+const SSH_PASS = process.env.SSH_PASS ?? "testpass";
+
+describe("recent connections", () => {
+    beforeEach(async () => {
+        await resetApp();
+        await waitForDashboard();
+    });
+
+    it("records a successful connection in the recent list", async () => {
+        await openNewHostModal();
+        await fillPasswordHostForm({
+            label: "recent-target",
+            host: SSHD_PASS_HOST,
+            port: SSHD_PASS_PORT,
+            username: SSH_USER,
+            password: SSH_PASS,
+        });
+        await clickConnect();
+        await waitForModalClosed();
+
+        const sessionId = await waitForAnyTerminal();
+        await waitForTerminalText(sessionId, ":~$");
+
+        // Switch back to the hosts page (Cmd+1 → first tab is the permanent
+        // Hosts tab). The recent-connections list lives on the dashboard.
+        const hostsTab = await $("[data-tab-label='Hosts']");
+        await hostsTab.click();
+
+        await waitForRecent("recent-target", 10_000);
+    });
+});

--- a/tests/e2e/specs/13-multiple-tabs.spec.ts
+++ b/tests/e2e/specs/13-multiple-tabs.spec.ts
@@ -1,0 +1,54 @@
+// Connecting to two hosts produces two terminal tabs alongside the
+// permanent Hosts tab.
+
+import { expect } from "chai";
+import { resetApp } from "../helpers/reset.js";
+import { waitForDashboard } from "../helpers/dashboard.js";
+import {
+    clickConnect,
+    fillPasswordHostForm,
+    openNewHostModal,
+    waitForModalClosed,
+} from "../helpers/host.js";
+import { waitForAnyTerminal, waitForTerminalText } from "../helpers/terminal.js";
+import { tabCountOfType, waitForTabCount } from "../helpers/tabs.js";
+
+const SSHD_PASS_HOST = process.env.SSHD_PASS_HOST ?? "sshd-pass";
+const SSHD_PASS_PORT = Number(process.env.SSHD_PASS_PORT ?? 2222);
+const SSH_USER = process.env.SSH_USER ?? "testuser";
+const SSH_PASS = process.env.SSH_PASS ?? "testpass";
+
+async function connectFresh(label: string): Promise<void> {
+    await openNewHostModal();
+    await fillPasswordHostForm({
+        label,
+        host: SSHD_PASS_HOST,
+        port: SSHD_PASS_PORT,
+        username: SSH_USER,
+        password: SSH_PASS,
+    });
+    await clickConnect();
+    await waitForModalClosed();
+}
+
+describe("multiple tabs", () => {
+    beforeEach(async () => {
+        await resetApp();
+        await waitForDashboard();
+    });
+
+    it("opens two terminal tabs for two hosts", async () => {
+        await connectFresh("first");
+        const firstSession = await waitForAnyTerminal();
+        await waitForTerminalText(firstSession, ":~$");
+
+        // Switch back to dashboard so the second connect doesn't replace.
+        const hostsTab = await $("[data-tab-label='Hosts']");
+        await hostsTab.click();
+
+        await connectFresh("second");
+        await waitForTabCount(3); // Hosts + 2 terminals
+
+        expect(await tabCountOfType("terminal")).to.equal(2);
+    });
+});

--- a/tests/e2e/specs/14-tab-switching-keys.spec.ts
+++ b/tests/e2e/specs/14-tab-switching-keys.spec.ts
@@ -1,0 +1,71 @@
+// Cmd+1 / Cmd+2 switches active tab — wired in AppShell's shortcuts.
+
+import { expect } from "chai";
+import { resetApp } from "../helpers/reset.js";
+import { waitForDashboard } from "../helpers/dashboard.js";
+import {
+    clickConnect,
+    fillPasswordHostForm,
+    openNewHostModal,
+    waitForModalClosed,
+} from "../helpers/host.js";
+import { waitForAnyTerminal, waitForTerminalText } from "../helpers/terminal.js";
+import { waitForTabCount } from "../helpers/tabs.js";
+import { cmd } from "../helpers/keyboard.js";
+
+const SSHD_PASS_HOST = process.env.SSHD_PASS_HOST ?? "sshd-pass";
+const SSHD_PASS_PORT = Number(process.env.SSHD_PASS_PORT ?? 2222);
+const SSH_USER = process.env.SSH_USER ?? "testuser";
+const SSH_PASS = process.env.SSH_PASS ?? "testpass";
+
+async function connectFresh(label: string): Promise<void> {
+    await openNewHostModal();
+    await fillPasswordHostForm({
+        label,
+        host: SSHD_PASS_HOST,
+        port: SSHD_PASS_PORT,
+        username: SSH_USER,
+        password: SSH_PASS,
+    });
+    await clickConnect();
+    await waitForModalClosed();
+}
+
+describe("keyboard: Cmd+1 / Cmd+2", () => {
+    beforeEach(async () => {
+        await resetApp();
+        await waitForDashboard();
+    });
+
+    it("switches between tabs by index", async () => {
+        await connectFresh("tab-one");
+        await waitForTerminalText(await waitForAnyTerminal(), ":~$");
+
+        const hostsTab = await $("[data-tab-label='Hosts']");
+        await hostsTab.click();
+
+        await connectFresh("tab-two");
+        await waitForTabCount(3);
+
+        // Cmd+1 → Hosts (first tab in tabOrder)
+        await cmd("1");
+        const tabOne = await $("[data-tab-label='Hosts']");
+        await browser.waitUntil(
+            async () => {
+                const cls = (await tabOne.getAttribute("class")) ?? "";
+                return cls.includes("text-accent") || cls.includes("bg-accent");
+            },
+            { timeout: 5_000, timeoutMsg: "Hosts tab did not activate via Cmd+1" },
+        );
+
+        // Cmd+2 → tab-one (or whichever is index 1 — both terminals are valid)
+        await cmd("2");
+        const activeLabel = await browser.execute(() => {
+            const el = document.querySelector(
+                "[data-tab-type][class*='text-accent'], [data-tab-type][class*='bg-accent']",
+            );
+            return el?.getAttribute("data-tab-label") ?? null;
+        });
+        expect(activeLabel).to.not.equal("Hosts");
+    });
+});

--- a/tests/e2e/specs/15-cmd-w-close.spec.ts
+++ b/tests/e2e/specs/15-cmd-w-close.spec.ts
@@ -1,0 +1,52 @@
+// Cmd+W closes the active tab (and disconnects the SSH session if it's a
+// terminal). The permanent Hosts tab is uncloseable so Cmd+W on it is a
+// no-op.
+
+import { expect } from "chai";
+import { resetApp } from "../helpers/reset.js";
+import { waitForDashboard } from "../helpers/dashboard.js";
+import {
+    clickConnect,
+    fillPasswordHostForm,
+    openNewHostModal,
+    waitForModalClosed,
+} from "../helpers/host.js";
+import { waitForAnyTerminal, waitForTerminalText } from "../helpers/terminal.js";
+import { tabCountOfType } from "../helpers/tabs.js";
+import { cmd } from "../helpers/keyboard.js";
+
+const SSHD_PASS_HOST = process.env.SSHD_PASS_HOST ?? "sshd-pass";
+const SSHD_PASS_PORT = Number(process.env.SSHD_PASS_PORT ?? 2222);
+const SSH_USER = process.env.SSH_USER ?? "testuser";
+const SSH_PASS = process.env.SSH_PASS ?? "testpass";
+
+describe("keyboard: Cmd+W", () => {
+    beforeEach(async () => {
+        await resetApp();
+        await waitForDashboard();
+    });
+
+    it("closes the active terminal tab", async () => {
+        await openNewHostModal();
+        await fillPasswordHostForm({
+            label: "close-target",
+            host: SSHD_PASS_HOST,
+            port: SSHD_PASS_PORT,
+            username: SSH_USER,
+            password: SSH_PASS,
+        });
+        await clickConnect();
+        await waitForModalClosed();
+
+        const sessionId = await waitForAnyTerminal();
+        await waitForTerminalText(sessionId, ":~$");
+        expect(await tabCountOfType("terminal")).to.equal(1);
+
+        await cmd("w");
+
+        await browser.waitUntil(
+            async () => (await tabCountOfType("terminal")) === 0,
+            { timeout: 10_000, timeoutMsg: "terminal tab did not close on Cmd+W" },
+        );
+    });
+});

--- a/tests/e2e/specs/16-sftp-navigate.spec.ts
+++ b/tests/e2e/specs/16-sftp-navigate.spec.ts
@@ -1,0 +1,93 @@
+// Open SFTP, navigate into a subdirectory, then back via the home button.
+
+import { expect } from "chai";
+import { resetApp } from "../helpers/reset.js";
+import { waitForDashboard } from "../helpers/dashboard.js";
+import {
+    clickSave,
+    fillPasswordHostForm,
+    findHostCardByLabel,
+    getHostId,
+    openNewHostModal,
+    waitForModalClosed,
+} from "../helpers/host.js";
+import {
+    createFolder,
+    deleteEntry,
+    openEntry,
+    waitForExplorer,
+} from "../helpers/sftp-ops.js";
+
+const SSHD_PASS_HOST = process.env.SSHD_PASS_HOST ?? "sshd-pass";
+const SSHD_PASS_PORT = Number(process.env.SSHD_PASS_PORT ?? 2222);
+const SSH_USER = process.env.SSH_USER ?? "testuser";
+const SSH_PASS = process.env.SSH_PASS ?? "testpass";
+
+async function openSftp(): Promise<void> {
+    await openNewHostModal();
+    await fillPasswordHostForm({
+        label: "nav-target",
+        host: SSHD_PASS_HOST,
+        port: SSHD_PASS_PORT,
+        username: SSH_USER,
+        password: SSH_PASS,
+    });
+    await clickSave();
+    await waitForModalClosed();
+    await findHostCardByLabel("nav-target");
+
+    const hostId = await getHostId("nav-target");
+    await (await $(`[data-testid='host-card-${hostId}-explorer']`)).click();
+    await waitForExplorer();
+}
+
+describe("SFTP navigate", () => {
+    beforeEach(async () => {
+        await resetApp();
+        await waitForDashboard();
+    });
+
+    it("navigates into a subdirectory and back via breadcrumb", async () => {
+        await openSftp();
+
+        // We start in the user's home dir (linuxserver/openssh-server uses
+        // /config for testuser). Remember the current breadcrumb's last
+        // segment so we can navigate back to it.
+        const dirName = "e2e-nav-" + Date.now();
+        await createFolder(dirName);
+
+        // Navigate into the new subdir.
+        await openEntry(dirName);
+        await browser.waitUntil(
+            async () => {
+                const last = await $(`button*=${dirName}`);
+                return await last.isExisting();
+            },
+            { timeout: 5_000, timeoutMsg: "breadcrumb never updated to subdir" },
+        );
+
+        // Click the parent segment (second-to-last) to navigate back. The
+        // parent's label is the home-dir basename, typically "config".
+        await browser.execute((target: string) => {
+            const buttons = Array.from(
+                document.querySelectorAll<HTMLButtonElement>(
+                    "[aria-label='Current path'] button",
+                ),
+            );
+            // The last button is the disabled current dir, the previous one
+            // is the parent — click that.
+            const parent = buttons.at(-2);
+            if (!parent) throw new Error("no parent breadcrumb segment");
+            parent.click();
+            return target; // unused — just satisfying the API
+        }, dirName);
+
+        // The folder we created should be back in the listing.
+        const entry = await $(`[data-entry-name='${dirName}']`);
+        await entry.waitForExist({ timeout: 5_000 });
+        expect(await entry.isExisting()).to.equal(true);
+
+        // Cleanup so a stale folder doesn't accumulate on the test server.
+        await deleteEntry(dirName);
+    });
+});

--- a/tests/e2e/specs/17-sftp-mkdir-rmdir.spec.ts
+++ b/tests/e2e/specs/17-sftp-mkdir-rmdir.spec.ts
@@ -1,0 +1,52 @@
+// SFTP: create a directory via the toolbar, verify it appears, then delete
+// it (Delete key + confirm) and verify it's gone.
+
+import { resetApp } from "../helpers/reset.js";
+import { waitForDashboard } from "../helpers/dashboard.js";
+import {
+    clickSave,
+    fillPasswordHostForm,
+    findHostCardByLabel,
+    getHostId,
+    openNewHostModal,
+    waitForModalClosed,
+} from "../helpers/host.js";
+import {
+    createFolder,
+    deleteEntry,
+    waitForExplorer,
+} from "../helpers/sftp-ops.js";
+
+const SSHD_PASS_HOST = process.env.SSHD_PASS_HOST ?? "sshd-pass";
+const SSHD_PASS_PORT = Number(process.env.SSHD_PASS_PORT ?? 2222);
+const SSH_USER = process.env.SSH_USER ?? "testuser";
+const SSH_PASS = process.env.SSH_PASS ?? "testpass";
+
+describe("SFTP mkdir/rmdir", () => {
+    beforeEach(async () => {
+        await resetApp();
+        await waitForDashboard();
+    });
+
+    it("creates a folder via toolbar, then deletes it", async () => {
+        await openNewHostModal();
+        await fillPasswordHostForm({
+            label: "mkdir-target",
+            host: SSHD_PASS_HOST,
+            port: SSHD_PASS_PORT,
+            username: SSH_USER,
+            password: SSH_PASS,
+        });
+        await clickSave();
+        await waitForModalClosed();
+        await findHostCardByLabel("mkdir-target");
+
+        const hostId = await getHostId("mkdir-target");
+        await (await $(`[data-testid='host-card-${hostId}-explorer']`)).click();
+        await waitForExplorer();
+
+        const folder = "e2e-folder-" + Date.now();
+        await createFolder(folder);
+        await deleteEntry(folder);
+    });
+});

--- a/tests/e2e/specs/18-sftp-rename.spec.ts
+++ b/tests/e2e/specs/18-sftp-rename.spec.ts
@@ -1,0 +1,57 @@
+// SFTP: rename a folder via F2 key, verify the new name appears and the
+// old one is gone.
+
+import { resetApp } from "../helpers/reset.js";
+import { waitForDashboard } from "../helpers/dashboard.js";
+import {
+    clickSave,
+    fillPasswordHostForm,
+    findHostCardByLabel,
+    getHostId,
+    openNewHostModal,
+    waitForModalClosed,
+} from "../helpers/host.js";
+import {
+    createFolder,
+    deleteEntry,
+    renameEntry,
+    waitForExplorer,
+} from "../helpers/sftp-ops.js";
+
+const SSHD_PASS_HOST = process.env.SSHD_PASS_HOST ?? "sshd-pass";
+const SSHD_PASS_PORT = Number(process.env.SSHD_PASS_PORT ?? 2222);
+const SSH_USER = process.env.SSH_USER ?? "testuser";
+const SSH_PASS = process.env.SSH_PASS ?? "testpass";
+
+describe("SFTP rename", () => {
+    beforeEach(async () => {
+        await resetApp();
+        await waitForDashboard();
+    });
+
+    it("renames a folder via F2", async () => {
+        await openNewHostModal();
+        await fillPasswordHostForm({
+            label: "rename-target",
+            host: SSHD_PASS_HOST,
+            port: SSHD_PASS_PORT,
+            username: SSH_USER,
+            password: SSH_PASS,
+        });
+        await clickSave();
+        await waitForModalClosed();
+        await findHostCardByLabel("rename-target");
+
+        const hostId = await getHostId("rename-target");
+        await (await $(`[data-testid='host-card-${hostId}-explorer']`)).click();
+        await waitForExplorer();
+
+        const oldName = "before-" + Date.now();
+        const newName = "after-" + Date.now();
+        await createFolder(oldName);
+        await renameEntry(oldName, newName);
+
+        // Cleanup so subsequent runs don't pile up.
+        await deleteEntry(newName);
+    });
+});

--- a/tests/e2e/specs/19-sftp-refresh.spec.ts
+++ b/tests/e2e/specs/19-sftp-refresh.spec.ts
@@ -1,0 +1,65 @@
+// SFTP refresh — picks up server-side changes made outside the UI.
+//
+// We can't easily mutate the server filesystem from inside the test, so this
+// spec verifies the more tractable behaviour: clicking refresh briefly
+// disables the button while it re-fetches.
+
+import { expect } from "chai";
+import { resetApp } from "../helpers/reset.js";
+import { waitForDashboard } from "../helpers/dashboard.js";
+import {
+    clickSave,
+    fillPasswordHostForm,
+    findHostCardByLabel,
+    getHostId,
+    openNewHostModal,
+    waitForModalClosed,
+} from "../helpers/host.js";
+import {
+    refreshExplorer,
+    waitForExplorer,
+    waitForEntry,
+    createFolder,
+    deleteEntry,
+} from "../helpers/sftp-ops.js";
+
+const SSHD_PASS_HOST = process.env.SSHD_PASS_HOST ?? "sshd-pass";
+const SSHD_PASS_PORT = Number(process.env.SSHD_PASS_PORT ?? 2222);
+const SSH_USER = process.env.SSH_USER ?? "testuser";
+const SSH_PASS = process.env.SSH_PASS ?? "testpass";
+
+describe("SFTP refresh", () => {
+    beforeEach(async () => {
+        await resetApp();
+        await waitForDashboard();
+    });
+
+    it("refreshes the listing without errors and entries persist", async () => {
+        await openNewHostModal();
+        await fillPasswordHostForm({
+            label: "refresh-target",
+            host: SSHD_PASS_HOST,
+            port: SSHD_PASS_PORT,
+            username: SSH_USER,
+            password: SSH_PASS,
+        });
+        await clickSave();
+        await waitForModalClosed();
+        await findHostCardByLabel("refresh-target");
+
+        const hostId = await getHostId("refresh-target");
+        await (await $(`[data-testid='host-card-${hostId}-explorer']`)).click();
+        await waitForExplorer();
+
+        const marker = "refresh-marker-" + Date.now();
+        await createFolder(marker);
+
+        await refreshExplorer();
+
+        // After refresh, the entry should still be there.
+        await waitForEntry(marker, 10_000);
+        expect(await (await $(`[data-entry-name='${marker}']`)).isExisting()).to.equal(true);
+
+        await deleteEntry(marker);
+    });
+});

--- a/tests/e2e/specs/20-groups-crud.spec.ts
+++ b/tests/e2e/specs/20-groups-crud.spec.ts
@@ -1,0 +1,35 @@
+// Groups CRUD: create a group, verify it renders, delete it, verify it's gone.
+
+import { expect } from "chai";
+import { resetApp } from "../helpers/reset.js";
+import { waitForDashboard } from "../helpers/dashboard.js";
+import {
+    deleteGroup,
+    fillGroupAndSave,
+    findGroupCard,
+    groupCount,
+    openNewGroupModal,
+} from "../helpers/groups.js";
+
+describe("groups CRUD", () => {
+    beforeEach(async () => {
+        await resetApp();
+        await waitForDashboard();
+    });
+
+    it("creates a group and shows it on the dashboard", async () => {
+        expect(await groupCount()).to.equal(0);
+        await openNewGroupModal();
+        await fillGroupAndSave("production");
+        await findGroupCard("production");
+        expect(await groupCount()).to.equal(1);
+    });
+
+    it("deletes a group", async () => {
+        await openNewGroupModal();
+        await fillGroupAndSave("to-delete");
+        await findGroupCard("to-delete");
+        await deleteGroup("to-delete");
+        expect(await groupCount()).to.equal(0);
+    });
+});

--- a/tests/e2e/specs/21-snippets-crud.spec.ts
+++ b/tests/e2e/specs/21-snippets-crud.spec.ts
@@ -1,0 +1,34 @@
+// Snippets CRUD: create, find, delete a snippet.
+
+import { expect } from "chai";
+import { resetApp } from "../helpers/reset.js";
+import {
+    deleteSnippet,
+    fillSnippetAndSave,
+    findSnippetCard,
+    gotoSnippetsPage,
+    openNewSnippetModal,
+    snippetCount,
+} from "../helpers/snippets.js";
+
+describe("snippets CRUD", () => {
+    beforeEach(async () => {
+        await resetApp();
+        await gotoSnippetsPage();
+    });
+
+    it("creates, finds, and deletes a snippet", async () => {
+        expect(await snippetCount()).to.equal(0);
+
+        await openNewSnippetModal();
+        await fillSnippetAndSave({
+            name: "Echo Hello",
+            command: "echo hello",
+        });
+        await findSnippetCard("Echo Hello");
+        expect(await snippetCount()).to.equal(1);
+
+        await deleteSnippet("Echo Hello");
+        expect(await snippetCount()).to.equal(0);
+    });
+});

--- a/tests/e2e/specs/22-snippet-palette-run.spec.ts
+++ b/tests/e2e/specs/22-snippet-palette-run.spec.ts
@@ -1,0 +1,70 @@
+// Snippet palette: Cmd+K opens it, selecting a snippet sends its command to
+// the active terminal.
+
+import { resetApp } from "../helpers/reset.js";
+import { waitForDashboard } from "../helpers/dashboard.js";
+import {
+    clickConnect,
+    fillPasswordHostForm,
+    openNewHostModal,
+    waitForModalClosed,
+} from "../helpers/host.js";
+import {
+    clickPaletteSnippet,
+    fillSnippetAndSave,
+    gotoSnippetsPage,
+    openNewSnippetModal,
+    waitForSnippetPalette,
+} from "../helpers/snippets.js";
+import {
+    waitForAnyTerminal,
+    waitForTerminalText,
+} from "../helpers/terminal.js";
+import { cmd } from "../helpers/keyboard.js";
+
+const SSHD_PASS_HOST = process.env.SSHD_PASS_HOST ?? "sshd-pass";
+const SSHD_PASS_PORT = Number(process.env.SSHD_PASS_PORT ?? 2222);
+const SSH_USER = process.env.SSH_USER ?? "testuser";
+const SSH_PASS = process.env.SSH_PASS ?? "testpass";
+
+describe("snippet palette", () => {
+    beforeEach(async () => {
+        await resetApp();
+    });
+
+    it("Cmd+K opens the palette and selecting a snippet sends its command", async () => {
+        // Create a snippet first.
+        await gotoSnippetsPage();
+        await openNewSnippetModal();
+        const sentinel = "palette_marker_" + Date.now();
+        await fillSnippetAndSave({
+            name: "Echo Sentinel",
+            command: `echo ${sentinel}`,
+        });
+
+        // Open a terminal so the palette has somewhere to send the command.
+        const hostsTab = await $("[data-tab-label='Hosts']");
+        await hostsTab.click();
+        await waitForDashboard();
+        await openNewHostModal();
+        await fillPasswordHostForm({
+            label: "palette-target",
+            host: SSHD_PASS_HOST,
+            port: SSHD_PASS_PORT,
+            username: SSH_USER,
+            password: SSH_PASS,
+        });
+        await clickConnect();
+        await waitForModalClosed();
+
+        const sessionId = await waitForAnyTerminal();
+        await waitForTerminalText(sessionId, ":~$");
+
+        // Open the palette and pick the snippet.
+        await cmd("k");
+        await waitForSnippetPalette();
+        await clickPaletteSnippet("Echo Sentinel");
+
+        await waitForTerminalText(sessionId, sentinel, { timeoutMs: 10_000 });
+    });
+});

--- a/tests/e2e/specs/23-settings-persist.spec.ts
+++ b/tests/e2e/specs/23-settings-persist.spec.ts
@@ -1,0 +1,34 @@
+// Settings persistence: change a setting, restart the app, verify it persists.
+
+import { expect } from "chai";
+import { relaunchApp, resetApp } from "../helpers/reset.js";
+
+async function gotoSettings(): Promise<void> {
+    const nav = await $("[aria-label='Settings']");
+    await nav.waitForClickable({ timeout: 10_000 });
+    await nav.click();
+    await (await $("[data-testid='s-fontsize']")).waitForDisplayed({ timeout: 10_000 });
+}
+
+describe("settings persistence", () => {
+    beforeEach(async () => {
+        await resetApp();
+    });
+
+    it("font size persists across an app restart", async () => {
+        await gotoSettings();
+
+        const fontInput = await $("[data-testid='s-fontsize']");
+        await fontInput.click();
+        await browser.keys(["Control", "a"]);
+        await browser.keys(["Delete"]);
+        await fontInput.setValue("18");
+        await browser.keys(["Enter"]);
+
+        await relaunchApp();
+        await gotoSettings();
+
+        const after = await $("[data-testid='s-fontsize']");
+        expect(await after.getValue()).to.equal("18");
+    });
+});

--- a/tests/e2e/specs/24-terminal-search.spec.ts
+++ b/tests/e2e/specs/24-terminal-search.spec.ts
@@ -1,0 +1,74 @@
+// Terminal search: Cmd+F opens the search bar, typing finds matches in
+// the active terminal buffer.
+
+import { expect } from "chai";
+import { resetApp } from "../helpers/reset.js";
+import { waitForDashboard } from "../helpers/dashboard.js";
+import {
+    clickConnect,
+    fillPasswordHostForm,
+    openNewHostModal,
+    waitForModalClosed,
+} from "../helpers/host.js";
+import {
+    runCommand,
+    waitForAnyTerminal,
+    waitForTerminalText,
+} from "../helpers/terminal.js";
+import { cmd } from "../helpers/keyboard.js";
+
+const SSHD_PASS_HOST = process.env.SSHD_PASS_HOST ?? "sshd-pass";
+const SSHD_PASS_PORT = Number(process.env.SSHD_PASS_PORT ?? 2222);
+const SSH_USER = process.env.SSH_USER ?? "testuser";
+const SSH_PASS = process.env.SSH_PASS ?? "testpass";
+
+describe("terminal search", () => {
+    beforeEach(async () => {
+        await resetApp();
+        await waitForDashboard();
+    });
+
+    it("Cmd+F finds text in the terminal buffer", async () => {
+        await openNewHostModal();
+        await fillPasswordHostForm({
+            label: "search-target",
+            host: SSHD_PASS_HOST,
+            port: SSHD_PASS_PORT,
+            username: SSH_USER,
+            password: SSH_PASS,
+        });
+        await clickConnect();
+        await waitForModalClosed();
+
+        const sessionId = await waitForAnyTerminal();
+        await waitForTerminalText(sessionId, ":~$");
+
+        // Emit a unique sentinel into the terminal buffer.
+        const sentinel = "findme_" + Date.now();
+        await runCommand(sessionId, `echo ${sentinel}`, sentinel);
+
+        // Open search and type the sentinel.
+        await cmd("f");
+        const input = await $("[data-testid='terminal-search-input']");
+        await input.waitForDisplayed({ timeout: 5_000 });
+        await input.click();
+        await input.setValue(sentinel);
+
+        // The search bar's data-match-text should report a non-empty,
+        // non-"No results" hit.
+        await browser.waitUntil(
+            async () => {
+                const txt = await (await $("[data-testid='terminal-search']")).getAttribute(
+                    "data-match-text",
+                );
+                return !!txt && txt !== "No results";
+            },
+            { timeout: 5_000, timeoutMsg: "search never reported a match" },
+        );
+
+        const matchText = await (await $("[data-testid='terminal-search']")).getAttribute(
+            "data-match-text",
+        );
+        expect(matchText).to.match(/of/);
+    });
+});

--- a/tests/e2e/specs/25-port-forward-crud.spec.ts
+++ b/tests/e2e/specs/25-port-forward-crud.spec.ts
@@ -1,0 +1,68 @@
+// Port-forward rule CRUD: create a rule against a saved host, find it,
+// delete it. Doesn't actually start the tunnel — that would require the
+// linuxserver sshd image to allow port forwarding which isn't enabled by
+// default.
+
+import { expect } from "chai";
+import { resetApp } from "../helpers/reset.js";
+import { waitForDashboard } from "../helpers/dashboard.js";
+import {
+    clickSave,
+    fillPasswordHostForm,
+    findHostCardByLabel,
+    getHostId,
+    openNewHostModal,
+    waitForModalClosed,
+} from "../helpers/host.js";
+import {
+    deleteRule,
+    fillRuleAndSave,
+    findRuleCard,
+    gotoPortForwardingPage,
+    openNewRuleDialog,
+    ruleCount,
+} from "../helpers/port-forwards.js";
+
+const SSHD_PASS_HOST = process.env.SSHD_PASS_HOST ?? "sshd-pass";
+const SSHD_PASS_PORT = Number(process.env.SSHD_PASS_PORT ?? 2222);
+const SSH_USER = process.env.SSH_USER ?? "testuser";
+const SSH_PASS = process.env.SSH_PASS ?? "testpass";
+
+describe("port-forward CRUD", () => {
+    beforeEach(async () => {
+        await resetApp();
+        await waitForDashboard();
+    });
+
+    it("creates a rule against a host, then deletes it", async () => {
+        // Need at least one host so the rule dialog's host CustomSelect is non-empty.
+        await openNewHostModal();
+        await fillPasswordHostForm({
+            label: "pf-target",
+            host: SSHD_PASS_HOST,
+            port: SSHD_PASS_PORT,
+            username: SSH_USER,
+            password: SSH_PASS,
+        });
+        await clickSave();
+        await waitForModalClosed();
+        await findHostCardByLabel("pf-target");
+        const hostId = await getHostId("pf-target");
+
+        await gotoPortForwardingPage();
+        expect(await ruleCount()).to.equal(0);
+
+        await openNewRuleDialog();
+        await fillRuleAndSave({
+            label: "tunnel-1",
+            hostId,
+            localPort: 15432,
+            remotePort: 5432,
+        });
+        await findRuleCard("tunnel-1");
+        expect(await ruleCount()).to.equal(1);
+
+        await deleteRule("tunnel-1");
+        expect(await ruleCount()).to.equal(0);
+    });
+});

--- a/tests/e2e/specs/26-split-pane.spec.ts
+++ b/tests/e2e/specs/26-split-pane.spec.ts
@@ -1,0 +1,57 @@
+// Split-pane: Cmd+D splits the active terminal horizontally; the DOM gets a
+// SplitContainer with two TerminalArea children.
+
+import { expect } from "chai";
+import { resetApp } from "../helpers/reset.js";
+import { waitForDashboard } from "../helpers/dashboard.js";
+import {
+    clickConnect,
+    fillPasswordHostForm,
+    openNewHostModal,
+    waitForModalClosed,
+} from "../helpers/host.js";
+import { waitForAnyTerminal, waitForTerminalText } from "../helpers/terminal.js";
+import { cmd } from "../helpers/keyboard.js";
+
+const SSHD_PASS_HOST = process.env.SSHD_PASS_HOST ?? "sshd-pass";
+const SSHD_PASS_PORT = Number(process.env.SSHD_PASS_PORT ?? 2222);
+const SSH_USER = process.env.SSH_USER ?? "testuser";
+const SSH_PASS = process.env.SSH_PASS ?? "testpass";
+
+describe("terminal split pane", () => {
+    beforeEach(async () => {
+        await resetApp();
+        await waitForDashboard();
+    });
+
+    it("Cmd+D splits the terminal into two panes", async () => {
+        await openNewHostModal();
+        await fillPasswordHostForm({
+            label: "split-target",
+            host: SSHD_PASS_HOST,
+            port: SSHD_PASS_PORT,
+            username: SSH_USER,
+            password: SSH_PASS,
+        });
+        await clickConnect();
+        await waitForModalClosed();
+        const sessionId = await waitForAnyTerminal();
+        await waitForTerminalText(sessionId, ":~$");
+
+        // Single pane: no SplitContainer yet.
+        expect((await $$("[data-testid='split-container']")).length).to.equal(0);
+
+        await cmd("d");
+
+        // After split, expect one SplitContainer and two terminals.
+        await browser.waitUntil(
+            async () => (await $$("[data-testid^='terminal-']")).length >= 2,
+            { timeout: 10_000, timeoutMsg: "second pane never opened" },
+        );
+        const split = await $("[data-testid='split-container']");
+        await split.waitForExist({ timeout: 5_000 });
+        const direction = await split.getAttribute("data-split-direction");
+        expect(direction).to.equal("horizontal");
+        expect((await $$("[data-testid^='terminal-']")).length).to.equal(2);
+    });
+});

--- a/tests/e2e/specs/27-pane-zoom.spec.ts
+++ b/tests/e2e/specs/27-pane-zoom.spec.ts
@@ -1,0 +1,62 @@
+// Pane zoom: in a split layout, Cmd+Shift+Enter toggles the zoomed state
+// on the active pane.
+
+import { expect } from "chai";
+import { resetApp } from "../helpers/reset.js";
+import { waitForDashboard } from "../helpers/dashboard.js";
+import {
+    clickConnect,
+    fillPasswordHostForm,
+    openNewHostModal,
+    waitForModalClosed,
+} from "../helpers/host.js";
+import { waitForAnyTerminal, waitForTerminalText } from "../helpers/terminal.js";
+import { cmd, cmdShift } from "../helpers/keyboard.js";
+
+const SSHD_PASS_HOST = process.env.SSHD_PASS_HOST ?? "sshd-pass";
+const SSHD_PASS_PORT = Number(process.env.SSHD_PASS_PORT ?? 2222);
+const SSH_USER = process.env.SSH_USER ?? "testuser";
+const SSH_PASS = process.env.SSH_PASS ?? "testpass";
+
+describe("terminal pane zoom", () => {
+    beforeEach(async () => {
+        await resetApp();
+        await waitForDashboard();
+    });
+
+    it("Cmd+Shift+Enter toggles the zoom state", async () => {
+        await openNewHostModal();
+        await fillPasswordHostForm({
+            label: "zoom-target",
+            host: SSHD_PASS_HOST,
+            port: SSHD_PASS_PORT,
+            username: SSH_USER,
+            password: SSH_PASS,
+        });
+        await clickConnect();
+        await waitForModalClosed();
+        const sessionId = await waitForAnyTerminal();
+        await waitForTerminalText(sessionId, ":~$");
+
+        await cmd("d");
+        await browser.waitUntil(
+            async () => (await $$("[data-testid^='terminal-']")).length >= 2,
+            { timeout: 10_000 },
+        );
+
+        const split = await $("[data-testid='split-container']");
+        expect(await split.getAttribute("data-zoomed")).to.equal("false");
+
+        await cmdShift("Enter");
+        await browser.waitUntil(
+            async () => (await split.getAttribute("data-zoomed")) === "true",
+            { timeout: 5_000, timeoutMsg: "pane never reported zoomed=true" },
+        );
+
+        await cmdShift("Enter");
+        await browser.waitUntil(
+            async () => (await split.getAttribute("data-zoomed")) === "false",
+            { timeout: 5_000, timeoutMsg: "pane never unzoomed" },
+        );
+    });
+});

--- a/tests/e2e/specs/28-sidebar-collapse.spec.ts
+++ b/tests/e2e/specs/28-sidebar-collapse.spec.ts
@@ -1,0 +1,29 @@
+// Sidebar collapse: clicking the collapse toggle flips the expanded state.
+
+import { expect } from "chai";
+import { resetApp } from "../helpers/reset.js";
+import { waitForDashboard } from "../helpers/dashboard.js";
+import { clickCollapseToggle, sidebarExpanded } from "../helpers/sidebar.js";
+
+describe("sidebar collapse", () => {
+    beforeEach(async () => {
+        await resetApp();
+        await waitForDashboard();
+    });
+
+    it("toggles the expanded state on click", async () => {
+        const initial = await sidebarExpanded();
+        await clickCollapseToggle();
+        await browser.waitUntil(
+            async () => (await sidebarExpanded()) === !initial,
+            { timeout: 5_000, timeoutMsg: "sidebar state did not toggle" },
+        );
+        expect(await sidebarExpanded()).to.equal(!initial);
+
+        // And flips back on a second click.
+        await clickCollapseToggle();
+        await browser.waitUntil(async () => (await sidebarExpanded()) === initial, {
+            timeout: 5_000,
+        });
+    });
+});

--- a/tests/e2e/specs/29-history-page.spec.ts
+++ b/tests/e2e/specs/29-history-page.spec.ts
@@ -1,0 +1,46 @@
+// History page: after connecting + disconnecting a host, the History page
+// should show an entry for it.
+
+import { expect } from "chai";
+import { resetApp } from "../helpers/reset.js";
+import { waitForDashboard } from "../helpers/dashboard.js";
+import {
+    clickConnect,
+    fillPasswordHostForm,
+    openNewHostModal,
+    waitForModalClosed,
+} from "../helpers/host.js";
+import { waitForAnyTerminal, waitForTerminalText } from "../helpers/terminal.js";
+import { gotoHistoryPage, historyEntryCount, waitForHistoryEntry } from "../helpers/history.js";
+
+const SSHD_PASS_HOST = process.env.SSHD_PASS_HOST ?? "sshd-pass";
+const SSHD_PASS_PORT = Number(process.env.SSHD_PASS_PORT ?? 2222);
+const SSH_USER = process.env.SSH_USER ?? "testuser";
+const SSH_PASS = process.env.SSH_PASS ?? "testpass";
+
+describe("history page", () => {
+    beforeEach(async () => {
+        await resetApp();
+        await waitForDashboard();
+    });
+
+    it("shows an entry after connecting and disconnecting", async () => {
+        await openNewHostModal();
+        await fillPasswordHostForm({
+            label: "history-target",
+            host: SSHD_PASS_HOST,
+            port: SSHD_PASS_PORT,
+            username: SSH_USER,
+            password: SSH_PASS,
+        });
+        await clickConnect();
+        await waitForModalClosed();
+
+        const sessionId = await waitForAnyTerminal();
+        await waitForTerminalText(sessionId, ":~$");
+
+        await gotoHistoryPage();
+        await waitForHistoryEntry("history-target");
+        expect(await historyEntryCount()).to.be.greaterThan(0);
+    });
+});

--- a/tests/e2e/specs/30-vault-untouched-on-edit.spec.ts
+++ b/tests/e2e/specs/30-vault-untouched-on-edit.spec.ts
@@ -1,0 +1,68 @@
+// Editing a host WITHOUT retyping the password must leave the saved
+// credential intact — verified by reconnecting successfully after the edit.
+
+import { resetApp } from "../helpers/reset.js";
+import { waitForDashboard } from "../helpers/dashboard.js";
+import {
+    clickConnect,
+    clickSave,
+    fillPasswordHostForm,
+    findHostCardByLabel,
+    openHostEdit,
+    openNewHostModal,
+    waitForModalClosed,
+} from "../helpers/host.js";
+import { waitForAnyTerminal, waitForTerminalText } from "../helpers/terminal.js";
+import { cmd } from "../helpers/keyboard.js";
+
+const SSHD_PASS_HOST = process.env.SSHD_PASS_HOST ?? "sshd-pass";
+const SSHD_PASS_PORT = Number(process.env.SSHD_PASS_PORT ?? 2222);
+const SSH_USER = process.env.SSH_USER ?? "testuser";
+const SSH_PASS = process.env.SSH_PASS ?? "testpass";
+
+describe("vault untouched on edit", () => {
+    beforeEach(async () => {
+        await resetApp();
+        await waitForDashboard();
+    });
+
+    it("keeps the saved password when the user edits without retyping it", async () => {
+        // Create and Connect (writes credential to vault).
+        await openNewHostModal();
+        await fillPasswordHostForm({
+            label: "untouched",
+            host: SSHD_PASS_HOST,
+            port: SSHD_PASS_PORT,
+            username: SSH_USER,
+            password: SSH_PASS,
+        });
+        await clickConnect();
+        await waitForModalClosed();
+        const sessionId = await waitForAnyTerminal();
+        await waitForTerminalText(sessionId, ":~$");
+
+        // Close the terminal and go back to the dashboard.
+        await cmd("w");
+
+        // Open the edit modal, change only the label, save.
+        await findHostCardByLabel("untouched");
+        await openHostEdit("untouched");
+        const labelInput = await $("[data-testid='host-modal-label']");
+        await labelInput.click();
+        await browser.keys(["Control", "a"]);
+        await browser.keys(["Backspace"]);
+        await labelInput.setValue("untouched-edited");
+        await clickSave();
+        await waitForModalClosed();
+        await findHostCardByLabel("untouched-edited");
+
+        // Reconnect via the card (uses the stored credential — no password
+        // in the form). If the vault was overwritten by the empty edit,
+        // this would fail with a credential error.
+        await openHostEdit("untouched-edited");
+        await clickConnect();
+        await waitForModalClosed();
+        const sid2 = await waitForAnyTerminal();
+        await waitForTerminalText(sid2, ":~$", { timeoutMs: 20_000 });
+    });
+});

--- a/tests/e2e/specs/31-reconnect-after-disconnect.spec.ts
+++ b/tests/e2e/specs/31-reconnect-after-disconnect.spec.ts
@@ -1,0 +1,81 @@
+// Reconnect-after-disconnect: connect, type `exit` so the remote shell
+// closes (which disconnects the SSH session), close the dead tab, then
+// reconnect via the card and verify a fresh prompt appears.
+
+import { resetApp } from "../helpers/reset.js";
+import { waitForDashboard } from "../helpers/dashboard.js";
+import {
+    clickConnect,
+    clickSave,
+    fillPasswordHostForm,
+    findHostCardByLabel,
+    getHostId,
+    openHostEdit,
+    openNewHostModal,
+    waitForModalClosed,
+} from "../helpers/host.js";
+import {
+    readTerminalText,
+    typeIntoTerminal,
+    waitForAnyTerminal,
+    waitForTerminalText,
+} from "../helpers/terminal.js";
+import { cmd } from "../helpers/keyboard.js";
+
+const SSHD_PASS_HOST = process.env.SSHD_PASS_HOST ?? "sshd-pass";
+const SSHD_PASS_PORT = Number(process.env.SSHD_PASS_PORT ?? 2222);
+const SSH_USER = process.env.SSH_USER ?? "testuser";
+const SSH_PASS = process.env.SSH_PASS ?? "testpass";
+
+describe("reconnect after disconnect", () => {
+    beforeEach(async () => {
+        await resetApp();
+        await waitForDashboard();
+    });
+
+    it("can reconnect after the remote shell exits", async () => {
+        await openNewHostModal();
+        await fillPasswordHostForm({
+            label: "reconnect-target",
+            host: SSHD_PASS_HOST,
+            port: SSHD_PASS_PORT,
+            username: SSH_USER,
+            password: SSH_PASS,
+        });
+        await clickSave();
+        await waitForModalClosed();
+        await findHostCardByLabel("reconnect-target");
+
+        // First connection.
+        const hostId = await getHostId("reconnect-target");
+        await openHostEdit("reconnect-target");
+        await clickConnect();
+        await waitForModalClosed();
+        const sessionId = await waitForAnyTerminal();
+        await waitForTerminalText(sessionId, ":~$");
+
+        // Send `exit` — the shell closes which tears down the SSH session.
+        await typeIntoTerminal(sessionId, "exit\n");
+        // Give it a moment for the disconnect signal to propagate.
+        await browser.pause(2_000);
+
+        // The terminal buffer should now contain "exit" (the user's keystroke
+        // echoed back) or "logout"/"Connection closed" from sshd. Don't
+        // require a specific message — just confirm we typed it.
+        const buf = await readTerminalText(sessionId);
+        if (!buf.includes("exit") && !buf.includes("logout")) {
+            throw new Error("did not see exit/logout in terminal buffer");
+        }
+
+        // Close the now-disconnected tab.
+        await cmd("w");
+
+        // Reconnect via the card (uses stored credentials).
+        const explorerBtn = await $(`[data-testid='host-card-${hostId}-terminal']`);
+        await explorerBtn.waitForClickable({ timeout: 10_000 });
+        await explorerBtn.click();
+
+        const sid2 = await waitForAnyTerminal();
+        await waitForTerminalText(sid2, ":~$", { timeoutMs: 20_000 });
+    });
+});

--- a/tests/e2e/specs/32-bad-key-path.spec.ts
+++ b/tests/e2e/specs/32-bad-key-path.spec.ts
@@ -1,0 +1,43 @@
+// Bad SSH key path — connecting with a non-existent key file should surface
+// a clear error in the modal, not hang or crash.
+
+import { expect } from "chai";
+import { resetApp } from "../helpers/reset.js";
+import { waitForDashboard } from "../helpers/dashboard.js";
+import {
+    clickConnect,
+    fillKeyHostForm,
+    openNewHostModal,
+} from "../helpers/host.js";
+
+const SSHD_KEY_HOST = process.env.SSHD_KEY_HOST ?? "sshd-key";
+const SSHD_KEY_PORT = Number(process.env.SSHD_KEY_PORT ?? 2222);
+const SSH_USER = process.env.SSH_USER ?? "testuser";
+
+describe("bad key path", () => {
+    beforeEach(async () => {
+        await resetApp();
+        await waitForDashboard();
+    });
+
+    it("shows an error when the key file does not exist", async () => {
+        await openNewHostModal();
+        await fillKeyHostForm({
+            label: "bad-key",
+            host: SSHD_KEY_HOST,
+            port: SSHD_KEY_PORT,
+            username: SSH_USER,
+            keyPath: "/keys/does-not-exist",
+        });
+        await clickConnect();
+
+        const err = await $("[data-testid='host-modal-error']");
+        await err.waitForDisplayed({ timeout: 30_000 });
+        const text = await err.getText();
+        expect(text.length).to.be.greaterThan(0);
+
+        // Modal stays open so the user can fix the path.
+        const modal = await $("[data-testid='host-modal']");
+        expect(await modal.isDisplayed()).to.equal(true);
+    });
+});

--- a/tests/e2e/specs/33-sftp-multiselect-delete.spec.ts
+++ b/tests/e2e/specs/33-sftp-multiselect-delete.spec.ts
@@ -1,0 +1,54 @@
+// Multi-select delete: create 3 folders, select all 3 (via test hook),
+// Delete + confirm → all gone in one round-trip.
+
+import { resetApp } from "../helpers/reset.js";
+import { waitForDashboard } from "../helpers/dashboard.js";
+import {
+    clickSave,
+    fillPasswordHostForm,
+    findHostCardByLabel,
+    getHostId,
+    openNewHostModal,
+    waitForModalClosed,
+} from "../helpers/host.js";
+import {
+    createFolder,
+    multiSelectAndDelete,
+    waitForExplorer,
+} from "../helpers/sftp-ops.js";
+
+const SSHD_PASS_HOST = process.env.SSHD_PASS_HOST ?? "sshd-pass";
+const SSHD_PASS_PORT = Number(process.env.SSHD_PASS_PORT ?? 2222);
+const SSH_USER = process.env.SSH_USER ?? "testuser";
+const SSH_PASS = process.env.SSH_PASS ?? "testpass";
+
+describe("SFTP multi-select delete", () => {
+    beforeEach(async () => {
+        await resetApp();
+        await waitForDashboard();
+    });
+
+    it("deletes three selected entries in one operation", async () => {
+        await openNewHostModal();
+        await fillPasswordHostForm({
+            label: "multi-target",
+            host: SSHD_PASS_HOST,
+            port: SSHD_PASS_PORT,
+            username: SSH_USER,
+            password: SSH_PASS,
+        });
+        await clickSave();
+        await waitForModalClosed();
+        await findHostCardByLabel("multi-target");
+
+        const hostId = await getHostId("multi-target");
+        await (await $(`[data-testid='host-card-${hostId}-explorer']`)).click();
+        await waitForExplorer();
+
+        const stamp = Date.now();
+        const names = [`m-a-${stamp}`, `m-b-${stamp}`, `m-c-${stamp}`];
+        for (const n of names) await createFolder(n);
+
+        await multiSelectAndDelete(names);
+    });
+});

--- a/tests/e2e/specs/34-sftp-sort.spec.ts
+++ b/tests/e2e/specs/34-sftp-sort.spec.ts
@@ -1,0 +1,80 @@
+// Sort order: click Name twice (descending), verify our two folders flip
+// their positions. We pick names whose alphabetical order is well-defined
+// regardless of the other directory contents.
+
+import { expect } from "chai";
+import { resetApp } from "../helpers/reset.js";
+import { waitForDashboard } from "../helpers/dashboard.js";
+import {
+    clickSave,
+    fillPasswordHostForm,
+    findHostCardByLabel,
+    getHostId,
+    openNewHostModal,
+    waitForModalClosed,
+} from "../helpers/host.js";
+import {
+    clickSortHeader,
+    createFolder,
+    deleteEntry,
+    entryOrder,
+    waitForExplorer,
+} from "../helpers/sftp-ops.js";
+
+const SSHD_PASS_HOST = process.env.SSHD_PASS_HOST ?? "sshd-pass";
+const SSHD_PASS_PORT = Number(process.env.SSHD_PASS_PORT ?? 2222);
+const SSH_USER = process.env.SSH_USER ?? "testuser";
+const SSH_PASS = process.env.SSH_PASS ?? "testpass";
+
+describe("SFTP sort", () => {
+    beforeEach(async () => {
+        await resetApp();
+        await waitForDashboard();
+    });
+
+    it("toggling Name sort reverses the order of two known entries", async () => {
+        await openNewHostModal();
+        await fillPasswordHostForm({
+            label: "sort-target",
+            host: SSHD_PASS_HOST,
+            port: SSHD_PASS_PORT,
+            username: SSH_USER,
+            password: SSH_PASS,
+        });
+        await clickSave();
+        await waitForModalClosed();
+        await findHostCardByLabel("sort-target");
+
+        const hostId = await getHostId("sort-target");
+        await (await $(`[data-testid='host-card-${hostId}-explorer']`)).click();
+        await waitForExplorer();
+
+        const stamp = Date.now();
+        const lower = `zzz-aaa-${stamp}`; // comes first alphabetically
+        const upper = `zzz-bbb-${stamp}`; // comes after
+        await createFolder(lower);
+        await createFolder(upper);
+
+        // Default sort is by Name ascending. Confirm lower < upper in listing.
+        const ascOrder = await entryOrder();
+        const ascA = ascOrder.indexOf(lower);
+        const ascB = ascOrder.indexOf(upper);
+        expect(ascA).to.be.lessThan(ascB);
+
+        // Click the Name header to flip to descending.
+        await clickSortHeader("name");
+
+        await browser.waitUntil(
+            async () => {
+                const order = await entryOrder();
+                return order.indexOf(lower) > order.indexOf(upper);
+            },
+            { timeout: 5_000, timeoutMsg: "Name sort order never flipped" },
+        );
+
+        // Cleanup so the test target doesn't accumulate stale entries.
+        await clickSortHeader("name"); // flip back to ascending for deletion
+        await deleteEntry(lower);
+        await deleteEntry(upper);
+    });
+});

--- a/tests/e2e/specs/35-sftp-large-listing.spec.ts
+++ b/tests/e2e/specs/35-sftp-large-listing.spec.ts
@@ -1,0 +1,73 @@
+// Large listing: create 20 folders, verify they all render, then bulk-delete.
+// Catches regressions where the file table breaks (or virtualizes badly)
+// when given more than the default "home dir is empty" entry count.
+
+import { expect } from "chai";
+import { resetApp } from "../helpers/reset.js";
+import { waitForDashboard } from "../helpers/dashboard.js";
+import {
+    clickSave,
+    fillPasswordHostForm,
+    findHostCardByLabel,
+    getHostId,
+    openNewHostModal,
+    waitForModalClosed,
+} from "../helpers/host.js";
+import {
+    createFolder,
+    multiSelectAndDelete,
+    waitForEntry,
+    waitForExplorer,
+} from "../helpers/sftp-ops.js";
+
+const SSHD_PASS_HOST = process.env.SSHD_PASS_HOST ?? "sshd-pass";
+const SSHD_PASS_PORT = Number(process.env.SSHD_PASS_PORT ?? 2222);
+const SSH_USER = process.env.SSH_USER ?? "testuser";
+const SSH_PASS = process.env.SSH_PASS ?? "testpass";
+
+const N_ENTRIES = 20;
+
+describe("SFTP large listing", () => {
+    beforeEach(async () => {
+        await resetApp();
+        await waitForDashboard();
+    });
+
+    it(`renders ${N_ENTRIES} entries`, async () => {
+        await openNewHostModal();
+        await fillPasswordHostForm({
+            label: "many-target",
+            host: SSHD_PASS_HOST,
+            port: SSHD_PASS_PORT,
+            username: SSH_USER,
+            password: SSH_PASS,
+        });
+        await clickSave();
+        await waitForModalClosed();
+        await findHostCardByLabel("many-target");
+
+        const hostId = await getHostId("many-target");
+        await (await $(`[data-testid='host-card-${hostId}-explorer']`)).click();
+        await waitForExplorer();
+
+        const stamp = Date.now();
+        const names = Array.from(
+            { length: N_ENTRIES },
+            (_, i) => `bulk-${stamp}-${String(i).padStart(2, "0")}`,
+        );
+
+        for (const n of names) await createFolder(n);
+
+        // First and last folders both visible in the rendered DOM (sanity:
+        // no virtualization is dropping them).
+        await waitForEntry(names[0]);
+        await waitForEntry(names[names.length - 1]);
+
+        // At minimum the table contains our 20 plus whatever the home dir
+        // started with (.ssh, .bash_history, logs, sshd, sshd.pid, ssh_host_keys).
+        const total = (await $$("[data-entry-row='true']")).length;
+        expect(total).to.be.greaterThanOrEqual(N_ENTRIES);
+
+        await multiSelectAndDelete(names);
+    });
+});

--- a/tests/e2e/specs/36-error-banner-clears.spec.ts
+++ b/tests/e2e/specs/36-error-banner-clears.spec.ts
@@ -1,0 +1,51 @@
+// Error → fix → save: error banner appears on a bad save, disappears once
+// the user fixes the form and the save succeeds.
+
+import { expect } from "chai";
+import { resetApp } from "../helpers/reset.js";
+import { waitForDashboard } from "../helpers/dashboard.js";
+import {
+    clickSave,
+    findHostCardByLabel,
+    openNewHostModal,
+    waitForModalClosed,
+} from "../helpers/host.js";
+
+describe("error banner clears after a successful save", () => {
+    beforeEach(async () => {
+        await resetApp();
+        await waitForDashboard();
+    });
+
+    it("save with empty Host shows an error; filling it in clears the banner", async () => {
+        await openNewHostModal();
+
+        // Fill in only Username (Host stays empty — required field).
+        const username = await $("[data-testid='host-modal-username']");
+        await username.click();
+        await username.setValue("testuser");
+
+        await clickSave();
+
+        // Validation error banner should appear, modal stays open.
+        const banner = await $("[data-testid='host-modal-error']");
+        await banner.waitForDisplayed({ timeout: 5_000 });
+        const firstMsg = await banner.getText();
+        expect(firstMsg.length).to.be.greaterThan(0);
+
+        // Now fix the form: fill in Host, and Save.
+        const host = await $("[data-testid='host-modal-host']");
+        await host.click();
+        await host.setValue("sshd-pass");
+
+        await clickSave();
+        await waitForModalClosed();
+
+        // Modal closed → host saved → no stale banner present.
+        // HostCard.displayName is `host.label || host.host` — with no label
+        // set, the card shows the bare hostname.
+        await findHostCardByLabel("sshd-pass");
+        expect(await (await $("[data-testid='host-modal-error']")).isExisting())
+            .to.equal(false);
+    });
+});

--- a/tests/e2e/specs/37-snippet-variables.spec.ts
+++ b/tests/e2e/specs/37-snippet-variables.spec.ts
@@ -1,0 +1,81 @@
+// Snippet with {{variables}}: palette opens the variables phase, user fills
+// in a value, Run sends the resolved command to the active terminal.
+
+import { resetApp } from "../helpers/reset.js";
+import { waitForDashboard } from "../helpers/dashboard.js";
+import {
+    clickConnect,
+    fillPasswordHostForm,
+    openNewHostModal,
+    waitForModalClosed,
+} from "../helpers/host.js";
+import {
+    clickPaletteSnippet,
+    fillSnippetAndSave,
+    gotoSnippetsPage,
+    openNewSnippetModal,
+    waitForSnippetPalette,
+} from "../helpers/snippets.js";
+import {
+    waitForAnyTerminal,
+    waitForTerminalText,
+} from "../helpers/terminal.js";
+import { cmd } from "../helpers/keyboard.js";
+
+const SSHD_PASS_HOST = process.env.SSHD_PASS_HOST ?? "sshd-pass";
+const SSHD_PASS_PORT = Number(process.env.SSHD_PASS_PORT ?? 2222);
+const SSH_USER = process.env.SSH_USER ?? "testuser";
+const SSH_PASS = process.env.SSH_PASS ?? "testpass";
+
+describe("snippet variables", () => {
+    beforeEach(async () => {
+        await resetApp();
+    });
+
+    it("prompts for {{var}} and substitutes it into the run command", async () => {
+        // Snippet that needs a `name` variable.
+        await gotoSnippetsPage();
+        await openNewSnippetModal();
+        await fillSnippetAndSave({
+            name: "Echo Name",
+            command: "echo hello {{name}}",
+        });
+
+        // Open a terminal.
+        const hostsTab = await $("[data-tab-label='Hosts']");
+        await hostsTab.click();
+        await waitForDashboard();
+        await openNewHostModal();
+        await fillPasswordHostForm({
+            label: "vars-target",
+            host: SSHD_PASS_HOST,
+            port: SSHD_PASS_PORT,
+            username: SSH_USER,
+            password: SSH_PASS,
+        });
+        await clickConnect();
+        await waitForModalClosed();
+
+        const sessionId = await waitForAnyTerminal();
+        await waitForTerminalText(sessionId, ":~$");
+
+        // Open palette, pick the snippet — should switch to the variables phase.
+        await cmd("k");
+        await waitForSnippetPalette();
+        await clickPaletteSnippet("Echo Name");
+
+        // Variable input should appear.
+        const varInput = await $("[data-testid='snippet-palette-var-name']");
+        await varInput.waitForDisplayed({ timeout: 5_000 });
+        const sentinel = "varname_" + Date.now();
+        await varInput.click();
+        await varInput.setValue(sentinel);
+
+        // Click Run (or press Enter — Run button is the form's submit).
+        const run = await $("[data-testid='snippet-palette-run']");
+        await run.waitForClickable({ timeout: 5_000 });
+        await run.click();
+
+        await waitForTerminalText(sessionId, `hello ${sentinel}`, { timeoutMs: 10_000 });
+    });
+});

--- a/tests/e2e/specs/38-edit-auth-type.spec.ts
+++ b/tests/e2e/specs/38-edit-auth-type.spec.ts
@@ -1,0 +1,85 @@
+// Editing a host's auth type — password → key — must persist and the host
+// must reconnect via the new auth method.
+
+import { expect } from "chai";
+import { resetApp } from "../helpers/reset.js";
+import { waitForDashboard } from "../helpers/dashboard.js";
+import {
+    clickConnect,
+    clickSave,
+    fillPasswordHostForm,
+    findHostCardByLabel,
+    openHostEdit,
+    openNewHostModal,
+    waitForModalClosed,
+} from "../helpers/host.js";
+import { waitForAnyTerminal, waitForTerminalText } from "../helpers/terminal.js";
+import { cmd } from "../helpers/keyboard.js";
+
+const SSHD_KEY_HOST = process.env.SSHD_KEY_HOST ?? "sshd-key";
+const SSHD_KEY_PORT = Number(process.env.SSHD_KEY_PORT ?? 2222);
+const SSH_USER = process.env.SSH_USER ?? "testuser";
+const SSH_KEY_PATH = process.env.SSH_KEY_PATH ?? "/keys/id_ed25519";
+
+describe("edit host auth type", () => {
+    beforeEach(async () => {
+        await resetApp();
+        await waitForDashboard();
+    });
+
+    it("changes a host from password to key auth and reconnects via key", async () => {
+        // Save against sshd-key with a deliberately wrong password — we won't
+        // try to connect with it. We'll change to key auth before connecting.
+        await openNewHostModal();
+        await fillPasswordHostForm({
+            label: "switch-target",
+            host: SSHD_KEY_HOST,
+            port: SSHD_KEY_PORT,
+            username: SSH_USER,
+            password: "wrong-password-on-purpose",
+        });
+        await clickSave();
+        await waitForModalClosed();
+        await findHostCardByLabel("switch-target");
+
+        // Edit — switch auth type to privateKey and set key path.
+        await openHostEdit("switch-target");
+        const authSel = await $("[data-testid='host-modal-auth']");
+        await authSel.click();
+        const keyOpt = await $("[data-testid='host-modal-auth-option-privateKey']");
+        await keyOpt.waitForClickable({ timeout: 5_000 });
+        await keyOpt.click();
+
+        const keyInput = await $("[data-testid='host-modal-keypath']");
+        await keyInput.waitForDisplayed({ timeout: 5_000 });
+        await keyInput.click();
+        await keyInput.setValue(SSH_KEY_PATH);
+
+        await clickSave();
+        await waitForModalClosed();
+
+        // Re-open edit modal and confirm the auth type stuck. Read the
+        // CustomSelect's `data-value` attribute — more stable than getText()
+        // which returns empty for portaled-dropdown buttons in WebKitWebDriver.
+        await openHostEdit("switch-target");
+        await browser.waitUntil(
+            async () =>
+                (await (await $("[data-testid='host-modal-auth']")).getAttribute(
+                    "data-value",
+                )) === "privateKey",
+            { timeout: 5_000, timeoutMsg: "auth type did not persist as privateKey" },
+        );
+        const v = await (await $("[data-testid='host-modal-auth']")).getAttribute("data-value");
+        expect(v).to.equal("privateKey");
+
+        // Connect via the now-key auth (the password is wrong; if it tried
+        // password auth, this would fail).
+        await clickConnect();
+        await waitForModalClosed();
+        const sessionId = await waitForAnyTerminal();
+        await waitForTerminalText(sessionId, ":~$", { timeoutMs: 20_000 });
+
+        // Cleanup tab.
+        await cmd("w");
+    });
+});

--- a/tests/e2e/specs/39-import-ssh-config.spec.ts
+++ b/tests/e2e/specs/39-import-ssh-config.spec.ts
@@ -1,0 +1,64 @@
+// Import SSH config: drop a config file at $HOME/.ssh/config, open the
+// import modal (which auto-scans that path on mount), submit the import,
+// verify hosts appear on the dashboard.
+
+import { mkdir, writeFile, rm } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { resetApp } from "../helpers/reset.js";
+import { waitForDashboard, hostCardCount } from "../helpers/dashboard.js";
+import { findHostCardByLabel } from "../helpers/host.js";
+
+const SSH_CONFIG_DIR = join(homedir(), ".ssh");
+const SSH_CONFIG_PATH = join(SSH_CONFIG_DIR, "config");
+
+const FAKE_CONFIG = `
+Host imported-alpha
+  HostName 10.0.0.1
+  User alice
+  Port 2222
+
+Host imported-beta
+  HostName 10.0.0.2
+  User bob
+  Port 22
+`;
+
+describe("import SSH config", () => {
+    beforeEach(async () => {
+        // Seed the SSH config BEFORE relaunching the app so the modal's
+        // auto-scan on mount finds it.
+        await mkdir(SSH_CONFIG_DIR, { recursive: true });
+        await writeFile(SSH_CONFIG_PATH, FAKE_CONFIG, "utf8");
+        await resetApp();
+        await waitForDashboard();
+    });
+
+    afterEach(async () => {
+        // Clean up so subsequent runs don't inherit a stale config.
+        await rm(SSH_CONFIG_PATH, { force: true });
+    });
+
+    it("scans the default config path and imports two hosts", async () => {
+        const before = await hostCardCount();
+
+        await (await $("[data-testid='import-ssh-config-button']")).click();
+
+        // Submit button text reflects how many will import. Wait for it to
+        // become enabled (scan complete + at least one selected).
+        const submit = await $("[data-testid='import-ssh-config-submit']");
+        await submit.waitForClickable({ timeout: 10_000 });
+        await submit.click();
+
+        // Both hosts should land on the dashboard (HostCard displayName uses
+        // host.label || host.host; the importer stores `host_alias` as the label).
+        await findHostCardByLabel("imported-alpha");
+        await findHostCardByLabel("imported-beta");
+
+        // Two new cards beyond whatever was there before.
+        await browser.waitUntil(
+            async () => (await hostCardCount()) >= before + 2,
+            { timeout: 10_000, timeoutMsg: "imported hosts didn't appear on dashboard" },
+        );
+    });
+});

--- a/tests/e2e/specs/40-startup-command.spec.ts
+++ b/tests/e2e/specs/40-startup-command.spec.ts
@@ -1,0 +1,52 @@
+// Host's `startup_command` field is executed by the SSH backend after the
+// shell starts. Verify it actually runs by setting it to an echo with a
+// known sentinel and asserting the sentinel appears in the terminal.
+
+import { resetApp } from "../helpers/reset.js";
+import { waitForDashboard } from "../helpers/dashboard.js";
+import {
+    clickConnect,
+    fillPasswordHostForm,
+    openNewHostModal,
+    waitForModalClosed,
+} from "../helpers/host.js";
+import { waitForAnyTerminal, waitForTerminalText } from "../helpers/terminal.js";
+
+const SSHD_PASS_HOST = process.env.SSHD_PASS_HOST ?? "sshd-pass";
+const SSHD_PASS_PORT = Number(process.env.SSHD_PASS_PORT ?? 2222);
+const SSH_USER = process.env.SSH_USER ?? "testuser";
+const SSH_PASS = process.env.SSH_PASS ?? "testpass";
+
+describe("host startup command", () => {
+    beforeEach(async () => {
+        await resetApp();
+        await waitForDashboard();
+    });
+
+    it("runs the host's startup_command after connecting", async () => {
+        const sentinel = "startup_marker_" + Date.now();
+
+        await openNewHostModal();
+        await fillPasswordHostForm({
+            label: "startup-target",
+            host: SSHD_PASS_HOST,
+            port: SSHD_PASS_PORT,
+            username: SSH_USER,
+            password: SSH_PASS,
+        });
+
+        // Set the startup command via its dedicated testid.
+        const startup = await $("[data-testid='host-modal-startup-command']");
+        await startup.click();
+        await startup.setValue(`echo ${sentinel}`);
+
+        await clickConnect();
+        await waitForModalClosed();
+
+        const sessionId = await waitForAnyTerminal();
+        // First wait for any prompt so we know we're connected, then look
+        // for the startup-command output specifically.
+        await waitForTerminalText(sessionId, ":~$");
+        await waitForTerminalText(sessionId, sentinel, { timeoutMs: 10_000 });
+    });
+});

--- a/tests/e2e/specs/41-s3-connection-save.spec.ts
+++ b/tests/e2e/specs/41-s3-connection-save.spec.ts
@@ -1,0 +1,47 @@
+// S3 connection save + delete via the dashboard.
+
+import { expect } from "chai";
+import { resetApp } from "../helpers/reset.js";
+import { waitForDashboard } from "../helpers/dashboard.js";
+import {
+    clickS3Save,
+    deleteS3Connection,
+    fillS3Form,
+    findS3Card,
+    openNewS3Dialog,
+    s3CardCount,
+} from "../helpers/s3.js";
+
+const MINIO_ENDPOINT = process.env.MINIO_ENDPOINT ?? "http://minio:9000";
+const MINIO_BUCKET = process.env.MINIO_BUCKET ?? "anyscp-test";
+const MINIO_ACCESS_KEY = process.env.MINIO_ACCESS_KEY ?? "minioadmin";
+const MINIO_SECRET_KEY = process.env.MINIO_SECRET_KEY ?? "minioadmin";
+
+describe("S3 connection save", () => {
+    beforeEach(async () => {
+        await resetApp();
+        await waitForDashboard();
+    });
+
+    it("saves a MinIO S3 connection and shows it on the dashboard", async () => {
+        expect(await s3CardCount()).to.equal(0);
+
+        await openNewS3Dialog();
+        await fillS3Form({
+            label: "minio-test",
+            provider: "minio",
+            accessKey: MINIO_ACCESS_KEY,
+            secretKey: MINIO_SECRET_KEY,
+            region: "us-east-1",
+            bucket: MINIO_BUCKET,
+            endpoint: MINIO_ENDPOINT,
+        });
+        await clickS3Save();
+
+        await findS3Card("minio-test");
+        expect(await s3CardCount()).to.equal(1);
+
+        await deleteS3Connection("minio-test");
+        expect(await s3CardCount()).to.equal(0);
+    });
+});

--- a/tests/e2e/specs/42-s3-connect-and-list.spec.ts
+++ b/tests/e2e/specs/42-s3-connect-and-list.spec.ts
@@ -1,0 +1,53 @@
+// Save a MinIO S3 connection, then click the Explorer button on the saved
+// S3 card to open the bucket and verify the seeded objects render.
+//
+// Note: the dialog's "Connect" button is buggy — it creates the session in
+// the backend but doesn't open a tab. The card-click path is what actually
+// opens the explorer (it calls addTab + setCurrentBucket). The test uses
+// the working path.
+
+import { resetApp } from "../helpers/reset.js";
+import { waitForDashboard } from "../helpers/dashboard.js";
+import {
+    clickS3Save,
+    fillS3Form,
+    getS3Id,
+    openNewS3Dialog,
+} from "../helpers/s3.js";
+import { waitForEntry, waitForExplorer } from "../helpers/sftp-ops.js";
+
+const MINIO_ENDPOINT = process.env.MINIO_ENDPOINT ?? "http://minio:9000";
+const MINIO_BUCKET = process.env.MINIO_BUCKET ?? "anyscp-test";
+const MINIO_ACCESS_KEY = process.env.MINIO_ACCESS_KEY ?? "minioadmin";
+const MINIO_SECRET_KEY = process.env.MINIO_SECRET_KEY ?? "minioadmin";
+
+describe("S3 connect + list", () => {
+    beforeEach(async () => {
+        await resetApp();
+        await waitForDashboard();
+    });
+
+    it("connects to MinIO and lists the seeded objects", async () => {
+        await openNewS3Dialog();
+        await fillS3Form({
+            label: "minio-explore",
+            provider: "minio",
+            accessKey: MINIO_ACCESS_KEY,
+            secretKey: MINIO_SECRET_KEY,
+            region: "us-east-1",
+            bucket: MINIO_BUCKET,
+            endpoint: MINIO_ENDPOINT,
+        });
+        await clickS3Save();
+
+        // Click the Explorer action button on the saved card.
+        const id = await getS3Id("minio-explore");
+        const explorerBtn = await $(`[data-testid='s3-card-${id}-explorer']`);
+        await explorerBtn.waitForClickable({ timeout: 10_000 });
+        await explorerBtn.click();
+
+        await waitForExplorer();
+        await waitForEntry("hello.txt");
+        await waitForEntry("data.json");
+    });
+});

--- a/tests/e2e/specs/43-sftp-create-file.spec.ts
+++ b/tests/e2e/specs/43-sftp-create-file.spec.ts
@@ -1,0 +1,51 @@
+// Toolbar "New File" creates a zero-byte file with the given name.
+
+import { resetApp } from "../helpers/reset.js";
+import { waitForDashboard } from "../helpers/dashboard.js";
+import {
+    clickSave,
+    fillPasswordHostForm,
+    findHostCardByLabel,
+    getHostId,
+    openNewHostModal,
+    waitForModalClosed,
+} from "../helpers/host.js";
+import {
+    createFile,
+    deleteEntry,
+    waitForExplorer,
+} from "../helpers/sftp-ops.js";
+
+const SSHD_PASS_HOST = process.env.SSHD_PASS_HOST ?? "sshd-pass";
+const SSHD_PASS_PORT = Number(process.env.SSHD_PASS_PORT ?? 2222);
+const SSH_USER = process.env.SSH_USER ?? "testuser";
+const SSH_PASS = process.env.SSH_PASS ?? "testpass";
+
+describe("SFTP create file", () => {
+    beforeEach(async () => {
+        await resetApp();
+        await waitForDashboard();
+    });
+
+    it("creates an empty file via the toolbar", async () => {
+        await openNewHostModal();
+        await fillPasswordHostForm({
+            label: "cf-target",
+            host: SSHD_PASS_HOST,
+            port: SSHD_PASS_PORT,
+            username: SSH_USER,
+            password: SSH_PASS,
+        });
+        await clickSave();
+        await waitForModalClosed();
+        await findHostCardByLabel("cf-target");
+
+        const hostId = await getHostId("cf-target");
+        await (await $(`[data-testid='host-card-${hostId}-explorer']`)).click();
+        await waitForExplorer();
+
+        const name = "e2e-touched-" + Date.now() + ".txt";
+        await createFile(name);
+        await deleteEntry(name);
+    });
+});

--- a/tests/e2e/specs/44-sftp-upload-file.spec.ts
+++ b/tests/e2e/specs/44-sftp-upload-file.spec.ts
@@ -1,0 +1,79 @@
+// Upload a local file to the SFTP server via the backend invoke. Verifies
+// the uploaded file appears in the remote listing after a refresh.
+
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { resetApp } from "../helpers/reset.js";
+import { waitForDashboard } from "../helpers/dashboard.js";
+import {
+    clickSave,
+    fillPasswordHostForm,
+    findHostCardByLabel,
+    getHostId,
+    openNewHostModal,
+    waitForModalClosed,
+} from "../helpers/host.js";
+import {
+    deleteEntry,
+    refreshExplorer,
+    waitForEntry,
+    waitForExplorer,
+} from "../helpers/sftp-ops.js";
+import { activeSftpSessionId, sftpUpload } from "../helpers/transfers.js";
+
+const SSHD_PASS_HOST = process.env.SSHD_PASS_HOST ?? "sshd-pass";
+const SSHD_PASS_PORT = Number(process.env.SSHD_PASS_PORT ?? 2222);
+const SSH_USER = process.env.SSH_USER ?? "testuser";
+const SSH_PASS = process.env.SSH_PASS ?? "testpass";
+const REMOTE_HOME = "/config";
+
+describe("SFTP upload file", () => {
+    beforeEach(async () => {
+        await resetApp();
+        await waitForDashboard();
+    });
+
+    it("uploads a local file and the entry appears remotely", async () => {
+        await openNewHostModal();
+        await fillPasswordHostForm({
+            label: "up-target",
+            host: SSHD_PASS_HOST,
+            port: SSHD_PASS_PORT,
+            username: SSH_USER,
+            password: SSH_PASS,
+        });
+        await clickSave();
+        await waitForModalClosed();
+        await findHostCardByLabel("up-target");
+
+        const hostId = await getHostId("up-target");
+        await (await $(`[data-testid='host-card-${hostId}-explorer']`)).click();
+        await waitForExplorer();
+
+        // Write a small local file.
+        const stamp = Date.now();
+        const dir = await mkdtemp(join(tmpdir(), "e2e-upload-"));
+        const localPath = join(dir, `payload-${stamp}.txt`);
+        const remoteName = `uploaded-${stamp}.txt`;
+        const remotePath = `${REMOTE_HOME}/${remoteName}`;
+        await writeFile(localPath, "hello from e2e upload\n", "utf8");
+
+        const sessionId = await activeSftpSessionId();
+        await sftpUpload(sessionId, localPath, remotePath);
+
+        // sftp_upload is async (returns a transfer_id immediately) — poll
+        // for the file by refreshing until it shows up.
+        await browser.waitUntil(
+            async () => {
+                await refreshExplorer();
+                const el = await $(`[data-entry-name='${remoteName}']`);
+                return await el.isExisting();
+            },
+            { timeout: 15_000, timeoutMsg: `uploaded file '${remoteName}' never appeared` },
+        );
+
+        await waitForEntry(remoteName);
+        await deleteEntry(remoteName);
+    });
+});

--- a/tests/e2e/specs/45-sftp-download-file.spec.ts
+++ b/tests/e2e/specs/45-sftp-download-file.spec.ts
@@ -1,0 +1,97 @@
+// Download an SFTP file to a local path and verify its content arrived.
+// First upload a known payload so we have something deterministic to
+// download back.
+
+import { expect } from "chai";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { resetApp } from "../helpers/reset.js";
+import { waitForDashboard } from "../helpers/dashboard.js";
+import {
+    clickSave,
+    fillPasswordHostForm,
+    findHostCardByLabel,
+    getHostId,
+    openNewHostModal,
+    waitForModalClosed,
+} from "../helpers/host.js";
+import {
+    deleteEntry,
+    refreshExplorer,
+    waitForExplorer,
+} from "../helpers/sftp-ops.js";
+import {
+    activeSftpSessionId,
+    sftpDownload,
+    sftpUpload,
+} from "../helpers/transfers.js";
+
+const SSHD_PASS_HOST = process.env.SSHD_PASS_HOST ?? "sshd-pass";
+const SSHD_PASS_PORT = Number(process.env.SSHD_PASS_PORT ?? 2222);
+const SSH_USER = process.env.SSH_USER ?? "testuser";
+const SSH_PASS = process.env.SSH_PASS ?? "testpass";
+const REMOTE_HOME = "/config";
+
+describe("SFTP download file", () => {
+    beforeEach(async () => {
+        await resetApp();
+        await waitForDashboard();
+    });
+
+    it("downloads a remote file with matching content", async () => {
+        await openNewHostModal();
+        await fillPasswordHostForm({
+            label: "dl-target",
+            host: SSHD_PASS_HOST,
+            port: SSHD_PASS_PORT,
+            username: SSH_USER,
+            password: SSH_PASS,
+        });
+        await clickSave();
+        await waitForModalClosed();
+        await findHostCardByLabel("dl-target");
+
+        const hostId = await getHostId("dl-target");
+        await (await $(`[data-testid='host-card-${hostId}-explorer']`)).click();
+        await waitForExplorer();
+
+        const stamp = Date.now();
+        const payload = `download-payload-${stamp}\n`;
+        const dir = await mkdtemp(join(tmpdir(), "e2e-download-"));
+        const uploadLocal = join(dir, "src.txt");
+        const downloadLocal = join(dir, "dst.txt");
+        const remoteName = `dl-${stamp}.txt`;
+        const remotePath = `${REMOTE_HOME}/${remoteName}`;
+        await writeFile(uploadLocal, payload, "utf8");
+
+        const sessionId = await activeSftpSessionId();
+        await sftpUpload(sessionId, uploadLocal, remotePath);
+
+        await browser.waitUntil(
+            async () => {
+                await refreshExplorer();
+                return await (await $(`[data-entry-name='${remoteName}']`)).isExisting();
+            },
+            { timeout: 15_000 },
+        );
+
+        await sftpDownload(sessionId, remotePath, downloadLocal);
+
+        await browser.waitUntil(
+            async () => {
+                try {
+                    const text = await readFile(downloadLocal, "utf8");
+                    return text === payload;
+                } catch {
+                    return false;
+                }
+            },
+            { timeout: 15_000, timeoutMsg: "downloaded file never matched expected content" },
+        );
+
+        const text = await readFile(downloadLocal, "utf8");
+        expect(text).to.equal(payload);
+        await deleteEntry(remoteName);
+    });
+});

--- a/tests/e2e/specs/46-sftp-upload-recursive.spec.ts
+++ b/tests/e2e/specs/46-sftp-upload-recursive.spec.ts
@@ -1,0 +1,101 @@
+// Recursive upload — create a local directory with nested files, enqueue
+// the dir for upload, then verify the top-level dir appears remotely and
+// (after navigating into it) contains the expected files.
+
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { mkdtemp } from "node:fs/promises";
+import { resetApp } from "../helpers/reset.js";
+import { waitForDashboard } from "../helpers/dashboard.js";
+import {
+    clickSave,
+    fillPasswordHostForm,
+    findHostCardByLabel,
+    getHostId,
+    openNewHostModal,
+    waitForModalClosed,
+} from "../helpers/host.js";
+import {
+    multiSelectAndDelete,
+    openEntry,
+    refreshExplorer,
+    waitForEntry,
+    waitForExplorer,
+} from "../helpers/sftp-ops.js";
+import {
+    activeSftpSessionId,
+    sftpEnqueueUpload,
+} from "../helpers/transfers.js";
+
+const SSHD_PASS_HOST = process.env.SSHD_PASS_HOST ?? "sshd-pass";
+const SSHD_PASS_PORT = Number(process.env.SSHD_PASS_PORT ?? 2222);
+const SSH_USER = process.env.SSH_USER ?? "testuser";
+const SSH_PASS = process.env.SSH_PASS ?? "testpass";
+const REMOTE_HOME = "/config";
+
+describe("SFTP recursive upload", () => {
+    beforeEach(async () => {
+        await resetApp();
+        await waitForDashboard();
+    });
+
+    it("uploads a directory tree (parent + 2 nested files)", async () => {
+        await openNewHostModal();
+        await fillPasswordHostForm({
+            label: "rec-target",
+            host: SSHD_PASS_HOST,
+            port: SSHD_PASS_PORT,
+            username: SSH_USER,
+            password: SSH_PASS,
+        });
+        await clickSave();
+        await waitForModalClosed();
+        await findHostCardByLabel("rec-target");
+
+        const hostId = await getHostId("rec-target");
+        await (await $(`[data-testid='host-card-${hostId}-explorer']`)).click();
+        await waitForExplorer();
+
+        // Build local tree: <tmp>/e2e-rec-<stamp>/{a.txt,b.txt}
+        const stamp = Date.now();
+        const tree = await mkdtemp(join(tmpdir(), `e2e-rec-${stamp}-`));
+        await writeFile(join(tree, "a.txt"), "alpha\n", "utf8");
+        await writeFile(join(tree, "b.txt"), "beta\n", "utf8");
+        // Add a nested subdir to prove depth handling.
+        await mkdir(join(tree, "nested"), { recursive: true });
+        await writeFile(join(tree, "nested", "deep.txt"), "deep\n", "utf8");
+
+        const dirName = tree.split("/").pop()!;
+
+        const sessionId = await activeSftpSessionId();
+        await sftpEnqueueUpload(sessionId, [tree], REMOTE_HOME);
+
+        // Wait for the top-level dir to land remotely.
+        await browser.waitUntil(
+            async () => {
+                await refreshExplorer();
+                return await (await $(`[data-entry-name='${dirName}']`)).isExisting();
+            },
+            { timeout: 20_000, timeoutMsg: `uploaded dir '${dirName}' never appeared` },
+        );
+
+        // Navigate in and verify the two files at the top of the tree.
+        await openEntry(dirName);
+        await waitForEntry("a.txt");
+        await waitForEntry("b.txt");
+        await waitForEntry("nested");
+
+        // Cleanup — go back to /config, bulk-delete the uploaded dir.
+        await browser.execute(() => {
+            const buttons = Array.from(
+                document.querySelectorAll<HTMLButtonElement>(
+                    "[aria-label='Current path'] button",
+                ),
+            );
+            buttons.at(-2)?.click();
+        });
+        await refreshExplorer();
+        await multiSelectAndDelete([dirName]);
+    });
+});

--- a/tests/e2e/specs/47-sftp-copy-paste.spec.ts
+++ b/tests/e2e/specs/47-sftp-copy-paste.spec.ts
@@ -1,0 +1,83 @@
+// Copy a remote folder into a subdirectory via the backend copy command.
+// Exercises sftp_copy_entries which the UI's Cmd+C/Cmd+V also invokes.
+
+import { resetApp } from "../helpers/reset.js";
+import { waitForDashboard } from "../helpers/dashboard.js";
+import {
+    clickSave,
+    fillPasswordHostForm,
+    findHostCardByLabel,
+    getHostId,
+    openNewHostModal,
+    waitForModalClosed,
+} from "../helpers/host.js";
+import {
+    createFolder,
+    deleteEntry,
+    openEntry,
+    refreshExplorer,
+    waitForEntry,
+    waitForExplorer,
+} from "../helpers/sftp-ops.js";
+import {
+    activeSftpSessionId,
+    sftpCopy,
+} from "../helpers/transfers.js";
+
+const SSHD_PASS_HOST = process.env.SSHD_PASS_HOST ?? "sshd-pass";
+const SSHD_PASS_PORT = Number(process.env.SSHD_PASS_PORT ?? 2222);
+const SSH_USER = process.env.SSH_USER ?? "testuser";
+const SSH_PASS = process.env.SSH_PASS ?? "testpass";
+const REMOTE_HOME = "/config";
+
+describe("SFTP copy entries", () => {
+    beforeEach(async () => {
+        await resetApp();
+        await waitForDashboard();
+    });
+
+    it("copies a folder into a sibling folder", async () => {
+        await openNewHostModal();
+        await fillPasswordHostForm({
+            label: "cp-target",
+            host: SSHD_PASS_HOST,
+            port: SSHD_PASS_PORT,
+            username: SSH_USER,
+            password: SSH_PASS,
+        });
+        await clickSave();
+        await waitForModalClosed();
+        await findHostCardByLabel("cp-target");
+
+        const hostId = await getHostId("cp-target");
+        await (await $(`[data-testid='host-card-${hostId}-explorer']`)).click();
+        await waitForExplorer();
+
+        const stamp = Date.now();
+        const src = `cp-src-${stamp}`;
+        const dest = `cp-dst-${stamp}`;
+        await createFolder(src);
+        await createFolder(dest);
+
+        const sessionId = await activeSftpSessionId();
+        await sftpCopy(sessionId, [`${REMOTE_HOME}/${src}`], `${REMOTE_HOME}/${dest}`);
+
+        // Navigate into destination and verify the copy.
+        await openEntry(dest);
+        await refreshExplorer();
+        await waitForEntry(src);
+
+        // Back to /config and clean up both.
+        await browser.execute(() => {
+            const buttons = Array.from(
+                document.querySelectorAll<HTMLButtonElement>(
+                    "[aria-label='Current path'] button",
+                ),
+            );
+            buttons.at(-2)?.click();
+        });
+        await refreshExplorer();
+        await deleteEntry(src);
+        await deleteEntry(dest);
+    });
+});

--- a/tests/e2e/specs/48-sftp-move-entries.spec.ts
+++ b/tests/e2e/specs/48-sftp-move-entries.spec.ts
@@ -1,0 +1,87 @@
+// Move an entry to a sibling folder — sftp_move_entries removes from source
+// and creates at destination atomically (rename on most SFTP servers).
+
+import { resetApp } from "../helpers/reset.js";
+import { waitForDashboard } from "../helpers/dashboard.js";
+import {
+    clickSave,
+    fillPasswordHostForm,
+    findHostCardByLabel,
+    getHostId,
+    openNewHostModal,
+    waitForModalClosed,
+} from "../helpers/host.js";
+import {
+    assertEntryAbsent,
+    createFolder,
+    deleteEntry,
+    openEntry,
+    refreshExplorer,
+    waitForEntry,
+    waitForExplorer,
+} from "../helpers/sftp-ops.js";
+import {
+    activeSftpSessionId,
+    sftpMove,
+} from "../helpers/transfers.js";
+
+const SSHD_PASS_HOST = process.env.SSHD_PASS_HOST ?? "sshd-pass";
+const SSHD_PASS_PORT = Number(process.env.SSHD_PASS_PORT ?? 2222);
+const SSH_USER = process.env.SSH_USER ?? "testuser";
+const SSH_PASS = process.env.SSH_PASS ?? "testpass";
+const REMOTE_HOME = "/config";
+
+describe("SFTP move entries", () => {
+    beforeEach(async () => {
+        await resetApp();
+        await waitForDashboard();
+    });
+
+    it("moves a folder into a sibling folder", async () => {
+        await openNewHostModal();
+        await fillPasswordHostForm({
+            label: "mv-target",
+            host: SSHD_PASS_HOST,
+            port: SSHD_PASS_PORT,
+            username: SSH_USER,
+            password: SSH_PASS,
+        });
+        await clickSave();
+        await waitForModalClosed();
+        await findHostCardByLabel("mv-target");
+
+        const hostId = await getHostId("mv-target");
+        await (await $(`[data-testid='host-card-${hostId}-explorer']`)).click();
+        await waitForExplorer();
+
+        const stamp = Date.now();
+        const src = `mv-src-${stamp}`;
+        const dest = `mv-dst-${stamp}`;
+        await createFolder(src);
+        await createFolder(dest);
+
+        const sessionId = await activeSftpSessionId();
+        await sftpMove(sessionId, [`${REMOTE_HOME}/${src}`], `${REMOTE_HOME}/${dest}`);
+
+        await refreshExplorer();
+        await assertEntryAbsent(src);
+        await waitForEntry(dest);
+
+        // Verify the moved folder is inside dest.
+        await openEntry(dest);
+        await refreshExplorer();
+        await waitForEntry(src);
+
+        // Back to /config; clean up.
+        await browser.execute(() => {
+            const buttons = Array.from(
+                document.querySelectorAll<HTMLButtonElement>(
+                    "[aria-label='Current path'] button",
+                ),
+            );
+            buttons.at(-2)?.click();
+        });
+        await refreshExplorer();
+        await deleteEntry(dest);
+    });
+});

--- a/tests/e2e/specs/49-s3-upload-object.spec.ts
+++ b/tests/e2e/specs/49-s3-upload-object.spec.ts
@@ -1,0 +1,69 @@
+// Upload a local file as an S3 object via s3_upload_file, then verify it
+// appears in the bucket listing.
+
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { resetApp } from "../helpers/reset.js";
+import { waitForDashboard } from "../helpers/dashboard.js";
+import {
+    clickS3Save,
+    fillS3Form,
+    getS3Id,
+    openNewS3Dialog,
+} from "../helpers/s3.js";
+import {
+    refreshExplorer,
+    waitForEntry,
+    waitForExplorer,
+} from "../helpers/sftp-ops.js";
+import { activeS3SessionId, s3Upload } from "../helpers/transfers.js";
+
+const MINIO_ENDPOINT = process.env.MINIO_ENDPOINT ?? "http://minio:9000";
+const MINIO_BUCKET = process.env.MINIO_BUCKET ?? "anyscp-test";
+const MINIO_ACCESS_KEY = process.env.MINIO_ACCESS_KEY ?? "minioadmin";
+const MINIO_SECRET_KEY = process.env.MINIO_SECRET_KEY ?? "minioadmin";
+
+describe("S3 upload object", () => {
+    beforeEach(async () => {
+        await resetApp();
+        await waitForDashboard();
+    });
+
+    it("uploads a local file as an S3 object", async () => {
+        await openNewS3Dialog();
+        await fillS3Form({
+            label: "s3-upload",
+            provider: "minio",
+            accessKey: MINIO_ACCESS_KEY,
+            secretKey: MINIO_SECRET_KEY,
+            region: "us-east-1",
+            bucket: MINIO_BUCKET,
+            endpoint: MINIO_ENDPOINT,
+        });
+        await clickS3Save();
+
+        const id = await getS3Id("s3-upload");
+        await (await $(`[data-testid='s3-card-${id}-explorer']`)).click();
+        await waitForExplorer();
+
+        const stamp = Date.now();
+        const dir = await mkdtemp(join(tmpdir(), "e2e-s3up-"));
+        const localPath = join(dir, "src.txt");
+        const key = `e2e-uploaded-${stamp}.txt`;
+        await writeFile(localPath, "uploaded from e2e\n", "utf8");
+
+        const sessionId = await activeS3SessionId();
+        await s3Upload(sessionId, localPath, key);
+
+        await browser.waitUntil(
+            async () => {
+                await refreshExplorer();
+                return await (await $(`[data-entry-name='${key}']`)).isExisting();
+            },
+            { timeout: 15_000, timeoutMsg: `S3 object '${key}' never appeared` },
+        );
+
+        await waitForEntry(key);
+    });
+});

--- a/tests/e2e/specs/50-s3-download-object.spec.ts
+++ b/tests/e2e/specs/50-s3-download-object.spec.ts
@@ -1,0 +1,58 @@
+// Download one of the seeded S3 objects (hello.txt) and verify the bytes
+// arrived locally with the expected content.
+
+import { expect } from "chai";
+import { mkdtemp, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { resetApp } from "../helpers/reset.js";
+import { waitForDashboard } from "../helpers/dashboard.js";
+import {
+    clickS3Save,
+    fillS3Form,
+    getS3Id,
+    openNewS3Dialog,
+} from "../helpers/s3.js";
+import { waitForExplorer } from "../helpers/sftp-ops.js";
+import { activeS3SessionId, s3Download } from "../helpers/transfers.js";
+
+const MINIO_ENDPOINT = process.env.MINIO_ENDPOINT ?? "http://minio:9000";
+const MINIO_BUCKET = process.env.MINIO_BUCKET ?? "anyscp-test";
+const MINIO_ACCESS_KEY = process.env.MINIO_ACCESS_KEY ?? "minioadmin";
+const MINIO_SECRET_KEY = process.env.MINIO_SECRET_KEY ?? "minioadmin";
+
+describe("S3 download object", () => {
+    beforeEach(async () => {
+        await resetApp();
+        await waitForDashboard();
+    });
+
+    it("downloads a seeded object with matching content", async () => {
+        await openNewS3Dialog();
+        await fillS3Form({
+            label: "s3-dl",
+            provider: "minio",
+            accessKey: MINIO_ACCESS_KEY,
+            secretKey: MINIO_SECRET_KEY,
+            region: "us-east-1",
+            bucket: MINIO_BUCKET,
+            endpoint: MINIO_ENDPOINT,
+        });
+        await clickS3Save();
+
+        const id = await getS3Id("s3-dl");
+        await (await $(`[data-testid='s3-card-${id}-explorer']`)).click();
+        await waitForExplorer();
+
+        const dir = await mkdtemp(join(tmpdir(), "e2e-s3dl-"));
+        const local = join(dir, "hello-out.txt");
+
+        const sessionId = await activeS3SessionId();
+        await s3Download(sessionId, "hello.txt", local);
+
+        const text = await readFile(local, "utf8");
+        // The seed wrote `echo "hello from minio" | mc pipe`, which produces
+        // exactly that string with a trailing newline.
+        expect(text.trim()).to.equal("hello from minio");
+    });
+});

--- a/tests/e2e/specs/51-s3-upload-recursive.spec.ts
+++ b/tests/e2e/specs/51-s3-upload-recursive.spec.ts
@@ -1,0 +1,77 @@
+// Recursive S3 upload via s3_upload_files — give it a directory and verify
+// the nested files appear as objects under the given prefix.
+
+import { expect } from "chai";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { resetApp } from "../helpers/reset.js";
+import { waitForDashboard } from "../helpers/dashboard.js";
+import {
+    clickS3Save,
+    fillS3Form,
+    getS3Id,
+    openNewS3Dialog,
+} from "../helpers/s3.js";
+import {
+    refreshExplorer,
+    waitForEntry,
+    waitForExplorer,
+} from "../helpers/sftp-ops.js";
+import { activeS3SessionId, s3UploadFiles } from "../helpers/transfers.js";
+
+const MINIO_ENDPOINT = process.env.MINIO_ENDPOINT ?? "http://minio:9000";
+const MINIO_BUCKET = process.env.MINIO_BUCKET ?? "anyscp-test";
+const MINIO_ACCESS_KEY = process.env.MINIO_ACCESS_KEY ?? "minioadmin";
+const MINIO_SECRET_KEY = process.env.MINIO_SECRET_KEY ?? "minioadmin";
+
+describe("S3 recursive upload", () => {
+    beforeEach(async () => {
+        await resetApp();
+        await waitForDashboard();
+    });
+
+    it("uploads a directory tree under a prefix", async () => {
+        await openNewS3Dialog();
+        await fillS3Form({
+            label: "s3-rec",
+            provider: "minio",
+            accessKey: MINIO_ACCESS_KEY,
+            secretKey: MINIO_SECRET_KEY,
+            region: "us-east-1",
+            bucket: MINIO_BUCKET,
+            endpoint: MINIO_ENDPOINT,
+        });
+        await clickS3Save();
+
+        const id = await getS3Id("s3-rec");
+        await (await $(`[data-testid='s3-card-${id}-explorer']`)).click();
+        await waitForExplorer();
+
+        // Build a local tree.
+        const stamp = Date.now();
+        const tree = await mkdtemp(join(tmpdir(), `e2e-s3rec-${stamp}-`));
+        await writeFile(join(tree, "alpha.txt"), "a\n", "utf8");
+        await mkdir(join(tree, "nested"), { recursive: true });
+        await writeFile(join(tree, "nested", "beta.txt"), "b\n", "utf8");
+
+        // s3_upload_files walks the dir and writes objects under
+        // `${prefix}<relative-path>`. With prefix "e2e-rec-XXX/" we expect
+        // the top-level folder in the bucket to be "e2e-rec-XXX".
+        const prefix = `e2e-rec-${stamp}/`;
+        const prefixFolder = prefix.replace(/\/$/, "");
+        const sessionId = await activeS3SessionId();
+        const uploaded = await s3UploadFiles(sessionId, [tree], prefix);
+        expect(uploaded).to.be.greaterThanOrEqual(2);
+
+        await browser.waitUntil(
+            async () => {
+                await refreshExplorer();
+                return await (await $(`[data-entry-name='${prefixFolder}']`)).isExisting();
+            },
+            { timeout: 15_000, timeoutMsg: `S3 prefix folder '${prefixFolder}' never appeared` },
+        );
+
+        await waitForEntry(prefixFolder);
+    });
+});

--- a/tests/e2e/tsconfig.json
+++ b/tests/e2e/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "types": ["node", "@wdio/globals/types", "@wdio/mocha-framework", "expect-webdriverio", "chai"],
+    "lib": ["ES2022", "DOM"],
+    "baseUrl": ".",
+    "noEmit": true
+  },
+  "include": ["wdio.conf.ts", "specs/**/*.ts", "helpers/**/*.ts"]
+}

--- a/tests/e2e/wdio.conf.ts
+++ b/tests/e2e/wdio.conf.ts
@@ -1,0 +1,166 @@
+// WebdriverIO configuration for anySCP E2E tests.
+//
+// We spawn `tauri-driver` ourselves (rather than via a service) because
+// the wdio service ecosystem doesn't ship an official tauri-driver plugin.
+// tauri-driver wraps WebKitWebDriver and proxies sessions to it, launching
+// the Tauri binary specified in `tauri:options.application`.
+
+import { spawn, type ChildProcess } from "node:child_process";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "..", "..");
+const screenshotDir = path.join(__dirname, "screenshots");
+const videoDir = path.join(__dirname, "videos");
+const xvfbDisplay = process.env.DISPLAY ?? ":99";
+
+const anyscpBin =
+    process.env.ANYSCP_BIN ?? path.join(repoRoot, "src-tauri/target/debug/anyscp");
+
+let driverProcess: ChildProcess | null = null;
+let recorder: { proc: ChildProcess; path: string } | null = null;
+
+function startRecording(testTitle: string, parentTitle: string): { proc: ChildProcess; path: string } | null {
+    const slug = `${parentTitle}-${testTitle}`
+        .replace(/[^a-z0-9-]+/gi, "_")
+        .slice(0, 120);
+    const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+    const out = path.join(videoDir, `${stamp}__${slug}.mp4`);
+    // Capture the xvfb display at modest fps. ultrafast preset keeps CPU low
+    // (we're sharing the host with the app + tauri-driver + WebKitWebDriver).
+    const proc = spawn(
+        "ffmpeg",
+        [
+            "-y",
+            "-loglevel", "error",
+            "-f", "x11grab",
+            "-framerate", "15",
+            "-video_size", "1280x800",
+            "-i", xvfbDisplay,
+            "-c:v", "libx264",
+            "-preset", "ultrafast",
+            "-pix_fmt", "yuv420p",
+            out,
+        ],
+        { stdio: ["ignore", "inherit", "inherit"] },
+    );
+    return { proc, path: out };
+}
+
+async function stopRecording(rec: { proc: ChildProcess; path: string }): Promise<void> {
+    return new Promise((resolve) => {
+        rec.proc.once("exit", () => resolve());
+        // SIGINT lets ffmpeg flush the trailing mp4 atom — SIGTERM would
+        // truncate the file and leave it unplayable.
+        rec.proc.kill("SIGINT");
+        // Hard cap so a misbehaving ffmpeg never blocks teardown.
+        setTimeout(() => {
+            if (!rec.proc.killed) rec.proc.kill("SIGKILL");
+            resolve();
+        }, 5_000);
+    });
+}
+
+export const config: WebdriverIO.Config = {
+    runner: "local",
+    specs: ["./specs/**/*.spec.ts"],
+    maxInstances: 1,
+
+    // tauri-driver speaks the W3C protocol on :4444 by default.
+    hostname: "127.0.0.1",
+    port: 4444,
+
+    capabilities: [
+        {
+            // tauri-driver matches on `tauri:options.application` only — it
+            // ignores `browserName`, and WebKitWebDriver downstream rejects
+            // unknown browserName values with "Failed to match capabilities".
+            // @ts-expect-error - tauri:options isn't in WebdriverIO's types
+            "tauri:options": {
+                application: anyscpBin,
+            },
+        },
+    ],
+
+    logLevel: (process.env.LOG_LEVEL as WebdriverIO.Config["logLevel"]) ?? "info",
+    bail: 0,
+    waitforTimeout: 15_000,
+    connectionRetryTimeout: 60_000,
+    connectionRetryCount: 3,
+
+    framework: "mocha",
+    reporters: ["spec"],
+    mochaOpts: {
+        ui: "bdd",
+        timeout: 120_000,
+    },
+
+    // ── Hooks ─────────────────────────────────────────────────────────────────
+    onPrepare() {
+        // Start tauri-driver once for the whole suite. It supervises
+        // WebKitWebDriver under the hood.
+        console.log("[wdio] starting tauri-driver");
+        driverProcess = spawn("tauri-driver", [], {
+            stdio: ["ignore", "inherit", "inherit"],
+        });
+        driverProcess.on("error", (err) => {
+            console.error("[wdio] tauri-driver failed to start:", err);
+        });
+        // Give it a moment to bind :4444.
+        return new Promise((resolve) => setTimeout(resolve, 1500));
+    },
+
+    onComplete() {
+        if (driverProcess && !driverProcess.killed) {
+            console.log("[wdio] stopping tauri-driver");
+            driverProcess.kill("SIGTERM");
+        }
+    },
+
+    // Each spec gets fresh app state — see helpers/reset.ts.
+    beforeTest: async function (test) {
+        try {
+            await mkdir(videoDir, { recursive: true });
+            recorder = startRecording(test.title, String(test.parent ?? ""));
+        } catch (err) {
+            console.error("[wdio] failed to start video recording:", err);
+            recorder = null;
+        }
+    },
+
+    afterTest: async function (test, _context, result) {
+        // Stop the recording first so the mp4 is flushed/closed before we
+        // touch it.
+        if (recorder) {
+            await stopRecording(recorder);
+            // Keep ALL recordings (passing + failing) for debugging — the
+            // user can delete tests/e2e/videos/ to reclaim disk space.
+            console.error(
+                `[wdio] ${result.passed ? "PASS" : "FAIL"}: ${test.title}`,
+            );
+            console.error(`[wdio]   video: ${recorder.path}`);
+            recorder = null;
+        }
+
+        // On failure, also dump HTML + the URL so we have non-video forensics.
+        if (!result.passed) {
+            try {
+                await mkdir(screenshotDir, { recursive: true });
+                const slug = `${test.parent}-${test.title}`
+                    .replace(/[^a-z0-9-]+/gi, "_")
+                    .slice(0, 120);
+                const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+                const htmlPath = path.join(screenshotDir, `${stamp}__${slug}.html`);
+                const html = await browser.execute(() => document.documentElement.outerHTML);
+                await writeFile(htmlPath, String(html), "utf8");
+                const url = await browser.getUrl();
+                console.error(`[wdio]   url:       ${url}`);
+                console.error(`[wdio]   html dump: ${htmlPath}`);
+            } catch (err) {
+                console.error("[wdio] failed to capture failure artifacts:", err);
+            }
+        }
+    },
+};

--- a/tests/e2e/wdio.conf.ts
+++ b/tests/e2e/wdio.conf.ts
@@ -6,7 +6,7 @@
 // the Tauri binary specified in `tauri:options.application`.
 
 import { spawn, type ChildProcess } from "node:child_process";
-import { mkdir, writeFile } from "node:fs/promises";
+import { appendFile, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -14,6 +14,8 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, "..", "..");
 const screenshotDir = path.join(__dirname, "screenshots");
 const videoDir = path.join(__dirname, "videos");
+const reportPath = path.join(__dirname, "report.md");
+const recordsPath = path.join(__dirname, ".test-records.ndjson");
 const xvfbDisplay = process.env.DISPLAY ?? ":99";
 
 const anyscpBin =
@@ -22,14 +24,24 @@ const anyscpBin =
 let driverProcess: ChildProcess | null = null;
 let recorder: { proc: ChildProcess; path: string } | null = null;
 
-function startRecording(testTitle: string, parentTitle: string): { proc: ChildProcess; path: string } | null {
+interface TestRecord {
+    parent: string;
+    title: string;
+    passed: boolean;
+    durationMs: number;
+    errorMessage?: string;
+    errorStack?: string;
+    videoPath?: string;
+    htmlDumpPath?: string;
+    url?: string;
+}
+
+function startRecording(testTitle: string, parentTitle: string): { proc: ChildProcess; path: string } {
     const slug = `${parentTitle}-${testTitle}`
         .replace(/[^a-z0-9-]+/gi, "_")
         .slice(0, 120);
     const stamp = new Date().toISOString().replace(/[:.]/g, "-");
     const out = path.join(videoDir, `${stamp}__${slug}.mp4`);
-    // Capture the xvfb display at modest fps. ultrafast preset keeps CPU low
-    // (we're sharing the host with the app + tauri-driver + WebKitWebDriver).
     const proc = spawn(
         "ffmpeg",
         [
@@ -63,12 +75,95 @@ async function stopRecording(rec: { proc: ChildProcess; path: string }): Promise
     });
 }
 
+/**
+ * Build a Markdown report from the NDJSON test records written by
+ * `afterTest`. Designed to be pasted as-is into a chat or issue.
+ */
+function renderReport(records: TestRecord[]): string {
+    const total = records.length;
+    const passed = records.filter((r) => r.passed).length;
+    const failed = total - passed;
+    const totalMs = records.reduce((s, r) => s + r.durationMs, 0);
+
+    const bySpec = new Map<string, TestRecord[]>();
+    for (const r of records) {
+        const arr = bySpec.get(r.parent) ?? [];
+        arr.push(r);
+        bySpec.set(r.parent, arr);
+    }
+
+    const lines: string[] = [];
+    lines.push(`# anySCP E2E report`);
+    lines.push("");
+    lines.push(`- **${passed}/${total} passed** (${failed} failed) in ${(totalMs / 1000).toFixed(1)}s`);
+    lines.push(`- Generated: ${new Date().toISOString()}`);
+    lines.push("");
+
+    // Per-spec summary table.
+    lines.push(`## Summary`);
+    lines.push("");
+    lines.push(`| Spec | Result | Time |`);
+    lines.push(`| --- | --- | --- |`);
+    for (const [spec, rs] of bySpec) {
+        const sPassed = rs.filter((r) => r.passed).length;
+        const sTotal = rs.length;
+        const sMs = rs.reduce((s, r) => s + r.durationMs, 0);
+        const status = sPassed === sTotal ? "✅" : `❌ ${sTotal - sPassed} failed`;
+        lines.push(`| ${spec} | ${status} ${sPassed}/${sTotal} | ${(sMs / 1000).toFixed(1)}s |`);
+    }
+    lines.push("");
+
+    // Per-failure detail.
+    const failures = records.filter((r) => !r.passed);
+    if (failures.length > 0) {
+        lines.push(`## Failures`);
+        lines.push("");
+        for (const f of failures) {
+            lines.push(`### \`${f.parent}\` — ${f.title}`);
+            lines.push("");
+            if (f.url) lines.push(`- URL: \`${f.url}\``);
+            if (f.videoPath) lines.push(`- Video: \`${path.relative(repoRoot, f.videoPath)}\``);
+            if (f.htmlDumpPath) lines.push(`- HTML dump: \`${path.relative(repoRoot, f.htmlDumpPath)}\``);
+            lines.push(`- Duration: ${(f.durationMs / 1000).toFixed(2)}s`);
+            lines.push("");
+            if (f.errorMessage) {
+                lines.push("```");
+                lines.push(f.errorMessage);
+                lines.push("```");
+                lines.push("");
+            }
+            if (f.errorStack) {
+                lines.push("<details><summary>Stack trace</summary>");
+                lines.push("");
+                lines.push("```");
+                lines.push(f.errorStack);
+                lines.push("```");
+                lines.push("");
+                lines.push("</details>");
+                lines.push("");
+            }
+        }
+    }
+
+    // Passing roll-up at the bottom for completeness.
+    const passing = records.filter((r) => r.passed);
+    if (passing.length > 0) {
+        lines.push(`## Passing`);
+        lines.push("");
+        for (const p of passing) {
+            lines.push(`- ✅ \`${p.parent}\` — ${p.title} (${(p.durationMs / 1000).toFixed(2)}s)`);
+        }
+        lines.push("");
+    }
+
+    return lines.join("\n");
+}
+
 export const config: WebdriverIO.Config = {
     runner: "local",
     specs: ["./specs/**/*.spec.ts"],
     maxInstances: 1,
 
-    // tauri-driver speaks the W3C protocol on :4444 by default.
     hostname: "127.0.0.1",
     port: 4444,
 
@@ -98,9 +193,10 @@ export const config: WebdriverIO.Config = {
     },
 
     // ── Hooks ─────────────────────────────────────────────────────────────────
-    onPrepare() {
-        // Start tauri-driver once for the whole suite. It supervises
-        // WebKitWebDriver under the hood.
+    async onPrepare() {
+        // Truncate the per-run records file before any worker writes to it.
+        await rm(recordsPath, { force: true });
+
         console.log("[wdio] starting tauri-driver");
         driverProcess = spawn("tauri-driver", [], {
             stdio: ["ignore", "inherit", "inherit"],
@@ -108,18 +204,36 @@ export const config: WebdriverIO.Config = {
         driverProcess.on("error", (err) => {
             console.error("[wdio] tauri-driver failed to start:", err);
         });
-        // Give it a moment to bind :4444.
         return new Promise((resolve) => setTimeout(resolve, 1500));
     },
 
-    onComplete() {
+    async onComplete() {
         if (driverProcess && !driverProcess.killed) {
             console.log("[wdio] stopping tauri-driver");
             driverProcess.kill("SIGTERM");
         }
+
+        // Read the NDJSON records produced by afterTest and write the
+        // human-readable Markdown report. Done in the launcher because
+        // `afterTest` runs inside worker processes and can't see each other.
+        try {
+            const raw = await readFile(recordsPath, "utf8").catch(() => "");
+            const records: TestRecord[] = raw
+                .split("\n")
+                .filter((l) => l.trim().length > 0)
+                .map((l) => JSON.parse(l) as TestRecord);
+            if (records.length > 0) {
+                const md = renderReport(records);
+                await writeFile(reportPath, md, "utf8");
+                console.log(`[wdio] report written: ${reportPath}`);
+            } else {
+                console.log("[wdio] no test records collected — skipping report");
+            }
+        } catch (err) {
+            console.error("[wdio] failed to write report:", err);
+        }
     },
 
-    // Each spec gets fresh app state — see helpers/reset.ts.
     beforeTest: async function (test) {
         try {
             await mkdir(videoDir, { recursive: true });
@@ -131,21 +245,25 @@ export const config: WebdriverIO.Config = {
     },
 
     afterTest: async function (test, _context, result) {
-        // Stop the recording first so the mp4 is flushed/closed before we
-        // touch it.
+        const record: TestRecord = {
+            parent: String(test.parent ?? ""),
+            title: test.title,
+            passed: !!result.passed,
+            durationMs: typeof result.duration === "number" ? result.duration : 0,
+        };
+
         if (recorder) {
             await stopRecording(recorder);
-            // Keep ALL recordings (passing + failing) for debugging — the
-            // user can delete tests/e2e/videos/ to reclaim disk space.
-            console.error(
-                `[wdio] ${result.passed ? "PASS" : "FAIL"}: ${test.title}`,
-            );
-            console.error(`[wdio]   video: ${recorder.path}`);
+            record.videoPath = recorder.path;
             recorder = null;
         }
 
-        // On failure, also dump HTML + the URL so we have non-video forensics.
         if (!result.passed) {
+            const errObj = (result as { error?: Error }).error;
+            if (errObj) {
+                record.errorMessage = errObj.message;
+                record.errorStack = errObj.stack;
+            }
             try {
                 await mkdir(screenshotDir, { recursive: true });
                 const slug = `${test.parent}-${test.title}`
@@ -155,12 +273,20 @@ export const config: WebdriverIO.Config = {
                 const htmlPath = path.join(screenshotDir, `${stamp}__${slug}.html`);
                 const html = await browser.execute(() => document.documentElement.outerHTML);
                 await writeFile(htmlPath, String(html), "utf8");
-                const url = await browser.getUrl();
-                console.error(`[wdio]   url:       ${url}`);
-                console.error(`[wdio]   html dump: ${htmlPath}`);
+                record.htmlDumpPath = htmlPath;
+                record.url = await browser.getUrl();
             } catch (err) {
                 console.error("[wdio] failed to capture failure artifacts:", err);
             }
         }
+
+        // Append as NDJSON — survives worker crashes mid-run.
+        try {
+            await appendFile(recordsPath, JSON.stringify(record) + "\n", "utf8");
+        } catch (err) {
+            console.error("[wdio] failed to append test record:", err);
+        }
+
+        console.error(`[wdio] ${record.passed ? "PASS" : "FAIL"}: ${record.title}`);
     },
 };


### PR DESCRIPTION
## Summary

- **56 end-to-end tests** covering the full user-facing surface: host CRUD, password + key SSH, SFTP file ops (incl. recursive upload, copy, move), S3 (via MinIO sidecar), snippets, groups, port-forwarding, settings persistence, terminal split/zoom/search, sidebar, history, keyboard shortcuts, error paths.
- **Containerized runner** so the suite works identically on dev machines (incl. Arch where `WebKitWebDriver` is not packaged) and CI. `make e2e` brings up the stack, runs `tauri-driver` + `WebKitWebDriver` under `xvfb` against a debug build, tears down.
- **Artifacts per run**: `tests/e2e/report.md` summary, per-spec mp4 video, HTML+URL dump on failure, live VNC view on `localhost:5900`.

## App changes that fell out of testing

- `HostEditModal.handleConnect` now records the connection (was inconsistent with the card-click and recent-click paths — modal connects didn't show up in History or Recent).
- `S3Browser` loads bucket objects when `currentBucket` is pre-selected (fixes empty-explorer bug when reopening a saved S3 connection).
- F2 keybinding to start renaming the selected explorer entry.
- `ANYSCP_DISABLE_TELEMETRY` env var skips PostHog init (used by the e2e container so test runs don't pollute analytics).
- `~70` `data-testid` attributes added across components (pure attribute additions, no logic changes).
- A few small store-level helpers (\`__e2e*\`) so tests can drive right-click/dialog flows that WebKitWebDriver can't reach reliably.

## How to run

```bash
make e2e                # full suite, ~140s
make e2e-shell          # interactive shell in the runner for debugging
make e2e-clean          # nuke image + volumes
```

Connect any VNC viewer to \`localhost:5900\` while a run is in progress to watch it live.

## Test plan

- [x] \`make e2e\` runs clean on a fresh checkout
- [x] \`tests/e2e/report.md\` shows 56/56
- [x] Spot-check a couple of mp4s under \`tests/e2e/videos/\`
- [x] Manually exercise the four app changes (record-on-connect, S3 reopen, F2 rename, ANYSCP_DISABLE_TELEMETRY)