### PR TITLE
feat(scp): SCP transport with transparent SFTP→SCP fallback

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,10 @@
         logs-ssh-pass logs-ssh-key \
         shell-ssh-pass shell-ssh-key \
         ssh-keygen ssh-status ssh-clean ssh-clean-keys \
+        scp-build start-scp-pass start-scp-key stop-scp-pass stop-scp-key \
+        connect-scp-pass connect-scp-key \
+        logs-scp-pass logs-scp-key \
+        shell-scp-pass shell-scp-key scp-clean-image \
         e2e e2e-build e2e-shell e2e-logs e2e-clean
 
 # Test SSH servers (linuxserver/openssh-server) for local development.
@@ -23,6 +27,19 @@ SSH_KEY_PORT       := 2223
 SSH_KEY_DIR        := .test-ssh
 SSH_KEY            := $(SSH_KEY_DIR)/id_ed25519
 SSH_PUB_KEY        := $(SSH_KEY).pub
+
+# SCP-only test server (extends linuxserver/openssh-server with SFTP stripped).
+SCP_IMAGE          := anyscp-test-scp-only:latest
+SCP_IMAGE_STAMP    := tests/scp-server/.image-stamp
+SCP_IMAGE_SRC      := tests/scp-server/Dockerfile tests/scp-server/disable-sftp.sh
+
+# SCP-only password container
+SSH_SCP_PASS_CONTAINER := anyscp-test-scp-pass
+SSH_SCP_PASS_PORT      := 2224
+
+# SCP-only key container
+SSH_SCP_KEY_CONTAINER  := anyscp-test-scp-key
+SSH_SCP_KEY_PORT       := 2225
 
 # ─── Keypair ──────────────────────────────────────────────────────────────────
 
@@ -117,14 +134,120 @@ logs-ssh-key:
 shell-ssh-key:
 	@docker exec -it $(SSH_KEY_CONTAINER) /bin/sh
 
+# ─── SCP-only image ───────────────────────────────────────────────────────────
+# Built from tests/scp-server/. Rebuilt automatically whenever the Dockerfile
+# or the init script change.
+
+$(SCP_IMAGE_STAMP): $(SCP_IMAGE_SRC)
+	@echo "  building $(SCP_IMAGE) (sources changed)"
+	@cd tests/scp-server && docker build -t $(SCP_IMAGE) .
+	@touch $@
+
+scp-build: $(SCP_IMAGE_STAMP)
+
+# ─── SCP-only password container ──────────────────────────────────────────────
+
+start-scp-pass: $(SCP_IMAGE_STAMP)
+	@if [ "$$(docker ps -aq -f name=^/$(SSH_SCP_PASS_CONTAINER)$$)" ]; then \
+		echo "Starting existing container $(SSH_SCP_PASS_CONTAINER)..."; \
+		docker start $(SSH_SCP_PASS_CONTAINER) >/dev/null; \
+	else \
+		echo "Creating container $(SSH_SCP_PASS_CONTAINER) on port $(SSH_SCP_PASS_PORT)..."; \
+		docker run -d \
+			--name $(SSH_SCP_PASS_CONTAINER) \
+			-p $(SSH_SCP_PASS_PORT):2222 \
+			-e PUID=1000 \
+			-e PGID=1000 \
+			-e TZ=Etc/UTC \
+			-e USER_NAME=$(SSH_USER) \
+			-e USER_PASSWORD=$(SSH_PASSWORD) \
+			-e PASSWORD_ACCESS=true \
+			-e SUDO_ACCESS=true \
+			$(SCP_IMAGE) >/dev/null; \
+	fi
+	@echo ""
+	@echo "  SCP-only (password) server running at:"
+	@echo "    Host:     localhost"
+	@echo "    Port:     $(SSH_SCP_PASS_PORT)"
+	@echo "    User:     $(SSH_USER)"
+	@echo "    Password: $(SSH_PASSWORD)"
+	@echo "    SFTP:     disabled (Subsystem stripped)"
+	@echo ""
+	@echo "  SCP (legacy proto): scp -O -P $(SSH_SCP_PASS_PORT) FILE $(SSH_USER)@localhost:"
+	@echo "  SFTP (should fail): sftp -P $(SSH_SCP_PASS_PORT) $(SSH_USER)@localhost"
+
+stop-scp-pass:
+	@docker stop $(SSH_SCP_PASS_CONTAINER) >/dev/null 2>&1 && echo "Stopped $(SSH_SCP_PASS_CONTAINER)" || echo "$(SSH_SCP_PASS_CONTAINER) not running"
+
+connect-scp-pass:
+	@ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p $(SSH_SCP_PASS_PORT) $(SSH_USER)@localhost
+
+logs-scp-pass:
+	@docker logs -f $(SSH_SCP_PASS_CONTAINER)
+
+shell-scp-pass:
+	@docker exec -it $(SSH_SCP_PASS_CONTAINER) /bin/sh
+
+# ─── SCP-only key container ───────────────────────────────────────────────────
+
+start-scp-key: $(SCP_IMAGE_STAMP) $(SSH_KEY)
+	@if [ "$$(docker ps -aq -f name=^/$(SSH_SCP_KEY_CONTAINER)$$)" ]; then \
+		echo "Starting existing container $(SSH_SCP_KEY_CONTAINER)..."; \
+		docker start $(SSH_SCP_KEY_CONTAINER) >/dev/null; \
+	else \
+		echo "Creating container $(SSH_SCP_KEY_CONTAINER) on port $(SSH_SCP_KEY_PORT)..."; \
+		docker run -d \
+			--name $(SSH_SCP_KEY_CONTAINER) \
+			-p $(SSH_SCP_KEY_PORT):2222 \
+			-e PUID=1000 \
+			-e PGID=1000 \
+			-e TZ=Etc/UTC \
+			-e USER_NAME=$(SSH_USER) \
+			-e PASSWORD_ACCESS=false \
+			-e SUDO_ACCESS=true \
+			-e PUBLIC_KEY="$$(cat $(SSH_PUB_KEY))" \
+			$(SCP_IMAGE) >/dev/null; \
+	fi
+	@echo ""
+	@echo "  SCP-only (key) server running at:"
+	@echo "    Host: localhost"
+	@echo "    Port: $(SSH_SCP_KEY_PORT)"
+	@echo "    User: $(SSH_USER)"
+	@echo "    Key:  $(SSH_KEY)"
+	@echo "    SFTP: disabled (Subsystem stripped)"
+	@echo ""
+	@echo "  SCP (legacy proto): scp -O -i $(SSH_KEY) -P $(SSH_SCP_KEY_PORT) FILE $(SSH_USER)@localhost:"
+
+stop-scp-key:
+	@docker stop $(SSH_SCP_KEY_CONTAINER) >/dev/null 2>&1 && echo "Stopped $(SSH_SCP_KEY_CONTAINER)" || echo "$(SSH_SCP_KEY_CONTAINER) not running"
+
+connect-scp-key: $(SSH_KEY)
+	@ssh -i $(SSH_KEY) -o IdentitiesOnly=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p $(SSH_SCP_KEY_PORT) $(SSH_USER)@localhost
+
+logs-scp-key:
+	@docker logs -f $(SSH_SCP_KEY_CONTAINER)
+
+shell-scp-key:
+	@docker exec -it $(SSH_SCP_KEY_CONTAINER) /bin/sh
+
 # ─── Combined status / cleanup ────────────────────────────────────────────────
 
 ssh-status:
-	@docker ps -a -f name=^/$(SSH_PASS_CONTAINER)$$ -f name=^/$(SSH_KEY_CONTAINER)$$
+	@docker ps -a \
+		-f name=^/$(SSH_PASS_CONTAINER)$$ \
+		-f name=^/$(SSH_KEY_CONTAINER)$$ \
+		-f name=^/$(SSH_SCP_PASS_CONTAINER)$$ \
+		-f name=^/$(SSH_SCP_KEY_CONTAINER)$$
 
 ssh-clean:
-	@docker rm -f $(SSH_PASS_CONTAINER) >/dev/null 2>&1 && echo "Removed $(SSH_PASS_CONTAINER)" || echo "$(SSH_PASS_CONTAINER) not present"
-	@docker rm -f $(SSH_KEY_CONTAINER)  >/dev/null 2>&1 && echo "Removed $(SSH_KEY_CONTAINER)"  || echo "$(SSH_KEY_CONTAINER) not present"
+	@docker rm -f $(SSH_PASS_CONTAINER)     >/dev/null 2>&1 && echo "Removed $(SSH_PASS_CONTAINER)"     || echo "$(SSH_PASS_CONTAINER) not present"
+	@docker rm -f $(SSH_KEY_CONTAINER)      >/dev/null 2>&1 && echo "Removed $(SSH_KEY_CONTAINER)"      || echo "$(SSH_KEY_CONTAINER) not present"
+	@docker rm -f $(SSH_SCP_PASS_CONTAINER) >/dev/null 2>&1 && echo "Removed $(SSH_SCP_PASS_CONTAINER)" || echo "$(SSH_SCP_PASS_CONTAINER) not present"
+	@docker rm -f $(SSH_SCP_KEY_CONTAINER)  >/dev/null 2>&1 && echo "Removed $(SSH_SCP_KEY_CONTAINER)"  || echo "$(SSH_SCP_KEY_CONTAINER) not present"
+
+scp-clean-image:
+	@docker rmi $(SCP_IMAGE) 2>/dev/null && echo "Removed $(SCP_IMAGE)" || echo "$(SCP_IMAGE) not present"
+	@rm -f $(SCP_IMAGE_STAMP)
 
 ssh-clean-keys:
 	@rm -rf $(SSH_KEY_DIR) && echo "Removed $(SSH_KEY_DIR)"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,6 +3,7 @@ mod db;
 mod import;
 mod portforward;
 mod s3;
+mod scp;
 mod sftp;
 mod snippets;
 mod ssh;
@@ -11,6 +12,8 @@ mod types;
 mod vault;
 
 use db::HostDb;
+use scp::ScpManager;
+use scp::transfer_manager::ScpTransferManager;
 use sftp::SftpManager;
 use sftp::transfer_manager::TransferManager;
 use portforward::manager::PortForwardManager;
@@ -50,6 +53,16 @@ pub fn run() {
             ));
             app.manage(sftp_manager);
             app.manage(transfer_manager);
+
+            // SCP shares the SSH connection but tracks its own sessions and
+            // transfer queue, mirroring the SFTP managers.
+            let scp_manager = Arc::new(ScpManager::new());
+            let scp_transfer_manager = Arc::new(ScpTransferManager::new(
+                scp_manager.clone(),
+                app.handle().clone(),
+            ));
+            app.manage(scp_manager);
+            app.manage(scp_transfer_manager);
 
             let pf_manager = Arc::new(PortForwardManager::new(app.handle().clone()));
             app.manage(pf_manager);
@@ -92,6 +105,31 @@ pub fn run() {
             sftp::commands::sftp_list_transfers,
             sftp::commands::sftp_clear_finished_transfers,
             sftp::commands::sftp_set_concurrency,
+            // SCP — session & filesystem (mirrors SFTP; used as a fallback
+            // when the remote has the SFTP subsystem disabled)
+            scp::commands::scp_open,
+            scp::commands::scp_close,
+            scp::commands::scp_list_dir,
+            scp::commands::scp_home_dir,
+            scp::commands::scp_mkdir,
+            scp::commands::scp_create_file,
+            scp::commands::scp_delete,
+            scp::commands::scp_rename,
+            // SCP — copy / move
+            scp::commands::scp_move_entries,
+            scp::commands::scp_copy_entries,
+            // SCP — direct transfers (edit-in-vscode workflow)
+            scp::commands::scp_download,
+            scp::commands::scp_upload,
+            scp::commands::scp_cancel_transfer,
+            scp::commands::scp_edit_in_vscode,
+            // SCP — queue-based Transfer Manager
+            scp::commands::scp_enqueue_upload,
+            scp::commands::scp_enqueue_download,
+            scp::commands::scp_retry_transfer,
+            scp::commands::scp_list_transfers,
+            scp::commands::scp_clear_finished_transfers,
+            scp::commands::scp_set_concurrency,
             // SSH
             ssh::commands::ssh_connect,
             ssh::commands::ssh_split_session,

--- a/src-tauri/src/scp/commands.rs
+++ b/src-tauri/src/scp/commands.rs
@@ -52,17 +52,21 @@ pub async fn scp_open(
         ));
     }
 
+    // Detect the remote userland once so listings use the right command.
+    let flavor = exec::detect_flavor(handle.clone()).await.unwrap_or_default();
+
     let scp_id = uuid::Uuid::new_v4().to_string();
     scp_manager.insert_session(
         scp_id.clone(),
         ScpSessionWrapper {
             ssh_session_id: session_id,
             ssh_handle: handle,
+            flavor,
         },
     );
 
-    tracing::info!(scp_session_id = %scp_id, "SCP session opened");
-    crate::telemetry::capture("scp_opened", serde_json::json!({}));
+    tracing::info!(scp_session_id = %scp_id, flavor = %flavor.as_str(), "SCP session opened");
+    crate::telemetry::capture("scp_opened", serde_json::json!({ "flavor": flavor.as_str() }));
     Ok(scp_id)
 }
 
@@ -82,14 +86,22 @@ pub async fn scp_close(
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
+type SshHandle =
+    Arc<tokio::sync::Mutex<russh::client::Handle<crate::ssh::handler::SshClientHandler>>>;
+
 /// Resolve the SSH handle behind an SCP session id.
-fn handle_for(
-    scp_manager: &Arc<ScpManager>,
-    scp_session_id: &str,
-) -> Result<Arc<tokio::sync::Mutex<russh::client::Handle<crate::ssh::handler::SshClientHandler>>>, ScpError>
-{
+fn handle_for(scp_manager: &Arc<ScpManager>, scp_session_id: &str) -> Result<SshHandle, ScpError> {
     let session = scp_manager.get_session(scp_session_id)?;
     Ok(session.ssh_handle.clone())
+}
+
+/// Resolve both the SSH handle and the detected userland flavor.
+fn handle_and_flavor(
+    scp_manager: &Arc<ScpManager>,
+    scp_session_id: &str,
+) -> Result<(SshHandle, super::listing::Flavor), ScpError> {
+    let session = scp_manager.get_session(scp_session_id)?;
+    Ok((session.ssh_handle.clone(), session.flavor))
 }
 
 // ─── Directory operations ─────────────────────────────────────────────────────
@@ -101,8 +113,8 @@ pub async fn scp_list_dir(
     path: String,
     scp_manager: State<'_, Arc<ScpManager>>,
 ) -> Result<Vec<ScpEntry>, ScpError> {
-    let handle = handle_for(&scp_manager, &scp_session_id)?;
-    exec::list_dir(handle, &path).await
+    let (handle, flavor) = handle_and_flavor(&scp_manager, &scp_session_id)?;
+    exec::list_dir(handle, flavor, &path).await
 }
 
 #[tauri::command]

--- a/src-tauri/src/scp/commands.rs
+++ b/src-tauri/src/scp/commands.rs
@@ -1,0 +1,586 @@
+//! Tauri commands exposed to the frontend. These mirror the SFTP command
+//! surface 1:1 (same arguments, same return shapes) so the Explorer UI can
+//! dispatch to either backend purely on the tab's transport kind.
+//!
+//! SCP has no native filesystem operations, so listing / mkdir / delete /
+//! rename / copy / move are implemented by exec'ing POSIX commands on the
+//! same SSH connection (see [`super::exec`]); transfers use the SCP wire
+//! protocol (see [`super::transfer`]).
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use tauri::{AppHandle, Emitter, State};
+use tokio_util::sync::CancellationToken;
+use tracing::instrument;
+
+use crate::ssh::manager::SshManager;
+
+use super::transfer_manager::ScpTransferManager;
+use super::{
+    exec, transfer, ScpEntry, ScpError, ScpManager, ScpSessionWrapper, TransferDirection,
+    TransferInfo, TransferProgress, TransferStatus,
+};
+
+// ─── Open / Close ────────────────────────────────────────────────────────────
+
+/// Register an "SCP session" over an existing SSH connection.
+///
+/// Unlike SFTP there is no subsystem to negotiate — SCP just exec's `scp`
+/// on demand — so this only validates that the SSH session exists and that
+/// the remote has a working `scp` binary, then stores a handle reference.
+///
+/// Returns a fresh `scp_session_id`.
+#[tauri::command]
+#[instrument(skip(ssh_manager, scp_manager), fields(ssh_session_id = %session_id))]
+pub async fn scp_open(
+    session_id: String,
+    ssh_manager: State<'_, SshManager>,
+    scp_manager: State<'_, Arc<ScpManager>>,
+) -> Result<String, ScpError> {
+    let handle = ssh_manager
+        .get_handle(&session_id)
+        .map_err(|e| ScpError::SshSessionNotFound(e.to_string()))?;
+
+    // Probe for a usable scp binary up front so we fail fast with a clear
+    // message rather than on the first transfer.
+    let probe = exec::ssh_exec(handle.clone(), "command -v scp >/dev/null 2>&1; echo $?").await?;
+    let code = String::from_utf8_lossy(&probe.0);
+    if code.trim() != "0" {
+        return Err(ScpError::RemoteError(
+            "remote host has no 'scp' binary on PATH".into(),
+        ));
+    }
+
+    let scp_id = uuid::Uuid::new_v4().to_string();
+    scp_manager.insert_session(
+        scp_id.clone(),
+        ScpSessionWrapper {
+            ssh_session_id: session_id,
+            ssh_handle: handle,
+        },
+    );
+
+    tracing::info!(scp_session_id = %scp_id, "SCP session opened");
+    crate::telemetry::capture("scp_opened", serde_json::json!({}));
+    Ok(scp_id)
+}
+
+/// Forget an SCP session. (No remote teardown — SCP is connectionless on top
+/// of the shared SSH session, which is closed separately.)
+#[tauri::command]
+#[instrument(skip(scp_manager), fields(scp_session_id = %scp_session_id))]
+pub async fn scp_close(
+    scp_session_id: String,
+    scp_manager: State<'_, Arc<ScpManager>>,
+) -> Result<(), ScpError> {
+    scp_manager.remove_session(&scp_session_id);
+    tracing::info!(scp_session_id = %scp_session_id, "SCP session closed");
+    crate::telemetry::capture("scp_closed", serde_json::json!({}));
+    Ok(())
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/// Resolve the SSH handle behind an SCP session id.
+fn handle_for(
+    scp_manager: &Arc<ScpManager>,
+    scp_session_id: &str,
+) -> Result<Arc<tokio::sync::Mutex<russh::client::Handle<crate::ssh::handler::SshClientHandler>>>, ScpError>
+{
+    let session = scp_manager.get_session(scp_session_id)?;
+    Ok(session.ssh_handle.clone())
+}
+
+// ─── Directory operations ─────────────────────────────────────────────────────
+
+#[tauri::command]
+#[instrument(skip(scp_manager), fields(scp_session_id = %scp_session_id, path = %path))]
+pub async fn scp_list_dir(
+    scp_session_id: String,
+    path: String,
+    scp_manager: State<'_, Arc<ScpManager>>,
+) -> Result<Vec<ScpEntry>, ScpError> {
+    let handle = handle_for(&scp_manager, &scp_session_id)?;
+    exec::list_dir(handle, &path).await
+}
+
+#[tauri::command]
+#[instrument(skip(scp_manager), fields(scp_session_id = %scp_session_id))]
+pub async fn scp_home_dir(
+    scp_session_id: String,
+    scp_manager: State<'_, Arc<ScpManager>>,
+) -> Result<String, ScpError> {
+    let handle = handle_for(&scp_manager, &scp_session_id)?;
+    exec::home_dir(handle).await
+}
+
+#[tauri::command]
+#[instrument(skip(scp_manager), fields(scp_session_id = %scp_session_id, path = %path))]
+pub async fn scp_mkdir(
+    scp_session_id: String,
+    path: String,
+    scp_manager: State<'_, Arc<ScpManager>>,
+) -> Result<(), ScpError> {
+    let handle = handle_for(&scp_manager, &scp_session_id)?;
+    let result = exec::mkdir_p(handle, &path).await;
+    if result.is_ok() {
+        crate::telemetry::capture("scp_dir_created", serde_json::json!({}));
+    }
+    result
+}
+
+#[tauri::command]
+#[instrument(skip(scp_manager), fields(scp_session_id = %scp_session_id, path = %path))]
+pub async fn scp_create_file(
+    scp_session_id: String,
+    path: String,
+    scp_manager: State<'_, Arc<ScpManager>>,
+) -> Result<(), ScpError> {
+    let handle = handle_for(&scp_manager, &scp_session_id)?;
+    let result = exec::touch(handle, &path).await;
+    if result.is_ok() {
+        crate::telemetry::capture("scp_file_created", serde_json::json!({}));
+    }
+    result
+}
+
+#[tauri::command]
+#[instrument(skip(scp_manager), fields(scp_session_id = %scp_session_id, path = %path))]
+pub async fn scp_delete(
+    scp_session_id: String,
+    path: String,
+    is_dir: bool,
+    scp_manager: State<'_, Arc<ScpManager>>,
+) -> Result<(), ScpError> {
+    let handle = handle_for(&scp_manager, &scp_session_id)?;
+    let result = exec::remove(handle, &path, is_dir).await;
+    if result.is_ok() {
+        crate::telemetry::capture("scp_entry_deleted", serde_json::json!({ "is_dir": is_dir }));
+    }
+    result
+}
+
+#[tauri::command]
+#[instrument(skip(scp_manager), fields(scp_session_id = %scp_session_id))]
+pub async fn scp_rename(
+    scp_session_id: String,
+    old_path: String,
+    new_path: String,
+    scp_manager: State<'_, Arc<ScpManager>>,
+) -> Result<(), ScpError> {
+    let handle = handle_for(&scp_manager, &scp_session_id)?;
+    let result = exec::rename(handle, &old_path, &new_path).await;
+    if result.is_ok() {
+        crate::telemetry::capture("scp_entry_renamed", serde_json::json!({}));
+    }
+    result
+}
+
+// ─── Copy / Move ──────────────────────────────────────────────────────────────
+
+/// Join a directory and a (deduplicated) entry name.
+fn join_remote(dir: &str, name: &str) -> String {
+    if dir == "/" {
+        format!("/{name}")
+    } else {
+        format!("{dir}/{name}")
+    }
+}
+
+#[tauri::command]
+#[instrument(skip(scp_manager), fields(scp_session_id = %scp_session_id))]
+pub async fn scp_move_entries(
+    scp_session_id: String,
+    source_paths: Vec<String>,
+    target_dir: String,
+    scp_manager: State<'_, Arc<ScpManager>>,
+) -> Result<Vec<String>, ScpError> {
+    let handle = handle_for(&scp_manager, &scp_session_id)?;
+    let mut new_paths = Vec::with_capacity(source_paths.len());
+
+    for source in &source_paths {
+        let name = std::path::Path::new(source)
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_else(|| "unknown".to_string());
+
+        // Prevent moving a directory into itself.
+        if target_dir.starts_with(source.as_str()) && source.contains('/') {
+            return Err(ScpError::RemoteIoError(format!(
+                "Cannot move {source} into itself"
+            )));
+        }
+
+        let deduped = exec::deduplicate_name(handle.clone(), &target_dir, &name).await?;
+        let dest = join_remote(&target_dir, &deduped);
+        exec::rename(handle.clone(), source, &dest).await?;
+        new_paths.push(dest);
+    }
+
+    crate::telemetry::capture("scp_entries_moved", serde_json::json!({ "count": source_paths.len() }));
+    Ok(new_paths)
+}
+
+#[tauri::command]
+#[instrument(skip(scp_manager), fields(scp_session_id = %scp_session_id))]
+pub async fn scp_copy_entries(
+    scp_session_id: String,
+    source_paths: Vec<String>,
+    target_dir: String,
+    scp_manager: State<'_, Arc<ScpManager>>,
+) -> Result<Vec<String>, ScpError> {
+    let handle = handle_for(&scp_manager, &scp_session_id)?;
+    let mut new_paths = Vec::with_capacity(source_paths.len());
+
+    for source in &source_paths {
+        let name = std::path::Path::new(source)
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_else(|| "unknown".to_string());
+
+        let deduped = exec::deduplicate_name(handle.clone(), &target_dir, &name).await?;
+        let dest = join_remote(&target_dir, &deduped);
+        // `cp -r` handles both files and directories.
+        exec::copy(handle.clone(), source, &dest).await?;
+        new_paths.push(dest);
+    }
+
+    crate::telemetry::capture("scp_entries_copied", serde_json::json!({ "count": source_paths.len() }));
+    Ok(new_paths)
+}
+
+// ─── Direct transfers (legacy single-file, used by edit-in-vscode) ────────────
+
+#[tauri::command]
+#[instrument(skip(scp_manager, app_handle), fields(scp_session_id = %scp_session_id))]
+pub async fn scp_download(
+    scp_session_id: String,
+    remote_path: String,
+    local_path: String,
+    scp_manager: State<'_, Arc<ScpManager>>,
+    app_handle: AppHandle,
+) -> Result<String, ScpError> {
+    let handle = handle_for(&scp_manager, &scp_session_id)?;
+
+    let transfer_id = uuid::Uuid::new_v4().to_string();
+    let token = CancellationToken::new();
+    let manager = Arc::clone(&scp_manager);
+    manager.insert_transfer(transfer_id.clone(), token.clone());
+
+    let tid = transfer_id.clone();
+    let sid = scp_session_id.clone();
+
+    tokio::spawn(async move {
+        let file_name = std::path::Path::new(&remote_path)
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_else(|| remote_path.clone());
+
+        let result = transfer::download_file(
+            handle,
+            &remote_path,
+            std::path::Path::new(&local_path),
+            &token,
+            |_| {},
+        )
+        .await;
+
+        manager.remove_transfer(&tid);
+
+        let status = match result {
+            Ok(()) => TransferStatus::Completed,
+            Err(ScpError::TransferCancelled) => TransferStatus::Cancelled,
+            Err(e) => TransferStatus::Failed(e.to_string()),
+        };
+        let _ = app_handle.emit(
+            "scp:progress",
+            &TransferProgress {
+                transfer_id: tid,
+                scp_session_id: sid,
+                file_name,
+                direction: TransferDirection::Download,
+                bytes_transferred: 0,
+                total_bytes: 0,
+                status,
+            },
+        );
+    });
+
+    Ok(transfer_id)
+}
+
+#[tauri::command]
+#[instrument(skip(scp_manager, app_handle), fields(scp_session_id = %scp_session_id))]
+pub async fn scp_upload(
+    scp_session_id: String,
+    local_path: String,
+    remote_path: String,
+    scp_manager: State<'_, Arc<ScpManager>>,
+    app_handle: AppHandle,
+) -> Result<String, ScpError> {
+    let handle = handle_for(&scp_manager, &scp_session_id)?;
+
+    let transfer_id = uuid::Uuid::new_v4().to_string();
+    let token = CancellationToken::new();
+    let manager = Arc::clone(&scp_manager);
+    manager.insert_transfer(transfer_id.clone(), token.clone());
+
+    let tid = transfer_id.clone();
+    let sid = scp_session_id.clone();
+
+    tokio::spawn(async move {
+        let file_name = std::path::Path::new(&local_path)
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_else(|| local_path.clone());
+
+        // Ensure the remote parent dir exists before the sink starts.
+        let parent = std::path::Path::new(&remote_path)
+            .parent()
+            .map(|p| p.to_string_lossy().to_string())
+            .filter(|p| !p.is_empty() && p != "/");
+        let result = async {
+            if let Some(parent) = parent {
+                exec::mkdir_p(handle.clone(), &parent).await?;
+            }
+            transfer::upload_file(
+                handle,
+                std::path::Path::new(&local_path),
+                &remote_path,
+                &token,
+                |_| {},
+            )
+            .await
+        }
+        .await;
+
+        manager.remove_transfer(&tid);
+
+        let status = match result {
+            Ok(()) => TransferStatus::Completed,
+            Err(ScpError::TransferCancelled) => TransferStatus::Cancelled,
+            Err(e) => TransferStatus::Failed(e.to_string()),
+        };
+        let _ = app_handle.emit(
+            "scp:progress",
+            &TransferProgress {
+                transfer_id: tid,
+                scp_session_id: sid,
+                file_name,
+                direction: TransferDirection::Upload,
+                bytes_transferred: 0,
+                total_bytes: 0,
+                status,
+            },
+        );
+    });
+
+    Ok(transfer_id)
+}
+
+#[tauri::command]
+#[instrument(skip(scp_manager, transfer_manager), fields(transfer_id = %transfer_id))]
+pub async fn scp_cancel_transfer(
+    transfer_id: String,
+    scp_manager: State<'_, Arc<ScpManager>>,
+    transfer_manager: State<'_, Arc<ScpTransferManager>>,
+) -> Result<(), ScpError> {
+    if transfer_manager.cancel(&transfer_id).is_ok() {
+        return Ok(());
+    }
+    scp_manager.cancel_transfer(&transfer_id)
+}
+
+/// Download a remote file to a temp dir, open it in VS Code, and re-upload on
+/// each save. Mirrors `sftp_edit_in_vscode` but over SCP.
+#[tauri::command]
+#[instrument(skip(scp_manager, app_handle), fields(scp_session_id = %scp_session_id, remote_path = %remote_path))]
+pub async fn scp_edit_in_vscode(
+    scp_session_id: String,
+    remote_path: String,
+    scp_manager: State<'_, Arc<ScpManager>>,
+    app_handle: AppHandle,
+) -> Result<(), ScpError> {
+    let handle = handle_for(&scp_manager, &scp_session_id)?;
+
+    let file_name = std::path::Path::new(&remote_path)
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_else(|| "file".to_string());
+
+    let temp_dir = std::env::temp_dir().join("anyscp-edit");
+    tokio::fs::create_dir_all(&temp_dir)
+        .await
+        .map_err(|e| ScpError::LocalIoError(e.to_string()))?;
+    let local_path = temp_dir.join(&file_name);
+
+    // 1. Download the file.
+    let token = CancellationToken::new();
+    transfer::download_file(handle.clone(), &remote_path, &local_path, &token, |_| {}).await?;
+
+    // 2. Open VS Code (non-blocking).
+    tokio::process::Command::new("code")
+        .arg(&local_path)
+        .spawn()
+        .map_err(|e| {
+            ScpError::LocalIoError(format!("Failed to open VS Code: {e}. Is 'code' in your PATH?"))
+        })?;
+
+    crate::telemetry::capture("edit_in_vscode", serde_json::json!({ "source": "scp" }));
+
+    // 3. Watch for saves and re-upload (best-effort, 30-minute window).
+    let handle_bg = handle.clone();
+    let remote_path_bg = remote_path.clone();
+    let local_path_bg = local_path.clone();
+    let app_handle_bg = app_handle.clone();
+    let sid = scp_session_id.clone();
+
+    tokio::task::spawn_blocking(move || {
+        use notify::{Config, Event, EventKind, RecursiveMode, Watcher};
+        use std::sync::mpsc;
+
+        let (tx, rx) = mpsc::channel::<Event>();
+        let mut watcher = notify::RecommendedWatcher::new(
+            move |res: Result<Event, notify::Error>| {
+                if let Ok(event) = res {
+                    let _ = tx.send(event);
+                }
+            },
+            Config::default(),
+        )
+        .expect("Failed to create file watcher");
+        watcher
+            .watch(&local_path_bg, RecursiveMode::NonRecursive)
+            .expect("Failed to watch file");
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30 * 60);
+
+        loop {
+            match rx.recv_timeout(std::time::Duration::from_secs(5)) {
+                Ok(event) => {
+                    let is_write = matches!(
+                        event.kind,
+                        EventKind::Modify(notify::event::ModifyKind::Data(_))
+                            | EventKind::Modify(notify::event::ModifyKind::Any)
+                    );
+                    if !is_write {
+                        continue;
+                    }
+                    std::thread::sleep(std::time::Duration::from_millis(300));
+
+                    let handle = handle_bg.clone();
+                    let remote_path = remote_path_bg.clone();
+                    let local_path = local_path_bg.clone();
+                    let app_handle = app_handle_bg.clone();
+                    let sid = sid.clone();
+                    let rt = tokio::runtime::Handle::current();
+                    rt.spawn(async move {
+                        let token = CancellationToken::new();
+                        match transfer::upload_file(handle, &local_path, &remote_path, &token, |_| {})
+                            .await
+                        {
+                            Ok(()) => {
+                                tracing::info!(remote_path = %remote_path, "File re-uploaded on save (scp)");
+                                let _ = app_handle.emit("scp:file-edited", &sid);
+                            }
+                            Err(e) => {
+                                tracing::error!(error = %e, "Failed to re-upload on save (scp)");
+                            }
+                        }
+                    });
+                }
+                Err(mpsc::RecvTimeoutError::Timeout) => {
+                    if std::time::Instant::now() > deadline {
+                        break;
+                    }
+                }
+                Err(mpsc::RecvTimeoutError::Disconnected) => break,
+            }
+        }
+        let _ = std::fs::remove_file(&local_path_bg);
+    });
+
+    Ok(())
+}
+
+// ─── Transfer Manager commands ─────────────────────────────────────────────────
+
+#[tauri::command]
+#[instrument(skip(transfer_manager), fields(scp_session_id = %scp_session_id))]
+pub async fn scp_enqueue_upload(
+    scp_session_id: String,
+    local_paths: Vec<String>,
+    remote_dir: String,
+    transfer_manager: State<'_, Arc<ScpTransferManager>>,
+) -> Result<Vec<String>, ScpError> {
+    let file_count = local_paths.len();
+    let paths: Vec<PathBuf> = local_paths.into_iter().map(PathBuf::from).collect();
+    let result = transfer_manager
+        .enqueue_upload(scp_session_id, paths, remote_dir)
+        .await;
+    if result.is_ok() {
+        crate::telemetry::capture("scp_upload_enqueued", serde_json::json!({ "file_count": file_count }));
+    }
+    result
+}
+
+#[tauri::command]
+#[instrument(skip(transfer_manager), fields(scp_session_id = %scp_session_id))]
+pub async fn scp_enqueue_download(
+    scp_session_id: String,
+    remote_paths: Vec<String>,
+    local_dir: String,
+    transfer_manager: State<'_, Arc<ScpTransferManager>>,
+) -> Result<Vec<String>, ScpError> {
+    let file_count = remote_paths.len();
+    let result = transfer_manager
+        .enqueue_download(scp_session_id, remote_paths, PathBuf::from(local_dir))
+        .await;
+    if result.is_ok() {
+        crate::telemetry::capture("scp_download_enqueued", serde_json::json!({ "file_count": file_count }));
+    }
+    result
+}
+
+#[tauri::command]
+#[instrument(skip(transfer_manager), fields(transfer_id = %transfer_id))]
+pub async fn scp_retry_transfer(
+    transfer_id: String,
+    transfer_manager: State<'_, Arc<ScpTransferManager>>,
+) -> Result<String, ScpError> {
+    transfer_manager.retry(&transfer_id)?;
+    Ok(transfer_id)
+}
+
+#[tauri::command]
+#[instrument(skip(transfer_manager))]
+pub async fn scp_list_transfers(
+    transfer_manager: State<'_, Arc<ScpTransferManager>>,
+) -> Result<Vec<TransferInfo>, ScpError> {
+    Ok(transfer_manager.list_all())
+}
+
+#[tauri::command]
+#[instrument(skip(transfer_manager))]
+pub async fn scp_clear_finished_transfers(
+    transfer_manager: State<'_, Arc<ScpTransferManager>>,
+) -> Result<(), ScpError> {
+    transfer_manager.clear_finished();
+    Ok(())
+}
+
+#[tauri::command]
+#[instrument(skip(transfer_manager), fields(max_concurrent = max_concurrent))]
+pub async fn scp_set_concurrency(
+    max_concurrent: u32,
+    transfer_manager: State<'_, Arc<ScpTransferManager>>,
+) -> Result<(), ScpError> {
+    if max_concurrent == 0 {
+        return Err(ScpError::ProtocolError(
+            "max_concurrent must be at least 1".to_string(),
+        ));
+    }
+    transfer_manager.set_max_concurrent(max_concurrent);
+    Ok(())
+}

--- a/src-tauri/src/scp/exec.rs
+++ b/src-tauri/src/scp/exec.rs
@@ -1,0 +1,465 @@
+//! Run shell commands on a fresh SSH session channel and capture
+//! stdout / stderr / exit code. Used by the SCP filesystem commands —
+//! SCP itself only does byte transfer; everything else (ls, mkdir, rm,
+//! mv, cp, touch, realpath) is implemented by exec'ing the equivalent
+//! POSIX command on the remote and parsing its output.
+//!
+//! Each call opens a new channel on the existing SSH connection. The
+//! channel is short-lived: open, exec, drain, close.
+
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+use russh::client::Handle;
+use russh::ChannelMsg;
+
+use crate::ssh::handler::SshClientHandler;
+
+use super::{format_permissions, shell_quote, ScpEntry, ScpEntryType, ScpError};
+
+/// Run `command` on the remote. Returns `(stdout, stderr, exit_code)`.
+pub async fn ssh_exec(
+    handle: Arc<Mutex<Handle<SshClientHandler>>>,
+    command: &str,
+) -> Result<(Vec<u8>, Vec<u8>, i32), ScpError> {
+    let mut channel = {
+        let h = handle.lock().await;
+        h.channel_open_session()
+            .await
+            .map_err(|e| ScpError::ChannelError(e.to_string()))?
+    };
+
+    channel
+        .exec(true, command.as_bytes())
+        .await
+        .map_err(|e| ScpError::ChannelError(format!("exec failed: {e}")))?;
+
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+    let mut exit_code: Option<i32> = None;
+
+    while let Some(msg) = channel.wait().await {
+        match msg {
+            ChannelMsg::Data { data } => stdout.extend_from_slice(&data),
+            ChannelMsg::ExtendedData { data, ext } => {
+                // ext = 1 is stderr per RFC 4254 §5.2.
+                if ext == 1 {
+                    stderr.extend_from_slice(&data);
+                }
+            }
+            ChannelMsg::ExitStatus { exit_status } => {
+                exit_code = Some(exit_status as i32);
+            }
+            ChannelMsg::Eof | ChannelMsg::Close => break,
+            _ => {}
+        }
+    }
+
+    // Some servers close without sending ExitStatus; treat as 0 then.
+    Ok((stdout, stderr, exit_code.unwrap_or(0)))
+}
+
+/// Run `command` and require exit code 0. Returns stdout. Errors include
+/// the captured stderr for diagnosis.
+pub async fn ssh_exec_ok(
+    handle: Arc<Mutex<Handle<SshClientHandler>>>,
+    command: &str,
+) -> Result<Vec<u8>, ScpError> {
+    let (stdout, stderr, exit) = ssh_exec(handle, command).await?;
+    if exit != 0 {
+        let stderr_str = String::from_utf8_lossy(&stderr).trim().to_string();
+        return Err(ScpError::CommandFailed {
+            exit_code: exit,
+            stderr: stderr_str,
+        });
+    }
+    Ok(stdout)
+}
+
+/// As [`ssh_exec_ok`] but expects UTF-8 stdout. Trims the trailing newline.
+pub async fn ssh_exec_str(
+    handle: Arc<Mutex<Handle<SshClientHandler>>>,
+    command: &str,
+) -> Result<String, ScpError> {
+    let stdout = ssh_exec_ok(handle, command).await?;
+    let mut s = String::from_utf8(stdout)
+        .map_err(|e| ScpError::ParseError(format!("non-UTF-8 stdout: {e}")))?;
+    while s.ends_with('\n') || s.ends_with('\r') {
+        s.pop();
+    }
+    Ok(s)
+}
+
+// ─── Filesystem ops ──────────────────────────────────────────────────────────
+
+/// Resolve the remote home directory by echoing `$HOME`.
+pub async fn home_dir(
+    handle: Arc<Mutex<Handle<SshClientHandler>>>,
+) -> Result<String, ScpError> {
+    let out = ssh_exec_str(handle, r#"printf '%s' "$HOME""#).await?;
+    if out.is_empty() {
+        return Err(ScpError::RemoteIoError("$HOME is empty".into()));
+    }
+    Ok(out)
+}
+
+/// Canonicalise a remote path (resolving `.`, `..`, symlinks). Available for
+/// the path bar to normalise user input; not yet wired into a command.
+#[allow(dead_code)]
+pub async fn realpath(
+    handle: Arc<Mutex<Handle<SshClientHandler>>>,
+    path: &str,
+) -> Result<String, ScpError> {
+    // -m is GNU-only and tolerates non-existent components. Fall back to
+    // -f (BSD/macOS `readlink -f`) if realpath is missing.
+    let cmd = format!(
+        "realpath -m {p} 2>/dev/null || readlink -f {p}",
+        p = shell_quote(path)
+    );
+    ssh_exec_str(handle, &cmd).await
+}
+
+/// `mkdir -p` on the remote.
+pub async fn mkdir_p(
+    handle: Arc<Mutex<Handle<SshClientHandler>>>,
+    path: &str,
+) -> Result<(), ScpError> {
+    let cmd = format!("mkdir -p -- {}", shell_quote(path));
+    ssh_exec_ok(handle, &cmd).await?;
+    Ok(())
+}
+
+/// `touch` a file (also creates parent dirs if needed via `mkdir -p`).
+pub async fn touch(
+    handle: Arc<Mutex<Handle<SshClientHandler>>>,
+    path: &str,
+) -> Result<(), ScpError> {
+    // Resolve parent. If the path has no slash, no parent is needed.
+    let parent = std::path::Path::new(path).parent().and_then(|p| {
+        let s = p.to_string_lossy();
+        if s.is_empty() || s == "/" {
+            None
+        } else {
+            Some(s.into_owned())
+        }
+    });
+    let cmd = match parent {
+        Some(p) => format!(
+            "mkdir -p -- {parent} && touch -- {file}",
+            parent = shell_quote(&p),
+            file = shell_quote(path),
+        ),
+        None => format!("touch -- {}", shell_quote(path)),
+    };
+    ssh_exec_ok(handle, &cmd).await?;
+    Ok(())
+}
+
+/// Remove a file (`rm`) or directory (`rm -rf`).
+pub async fn remove(
+    handle: Arc<Mutex<Handle<SshClientHandler>>>,
+    path: &str,
+    is_dir: bool,
+) -> Result<(), ScpError> {
+    let cmd = if is_dir {
+        format!("rm -rf -- {}", shell_quote(path))
+    } else {
+        format!("rm -- {}", shell_quote(path))
+    };
+    ssh_exec_ok(handle, &cmd).await?;
+    Ok(())
+}
+
+/// `mv src dst`.
+pub async fn rename(
+    handle: Arc<Mutex<Handle<SshClientHandler>>>,
+    src: &str,
+    dst: &str,
+) -> Result<(), ScpError> {
+    let cmd = format!("mv -- {} {}", shell_quote(src), shell_quote(dst));
+    ssh_exec_ok(handle, &cmd).await?;
+    Ok(())
+}
+
+/// `cp -r src dst` (no overwrite of existing destination — `cp` itself
+/// handles that with the same semantics as for files).
+pub async fn copy(
+    handle: Arc<Mutex<Handle<SshClientHandler>>>,
+    src: &str,
+    dst: &str,
+) -> Result<(), ScpError> {
+    let cmd = format!(
+        "cp -r -- {src} {dst}",
+        src = shell_quote(src),
+        dst = shell_quote(dst)
+    );
+    ssh_exec_ok(handle, &cmd).await?;
+    Ok(())
+}
+
+/// Stat a single path. Returns None when the path doesn't exist.
+pub async fn stat(
+    handle: Arc<Mutex<Handle<SshClientHandler>>>,
+    path: &str,
+) -> Result<Option<StatInfo>, ScpError> {
+    // %f = type letter (we don't use stat's %f for raw mode — `find -printf`
+    // does that better below). Use stat -c with type, mode, size, mtime.
+    let cmd = format!(
+        // Returns "<type>\t<mode_octal>\t<size>\t<mtime>" or non-zero exit if missing.
+        // `stat -c` is GNU; macOS uses -f with a different format. Stick with GNU.
+        "stat -c '%F\t%a\t%s\t%Y' -- {p} 2>/dev/null",
+        p = shell_quote(path)
+    );
+    let (stdout, _, exit) = ssh_exec(handle, &cmd).await?;
+    if exit != 0 {
+        return Ok(None);
+    }
+    let line = String::from_utf8_lossy(&stdout);
+    let line = line.trim_end_matches('\n');
+    if line.is_empty() {
+        return Ok(None);
+    }
+    let parts: Vec<&str> = line.split('\t').collect();
+    if parts.len() != 4 {
+        return Err(ScpError::ParseError(format!(
+            "stat: expected 4 fields, got {} in {line:?}",
+            parts.len()
+        )));
+    }
+    let type_str = parts[0];
+    let entry_type = match type_str {
+        "regular file" | "regular empty file" => ScpEntryType::File,
+        "directory" => ScpEntryType::Directory,
+        "symbolic link" => ScpEntryType::Symlink,
+        _ => ScpEntryType::Other,
+    };
+    let mode = u32::from_str_radix(parts[1], 8)
+        .map_err(|e| ScpError::ParseError(format!("stat: bad mode {:?}: {e}", parts[1])))?;
+    let size: u64 = parts[2]
+        .parse()
+        .map_err(|e| ScpError::ParseError(format!("stat: bad size {:?}: {e}", parts[2])))?;
+    let mtime: u64 = parts[3]
+        .parse()
+        .map_err(|e| ScpError::ParseError(format!("stat: bad mtime {:?}: {e}", parts[3])))?;
+
+    Ok(Some(StatInfo {
+        entry_type,
+        mode,
+        size,
+        mtime,
+    }))
+}
+
+#[derive(Debug, Clone)]
+pub struct StatInfo {
+    pub entry_type: ScpEntryType,
+    // mode/mtime are parsed for completeness; only entry_type and size are
+    // consumed today (by the download enqueue path).
+    #[allow(dead_code)]
+    pub mode: u32,
+    pub size: u64,
+    #[allow(dead_code)]
+    pub mtime: u64,
+}
+
+/// Whether a remote path exists. Used by deduplicate_name for copy/move.
+pub async fn exists(
+    handle: Arc<Mutex<Handle<SshClientHandler>>>,
+    path: &str,
+) -> Result<bool, ScpError> {
+    // `test -e` exits 0 if path exists, 1 otherwise. Any other exit is a
+    // genuine error (e.g. permission denied to the parent), which we map
+    // to the "doesn't exist" case to keep the dedup loop progressing —
+    // the subsequent rename/copy will surface the real error.
+    let cmd = format!("test -e {} && echo y || echo n", shell_quote(path));
+    let out = ssh_exec_str(handle, &cmd).await?;
+    Ok(out.trim() == "y")
+}
+
+// ─── Directory listing ──────────────────────────────────────────────────────
+
+/// List the contents of `dir` using GNU `find -printf` with NUL record
+/// separators. Each record: `<type>\t<mode_octal>\t<size>\t<mtime_seconds>\t<basename>\0`.
+///
+/// `<type>` is `f` (file), `d` (directory), `l` (symlink), `b/c/p/s` (other).
+pub async fn list_dir(
+    handle: Arc<Mutex<Handle<SshClientHandler>>>,
+    dir: &str,
+) -> Result<Vec<ScpEntry>, ScpError> {
+    let cmd = format!(
+        "find {dir} -mindepth 1 -maxdepth 1 -printf '%y\\t%m\\t%s\\t%T@\\t%f\\0'",
+        dir = shell_quote(dir)
+    );
+    let stdout = ssh_exec_ok(handle, &cmd).await?;
+
+    let mut entries = Vec::new();
+    for record in stdout.split(|b| *b == 0) {
+        if record.is_empty() {
+            continue;
+        }
+        let line = std::str::from_utf8(record)
+            .map_err(|e| ScpError::ParseError(format!("non-UTF-8 listing record: {e}")))?;
+        let parts: Vec<&str> = line.splitn(5, '\t').collect();
+        if parts.len() != 5 {
+            return Err(ScpError::ParseError(format!(
+                "listing record has {} fields, expected 5: {line:?}",
+                parts.len()
+            )));
+        }
+        let type_char = parts[0];
+        let mode_str = parts[1];
+        let size_str = parts[2];
+        let mtime_str = parts[3];
+        let name = parts[4];
+
+        let (entry_type, is_symlink) = match type_char {
+            "f" => (ScpEntryType::File, false),
+            "d" => (ScpEntryType::Directory, false),
+            "l" => (ScpEntryType::Symlink, true),
+            _ => (ScpEntryType::Other, false),
+        };
+
+        let permissions = u32::from_str_radix(mode_str, 8).unwrap_or(0) & 0o7777;
+        let size: u64 = size_str.parse().unwrap_or(0);
+        // mtime is a float ("1700000000.0000000000"). Take the integer part.
+        let modified: Option<u64> = mtime_str
+            .split('.')
+            .next()
+            .and_then(|s| s.parse().ok());
+
+        let full_path = if dir == "/" {
+            format!("/{name}")
+        } else {
+            format!("{dir}/{name}")
+        };
+
+        entries.push(ScpEntry {
+            name: name.to_string(),
+            path: full_path,
+            entry_type,
+            size,
+            permissions,
+            permissions_display: format_permissions(permissions),
+            modified,
+            is_symlink,
+        });
+    }
+
+    // Directories first, then alphabetical within each group.
+    entries.sort_by(|a, b| {
+        let a_dir = a.entry_type == ScpEntryType::Directory;
+        let b_dir = b.entry_type == ScpEntryType::Directory;
+        b_dir
+            .cmp(&a_dir)
+            .then_with(|| a.name.to_lowercase().cmp(&b.name.to_lowercase()))
+    });
+
+    Ok(entries)
+}
+
+/// One node in a recursive directory walk, with its path relative to the
+/// walk root.
+#[derive(Debug, Clone)]
+pub struct TreeEntry {
+    /// Path relative to the walk root (never starts with `/`).
+    pub rel_path: String,
+    pub is_dir: bool,
+    pub size: u64,
+}
+
+/// Recursively enumerate everything under `dir` (excluding `dir` itself),
+/// returning each node's path relative to `dir`. Directories first within the
+/// list isn't guaranteed — callers that need ordering should sort by depth.
+pub async fn enumerate_tree(
+    handle: Arc<Mutex<Handle<SshClientHandler>>>,
+    dir: &str,
+) -> Result<Vec<TreeEntry>, ScpError> {
+    // %y = type letter, %s = size, %P = path relative to the starting point.
+    let cmd = format!(
+        "find {dir} -mindepth 1 -printf '%y\\t%s\\t%P\\0'",
+        dir = shell_quote(dir)
+    );
+    let stdout = ssh_exec_ok(handle, &cmd).await?;
+
+    let mut entries = Vec::new();
+    for record in stdout.split(|b| *b == 0) {
+        if record.is_empty() {
+            continue;
+        }
+        let line = std::str::from_utf8(record)
+            .map_err(|e| ScpError::ParseError(format!("non-UTF-8 tree record: {e}")))?;
+        let parts: Vec<&str> = line.splitn(3, '\t').collect();
+        if parts.len() != 3 {
+            return Err(ScpError::ParseError(format!(
+                "tree record has {} fields, expected 3: {line:?}",
+                parts.len()
+            )));
+        }
+        let is_dir = parts[0] == "d";
+        let size: u64 = parts[1].parse().unwrap_or(0);
+        let rel_path = parts[2].to_string();
+        if rel_path.is_empty() {
+            continue;
+        }
+        entries.push(TreeEntry {
+            rel_path,
+            is_dir,
+            size,
+        });
+    }
+    Ok(entries)
+}
+
+/// Sum (total_bytes, file_count) under a remote directory in one `find` pass.
+pub async fn dir_stats(
+    handle: Arc<Mutex<Handle<SshClientHandler>>>,
+    dir: &str,
+) -> Result<(u64, u32), ScpError> {
+    let entries = enumerate_tree(handle, dir).await?;
+    let mut bytes = 0u64;
+    let mut count = 0u32;
+    for e in &entries {
+        if !e.is_dir {
+            bytes += e.size;
+            count += 1;
+        }
+    }
+    Ok((bytes, count))
+}
+
+/// Pick a name in `target_dir` that doesn't collide. Same semantics as the
+/// SFTP equivalent: appends ` (1)`, ` (2)`, ... before the file extension.
+pub async fn deduplicate_name(
+    handle: Arc<Mutex<Handle<SshClientHandler>>>,
+    target_dir: &str,
+    name: &str,
+) -> Result<String, ScpError> {
+    let base_path = if target_dir == "/" {
+        format!("/{name}")
+    } else {
+        format!("{target_dir}/{name}")
+    };
+
+    if !exists(handle.clone(), &base_path).await? {
+        return Ok(name.to_string());
+    }
+
+    let (stem, ext) = match name.rfind('.') {
+        Some(pos) if pos > 0 => (&name[..pos], &name[pos..]),
+        _ => (name, ""),
+    };
+
+    for i in 1u32..1000 {
+        let candidate = format!("{stem} ({i}){ext}");
+        let candidate_path = if target_dir == "/" {
+            format!("/{candidate}")
+        } else {
+            format!("{target_dir}/{candidate}")
+        };
+        if !exists(handle.clone(), &candidate_path).await? {
+            return Ok(candidate);
+        }
+    }
+
+    Ok(format!("{stem} (copy){ext}"))
+}

--- a/src-tauri/src/scp/exec.rs
+++ b/src-tauri/src/scp/exec.rs
@@ -15,7 +15,13 @@ use russh::ChannelMsg;
 
 use crate::ssh::handler::SshClientHandler;
 
-use super::{format_permissions, shell_quote, ScpEntry, ScpEntryType, ScpError};
+use super::listing::{self, Flavor};
+use super::{shell_quote, ScpEntry, ScpError};
+
+// Re-export so callers keep using `exec::StatInfo` / `exec::TreeEntry`.
+pub use super::listing::{StatInfo, TreeEntry};
+
+type SshHandle = Arc<Mutex<Handle<SshClientHandler>>>;
 
 /// Run `command` on the remote. Returns `(stdout, stderr, exit_code)`.
 pub async fn ssh_exec(
@@ -197,69 +203,42 @@ pub async fn copy(
     Ok(())
 }
 
+/// Detect the remote's userland once. GNU has `find -printf`; busybox lacks
+/// it but keeps `stat -c`; BSD/macOS have neither (only `stat -f`).
+pub async fn detect_flavor(handle: SshHandle) -> Result<Flavor, ScpError> {
+    let probe = "if find / -maxdepth 0 -printf '' >/dev/null 2>&1; then echo gnu; \
+                 elif stat -c '%s' / >/dev/null 2>&1; then echo busybox; \
+                 else echo bsd; fi";
+    let out = ssh_exec_str(handle, probe).await?;
+    Ok(Flavor::parse(&out).unwrap_or(Flavor::Gnu))
+}
+
 /// Stat a single path. Returns None when the path doesn't exist.
 pub async fn stat(
-    handle: Arc<Mutex<Handle<SshClientHandler>>>,
+    handle: SshHandle,
+    flavor: Flavor,
     path: &str,
 ) -> Result<Option<StatInfo>, ScpError> {
-    // %f = type letter (we don't use stat's %f for raw mode — `find -printf`
-    // does that better below). Use stat -c with type, mode, size, mtime.
-    let cmd = format!(
-        // Returns "<type>\t<mode_octal>\t<size>\t<mtime>" or non-zero exit if missing.
-        // `stat -c` is GNU; macOS uses -f with a different format. Stick with GNU.
-        "stat -c '%F\t%a\t%s\t%Y' -- {p} 2>/dev/null",
-        p = shell_quote(path)
-    );
+    let cmd = match flavor {
+        Flavor::Gnu | Flavor::Busybox => format!(
+            "stat -c '{fmt}' -- {p} 2>/dev/null",
+            fmt = listing::STATC_FMT,
+            p = shell_quote(path)
+        ),
+        Flavor::Bsd => format!(
+            "stat -f '{fmt}' -- {p} 2>/dev/null",
+            fmt = listing::STATF_FMT,
+            p = shell_quote(path)
+        ),
+    };
     let (stdout, _, exit) = ssh_exec(handle, &cmd).await?;
     if exit != 0 {
         return Ok(None);
     }
-    let line = String::from_utf8_lossy(&stdout);
-    let line = line.trim_end_matches('\n');
-    if line.is_empty() {
-        return Ok(None);
+    match flavor {
+        Flavor::Gnu | Flavor::Busybox => listing::parse_statc_single(&stdout),
+        Flavor::Bsd => listing::parse_statf_single(&stdout),
     }
-    let parts: Vec<&str> = line.split('\t').collect();
-    if parts.len() != 4 {
-        return Err(ScpError::ParseError(format!(
-            "stat: expected 4 fields, got {} in {line:?}",
-            parts.len()
-        )));
-    }
-    let type_str = parts[0];
-    let entry_type = match type_str {
-        "regular file" | "regular empty file" => ScpEntryType::File,
-        "directory" => ScpEntryType::Directory,
-        "symbolic link" => ScpEntryType::Symlink,
-        _ => ScpEntryType::Other,
-    };
-    let mode = u32::from_str_radix(parts[1], 8)
-        .map_err(|e| ScpError::ParseError(format!("stat: bad mode {:?}: {e}", parts[1])))?;
-    let size: u64 = parts[2]
-        .parse()
-        .map_err(|e| ScpError::ParseError(format!("stat: bad size {:?}: {e}", parts[2])))?;
-    let mtime: u64 = parts[3]
-        .parse()
-        .map_err(|e| ScpError::ParseError(format!("stat: bad mtime {:?}: {e}", parts[3])))?;
-
-    Ok(Some(StatInfo {
-        entry_type,
-        mode,
-        size,
-        mtime,
-    }))
-}
-
-#[derive(Debug, Clone)]
-pub struct StatInfo {
-    pub entry_type: ScpEntryType,
-    // mode/mtime are parsed for completeness; only entry_type and size are
-    // consumed today (by the download enqueue path).
-    #[allow(dead_code)]
-    pub mode: u32,
-    pub size: u64,
-    #[allow(dead_code)]
-    pub mtime: u64,
 }
 
 /// Whether a remote path exists. Used by deduplicate_name for copy/move.
@@ -278,144 +257,89 @@ pub async fn exists(
 
 // ─── Directory listing ──────────────────────────────────────────────────────
 
-/// List the contents of `dir` using GNU `find -printf` with NUL record
-/// separators. Each record: `<type>\t<mode_octal>\t<size>\t<mtime_seconds>\t<basename>\0`.
-///
-/// `<type>` is `f` (file), `d` (directory), `l` (symlink), `b/c/p/s` (other).
+/// List the immediate contents of `dir`, using the right command for the
+/// remote `flavor`:
+/// - GNU: one `find -printf` pass (NUL-delimited).
+/// - busybox: `find … -exec stat -c …` (busybox find has no `-printf`).
+/// - BSD/macOS: `find … -exec stat -f …`.
 pub async fn list_dir(
-    handle: Arc<Mutex<Handle<SshClientHandler>>>,
+    handle: SshHandle,
+    flavor: Flavor,
     dir: &str,
 ) -> Result<Vec<ScpEntry>, ScpError> {
-    let cmd = format!(
-        "find {dir} -mindepth 1 -maxdepth 1 -printf '%y\\t%m\\t%s\\t%T@\\t%f\\0'",
-        dir = shell_quote(dir)
-    );
-    let stdout = ssh_exec_ok(handle, &cmd).await?;
-
-    let mut entries = Vec::new();
-    for record in stdout.split(|b| *b == 0) {
-        if record.is_empty() {
-            continue;
+    let q = shell_quote(dir);
+    match flavor {
+        Flavor::Gnu => {
+            let cmd = format!(
+                "find {q} -mindepth 1 -maxdepth 1 -printf '{fmt}'",
+                fmt = listing::GNU_LISTING_PRINTF
+            );
+            let stdout = ssh_exec_ok(handle, &cmd).await?;
+            listing::parse_gnu_listing(&stdout, dir)
         }
-        let line = std::str::from_utf8(record)
-            .map_err(|e| ScpError::ParseError(format!("non-UTF-8 listing record: {e}")))?;
-        let parts: Vec<&str> = line.splitn(5, '\t').collect();
-        if parts.len() != 5 {
-            return Err(ScpError::ParseError(format!(
-                "listing record has {} fields, expected 5: {line:?}",
-                parts.len()
-            )));
+        Flavor::Busybox => {
+            let cmd = format!(
+                "find {q} -mindepth 1 -maxdepth 1 -exec stat -c '{fmt}' {{}} +",
+                fmt = listing::STATC_FMT_NAMED
+            );
+            let stdout = ssh_exec_ok(handle, &cmd).await?;
+            listing::parse_statc_listing(&stdout, dir)
         }
-        let type_char = parts[0];
-        let mode_str = parts[1];
-        let size_str = parts[2];
-        let mtime_str = parts[3];
-        let name = parts[4];
-
-        let (entry_type, is_symlink) = match type_char {
-            "f" => (ScpEntryType::File, false),
-            "d" => (ScpEntryType::Directory, false),
-            "l" => (ScpEntryType::Symlink, true),
-            _ => (ScpEntryType::Other, false),
-        };
-
-        let permissions = u32::from_str_radix(mode_str, 8).unwrap_or(0) & 0o7777;
-        let size: u64 = size_str.parse().unwrap_or(0);
-        // mtime is a float ("1700000000.0000000000"). Take the integer part.
-        let modified: Option<u64> = mtime_str
-            .split('.')
-            .next()
-            .and_then(|s| s.parse().ok());
-
-        let full_path = if dir == "/" {
-            format!("/{name}")
-        } else {
-            format!("{dir}/{name}")
-        };
-
-        entries.push(ScpEntry {
-            name: name.to_string(),
-            path: full_path,
-            entry_type,
-            size,
-            permissions,
-            permissions_display: format_permissions(permissions),
-            modified,
-            is_symlink,
-        });
+        Flavor::Bsd => {
+            let cmd = format!(
+                "find {q} -mindepth 1 -maxdepth 1 -exec stat -f '{fmt}' {{}} +",
+                fmt = listing::STATF_FMT_NAMED
+            );
+            let stdout = ssh_exec_ok(handle, &cmd).await?;
+            listing::parse_statf_listing(&stdout, dir)
+        }
     }
-
-    // Directories first, then alphabetical within each group.
-    entries.sort_by(|a, b| {
-        let a_dir = a.entry_type == ScpEntryType::Directory;
-        let b_dir = b.entry_type == ScpEntryType::Directory;
-        b_dir
-            .cmp(&a_dir)
-            .then_with(|| a.name.to_lowercase().cmp(&b.name.to_lowercase()))
-    });
-
-    Ok(entries)
-}
-
-/// One node in a recursive directory walk, with its path relative to the
-/// walk root.
-#[derive(Debug, Clone)]
-pub struct TreeEntry {
-    /// Path relative to the walk root (never starts with `/`).
-    pub rel_path: String,
-    pub is_dir: bool,
-    pub size: u64,
 }
 
 /// Recursively enumerate everything under `dir` (excluding `dir` itself),
-/// returning each node's path relative to `dir`. Directories first within the
-/// list isn't guaranteed — callers that need ordering should sort by depth.
+/// each node's path relative to `dir`. Ordering is not guaranteed — callers
+/// that need dirs-before-files should sort by depth.
 pub async fn enumerate_tree(
-    handle: Arc<Mutex<Handle<SshClientHandler>>>,
+    handle: SshHandle,
+    flavor: Flavor,
     dir: &str,
 ) -> Result<Vec<TreeEntry>, ScpError> {
-    // %y = type letter, %s = size, %P = path relative to the starting point.
-    let cmd = format!(
-        "find {dir} -mindepth 1 -printf '%y\\t%s\\t%P\\0'",
-        dir = shell_quote(dir)
-    );
-    let stdout = ssh_exec_ok(handle, &cmd).await?;
-
-    let mut entries = Vec::new();
-    for record in stdout.split(|b| *b == 0) {
-        if record.is_empty() {
-            continue;
+    let q = shell_quote(dir);
+    match flavor {
+        Flavor::Gnu => {
+            let cmd = format!(
+                "find {q} -mindepth 1 -printf '{fmt}'",
+                fmt = listing::GNU_TREE_PRINTF
+            );
+            let stdout = ssh_exec_ok(handle, &cmd).await?;
+            listing::parse_gnu_tree(&stdout)
         }
-        let line = std::str::from_utf8(record)
-            .map_err(|e| ScpError::ParseError(format!("non-UTF-8 tree record: {e}")))?;
-        let parts: Vec<&str> = line.splitn(3, '\t').collect();
-        if parts.len() != 3 {
-            return Err(ScpError::ParseError(format!(
-                "tree record has {} fields, expected 3: {line:?}",
-                parts.len()
-            )));
+        Flavor::Busybox => {
+            let cmd = format!(
+                "find {q} -mindepth 1 -exec stat -c '{fmt}' {{}} +",
+                fmt = listing::STATC_TREE_FMT
+            );
+            let stdout = ssh_exec_ok(handle, &cmd).await?;
+            listing::parse_statc_tree(&stdout, dir)
         }
-        let is_dir = parts[0] == "d";
-        let size: u64 = parts[1].parse().unwrap_or(0);
-        let rel_path = parts[2].to_string();
-        if rel_path.is_empty() {
-            continue;
+        Flavor::Bsd => {
+            let cmd = format!(
+                "find {q} -mindepth 1 -exec stat -f '{fmt}' {{}} +",
+                fmt = listing::STATF_TREE_FMT
+            );
+            let stdout = ssh_exec_ok(handle, &cmd).await?;
+            listing::parse_statf_tree(&stdout, dir)
         }
-        entries.push(TreeEntry {
-            rel_path,
-            is_dir,
-            size,
-        });
     }
-    Ok(entries)
 }
 
-/// Sum (total_bytes, file_count) under a remote directory in one `find` pass.
+/// Sum (total_bytes, file_count) under a remote directory in one walk.
 pub async fn dir_stats(
-    handle: Arc<Mutex<Handle<SshClientHandler>>>,
+    handle: SshHandle,
+    flavor: Flavor,
     dir: &str,
 ) -> Result<(u64, u32), ScpError> {
-    let entries = enumerate_tree(handle, dir).await?;
+    let entries = enumerate_tree(handle, flavor, dir).await?;
     let mut bytes = 0u64;
     let mut count = 0u32;
     for e in &entries {

--- a/src-tauri/src/scp/listing.rs
+++ b/src-tauri/src/scp/listing.rs
@@ -1,0 +1,580 @@
+//! Portable directory-listing and stat parsing for SCP mode.
+//!
+//! SCP has no native filesystem ops, so we shell out over SSH. The exact
+//! command differs by the remote's userland:
+//!
+//! - **GNU** (Ubuntu, Debian, Fedora, RHEL, Arch, Alpine+coreutils, …):
+//!   `find … -printf` emits everything in one machine-readable, NUL-delimited
+//!   pass. Fastest and most robust.
+//! - **busybox** (minimal Alpine, routers, IoT): busybox `find` has no
+//!   `-printf`, but busybox `stat -c` works — so we `find … -exec stat -c …`.
+//! - **BSD / macOS**: neither `find -printf` nor `stat -c`; BSD `stat -f` uses
+//!   a different format language, so we `find … -exec stat -f …`.
+//!
+//! The flavor is detected once per session (see [`Flavor`] /
+//! `exec::detect_flavor`). This module holds the **pure parsers** — they take
+//! raw command bytes and produce [`ScpEntry`] / [`StatInfo`] / [`TreeEntry`],
+//! with no SSH dependency, so every flavor is unit-tested below.
+
+use super::{format_permissions, ScpEntry, ScpEntryType, ScpError};
+
+/// Which remote userland we're talking to. Detected once at session open.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Flavor {
+    /// GNU coreutils + findutils (`find -printf`, `stat -c`).
+    Gnu,
+    /// busybox (`stat -c` works, `find -printf` does not).
+    Busybox,
+    /// BSD / macOS (`stat -f`, no `find -printf`, no `stat -c`).
+    Bsd,
+}
+
+impl Default for Flavor {
+    /// GNU is the safest assumption when detection is inconclusive — it's the
+    /// most common server userland and its commands are the most capable.
+    fn default() -> Self {
+        Flavor::Gnu
+    }
+}
+
+impl Flavor {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Flavor::Gnu => "gnu",
+            Flavor::Busybox => "busybox",
+            Flavor::Bsd => "bsd",
+        }
+    }
+
+    pub fn parse(s: &str) -> Option<Flavor> {
+        match s.trim() {
+            "gnu" => Some(Flavor::Gnu),
+            "busybox" => Some(Flavor::Busybox),
+            "bsd" => Some(Flavor::Bsd),
+            _ => None,
+        }
+    }
+}
+
+/// Result of stat-ing a single path.
+#[derive(Debug, Clone)]
+pub struct StatInfo {
+    pub entry_type: ScpEntryType,
+    #[allow(dead_code)]
+    pub mode: u32,
+    pub size: u64,
+    #[allow(dead_code)]
+    pub mtime: u64,
+}
+
+/// One node in a recursive walk, path relative to the walk root.
+#[derive(Debug, Clone)]
+pub struct TreeEntry {
+    pub rel_path: String,
+    pub is_dir: bool,
+    pub size: u64,
+}
+
+// ─── Command builders ────────────────────────────────────────────────────────
+// Format strings each flavor's listing/stat commands use. Kept next to the
+// parsers so the producer and consumer stay in sync.
+
+// NOTE on escapes: `find -printf` interprets backslash escapes (`\t`, `\0`),
+// so its formats use *literal* backslash-t / backslash-0 (raw strings).
+// `stat -c` / `stat -f` do NOT interpret escapes — they emit the format
+// bytes verbatim — so their formats embed *real* tab characters ("\t" in a
+// non-raw string literal is a 0x09 byte). Both end up tab-separated on the
+// wire, which is what the parsers split on.
+
+/// `find` `-printf` format for GNU one-pass listing (NUL-delimited records).
+pub const GNU_LISTING_PRINTF: &str = r"%y\t%m\t%s\t%T@\t%f\0";
+/// GNU `find` `-printf` for a recursive tree walk (relative paths).
+pub const GNU_TREE_PRINTF: &str = r"%y\t%s\t%P\0";
+/// `stat -c` format (GNU + busybox), single stat. Fields: human-type,
+/// octal-perms, size, mtime-epoch. Real tabs (stat -c doesn't interpret \t).
+pub const STATC_FMT: &str = "%F\t%a\t%s\t%Y";
+/// `stat -c` with the file name appended, for `-exec` listing.
+pub const STATC_FMT_NAMED: &str = "%F\t%a\t%s\t%Y\t%n";
+/// `stat -c` for a tree walk: type, size, name.
+pub const STATC_TREE_FMT: &str = "%F\t%s\t%n";
+/// `stat -f` format (BSD/macOS), single stat. Fields: perm-string, size, mtime.
+pub const STATF_FMT: &str = "%Sp\t%z\t%m";
+/// `stat -f` with name, for `-exec` listing.
+pub const STATF_FMT_NAMED: &str = "%Sp\t%z\t%m\t%N";
+/// `stat -f` for a tree walk: perm-string, size, name.
+pub const STATF_TREE_FMT: &str = "%Sp\t%z\t%N";
+
+// ─── Helpers ───────────────────────────────────────────────────────────────────
+
+fn basename(path: &str) -> &str {
+    match path.rfind('/') {
+        Some(i) => &path[i + 1..],
+        None => path,
+    }
+}
+
+fn join_remote(dir: &str, name: &str) -> String {
+    if dir == "/" {
+        format!("/{name}")
+    } else {
+        format!("{}/{}", dir.trim_end_matches('/'), name)
+    }
+}
+
+fn type_from_y(c: &str) -> (ScpEntryType, bool) {
+    match c {
+        "f" => (ScpEntryType::File, false),
+        "d" => (ScpEntryType::Directory, false),
+        "l" => (ScpEntryType::Symlink, true),
+        _ => (ScpEntryType::Other, false),
+    }
+}
+
+fn type_from_human(f: &str) -> (ScpEntryType, bool) {
+    match f {
+        "regular file" | "regular empty file" => (ScpEntryType::File, false),
+        "directory" => (ScpEntryType::Directory, false),
+        "symbolic link" => (ScpEntryType::Symlink, true),
+        _ => (ScpEntryType::Other, false),
+    }
+}
+
+/// Map a BSD `%Sp` permission string (e.g. `drwxr-xr-x`) to type + mode bits.
+/// The leading char is the type; the next 9 are the rwx triads.
+fn parse_sp(sp: &str) -> (ScpEntryType, bool, u32) {
+    let chars: Vec<char> = sp.chars().collect();
+    let (entry_type, is_symlink) = match chars.first() {
+        Some('d') => (ScpEntryType::Directory, false),
+        Some('l') => (ScpEntryType::Symlink, true),
+        Some('-') => (ScpEntryType::File, false),
+        _ => (ScpEntryType::Other, false),
+    };
+    let mode = if chars.len() >= 10 {
+        rwx_to_mode(&sp[sp.char_indices().nth(1).map(|(i, _)| i).unwrap_or(1)..])
+    } else {
+        0
+    };
+    (entry_type, is_symlink, mode)
+}
+
+/// Convert a 9-char `rwxrwxrwx`-style string (with optional s/S/t/T) to a
+/// 12-bit Unix mode (including setuid/setgid/sticky).
+fn rwx_to_mode(rwx: &str) -> u32 {
+    let b: Vec<char> = rwx.chars().take(9).collect();
+    if b.len() < 9 {
+        return 0;
+    }
+    let mut mode: u32 = 0;
+    // Read triads: owner, group, other.
+    if b[0] == 'r' { mode |= 0o400; }
+    if b[1] == 'w' { mode |= 0o200; }
+    match b[2] { 'x' => mode |= 0o100, 's' => mode |= 0o100 | 0o4000, 'S' => mode |= 0o4000, _ => {} }
+    if b[3] == 'r' { mode |= 0o040; }
+    if b[4] == 'w' { mode |= 0o020; }
+    match b[5] { 'x' => mode |= 0o010, 's' => mode |= 0o010 | 0o2000, 'S' => mode |= 0o2000, _ => {} }
+    if b[6] == 'r' { mode |= 0o004; }
+    if b[7] == 'w' { mode |= 0o002; }
+    match b[8] { 'x' => mode |= 0o001, 't' => mode |= 0o001 | 0o1000, 'T' => mode |= 0o1000, _ => {} }
+    mode
+}
+
+fn mk_entry(
+    name: &str,
+    path: String,
+    entry_type: ScpEntryType,
+    is_symlink: bool,
+    permissions: u32,
+    size: u64,
+    modified: Option<u64>,
+) -> ScpEntry {
+    let permissions = permissions & 0o7777;
+    ScpEntry {
+        name: name.to_string(),
+        path,
+        entry_type,
+        size,
+        permissions,
+        permissions_display: format_permissions(permissions),
+        modified,
+        is_symlink,
+    }
+}
+
+/// Directories first, then case-insensitive alphabetical within each group.
+pub fn sort_entries(entries: &mut [ScpEntry]) {
+    entries.sort_by(|a, b| {
+        let a_dir = a.entry_type == ScpEntryType::Directory;
+        let b_dir = b.entry_type == ScpEntryType::Directory;
+        b_dir
+            .cmp(&a_dir)
+            .then_with(|| a.name.to_lowercase().cmp(&b.name.to_lowercase()))
+    });
+}
+
+// ─── Listing parsers ─────────────────────────────────────────────────────────
+
+/// Parse GNU `find -printf '%y\t%m\t%s\t%T@\t%f\0'` output.
+pub fn parse_gnu_listing(stdout: &[u8], dir: &str) -> Result<Vec<ScpEntry>, ScpError> {
+    let mut out = Vec::new();
+    for record in stdout.split(|b| *b == 0) {
+        if record.is_empty() {
+            continue;
+        }
+        let line = std::str::from_utf8(record)
+            .map_err(|e| ScpError::ParseError(format!("non-UTF-8 listing record: {e}")))?;
+        let parts: Vec<&str> = line.splitn(5, '\t').collect();
+        if parts.len() != 5 {
+            return Err(ScpError::ParseError(format!(
+                "GNU listing record has {} fields, expected 5: {line:?}",
+                parts.len()
+            )));
+        }
+        let (entry_type, is_symlink) = type_from_y(parts[0]);
+        let permissions = u32::from_str_radix(parts[1], 8).unwrap_or(0);
+        let size: u64 = parts[2].parse().unwrap_or(0);
+        let modified: Option<u64> = parts[3].split('.').next().and_then(|s| s.parse().ok());
+        let name = parts[4];
+        out.push(mk_entry(name, join_remote(dir, name), entry_type, is_symlink, permissions, size, modified));
+    }
+    sort_entries(&mut out);
+    Ok(out)
+}
+
+/// Parse `find … -exec stat -c '%F\t%a\t%s\t%Y\t%n' {} +` output (GNU/busybox),
+/// one newline-delimited record per entry, `%n` = full path.
+pub fn parse_statc_listing(stdout: &[u8], _dir: &str) -> Result<Vec<ScpEntry>, ScpError> {
+    let text = std::str::from_utf8(stdout)
+        .map_err(|e| ScpError::ParseError(format!("non-UTF-8 stat output: {e}")))?;
+    let mut out = Vec::new();
+    for line in text.lines() {
+        if line.is_empty() {
+            continue;
+        }
+        let parts: Vec<&str> = line.splitn(5, '\t').collect();
+        if parts.len() != 5 {
+            return Err(ScpError::ParseError(format!(
+                "stat -c record has {} fields, expected 5: {line:?}",
+                parts.len()
+            )));
+        }
+        let (entry_type, is_symlink) = type_from_human(parts[0]);
+        let permissions = u32::from_str_radix(parts[1], 8).unwrap_or(0);
+        let size: u64 = parts[2].parse().unwrap_or(0);
+        let modified: Option<u64> = parts[3].parse().ok();
+        let full = parts[4];
+        out.push(mk_entry(basename(full), full.to_string(), entry_type, is_symlink, permissions, size, modified));
+    }
+    sort_entries(&mut out);
+    Ok(out)
+}
+
+/// Parse `find … -exec stat -f '%Sp\t%z\t%m\t%N' {} +` output (BSD/macOS).
+pub fn parse_statf_listing(stdout: &[u8], _dir: &str) -> Result<Vec<ScpEntry>, ScpError> {
+    let text = std::str::from_utf8(stdout)
+        .map_err(|e| ScpError::ParseError(format!("non-UTF-8 stat output: {e}")))?;
+    let mut out = Vec::new();
+    for line in text.lines() {
+        if line.is_empty() {
+            continue;
+        }
+        let parts: Vec<&str> = line.splitn(4, '\t').collect();
+        if parts.len() != 4 {
+            return Err(ScpError::ParseError(format!(
+                "stat -f record has {} fields, expected 4: {line:?}",
+                parts.len()
+            )));
+        }
+        let (entry_type, is_symlink, permissions) = parse_sp(parts[0]);
+        let size: u64 = parts[1].parse().unwrap_or(0);
+        let modified: Option<u64> = parts[2].parse().ok();
+        let full = parts[3];
+        out.push(mk_entry(basename(full), full.to_string(), entry_type, is_symlink, permissions, size, modified));
+    }
+    sort_entries(&mut out);
+    Ok(out)
+}
+
+// ─── Single-stat parsers ───────────────────────────────────────────────────────
+
+/// Parse `stat -c '%F\t%a\t%s\t%Y'` output (single path; GNU/busybox).
+pub fn parse_statc_single(stdout: &[u8]) -> Result<Option<StatInfo>, ScpError> {
+    let text = std::str::from_utf8(stdout)
+        .map_err(|e| ScpError::ParseError(format!("non-UTF-8 stat output: {e}")))?;
+    let line = text.trim_end_matches('\n');
+    if line.is_empty() {
+        return Ok(None);
+    }
+    let parts: Vec<&str> = line.split('\t').collect();
+    if parts.len() != 4 {
+        return Err(ScpError::ParseError(format!(
+            "stat -c expected 4 fields, got {} in {line:?}",
+            parts.len()
+        )));
+    }
+    let (entry_type, _) = type_from_human(parts[0]);
+    let mode = u32::from_str_radix(parts[1], 8)
+        .map_err(|e| ScpError::ParseError(format!("stat -c bad mode {:?}: {e}", parts[1])))?;
+    let size: u64 = parts[2]
+        .parse()
+        .map_err(|e| ScpError::ParseError(format!("stat -c bad size {:?}: {e}", parts[2])))?;
+    let mtime: u64 = parts[3]
+        .parse()
+        .map_err(|e| ScpError::ParseError(format!("stat -c bad mtime {:?}: {e}", parts[3])))?;
+    Ok(Some(StatInfo { entry_type, mode, size, mtime }))
+}
+
+/// Parse `stat -f '%Sp\t%z\t%m'` output (single path; BSD/macOS).
+pub fn parse_statf_single(stdout: &[u8]) -> Result<Option<StatInfo>, ScpError> {
+    let text = std::str::from_utf8(stdout)
+        .map_err(|e| ScpError::ParseError(format!("non-UTF-8 stat output: {e}")))?;
+    let line = text.trim_end_matches('\n');
+    if line.is_empty() {
+        return Ok(None);
+    }
+    let parts: Vec<&str> = line.split('\t').collect();
+    if parts.len() != 3 {
+        return Err(ScpError::ParseError(format!(
+            "stat -f expected 3 fields, got {} in {line:?}",
+            parts.len()
+        )));
+    }
+    let (entry_type, _, mode) = parse_sp(parts[0]);
+    let size: u64 = parts[1]
+        .parse()
+        .map_err(|e| ScpError::ParseError(format!("stat -f bad size {:?}: {e}", parts[1])))?;
+    let mtime: u64 = parts[2]
+        .parse()
+        .map_err(|e| ScpError::ParseError(format!("stat -f bad mtime {:?}: {e}", parts[2])))?;
+    Ok(Some(StatInfo { entry_type, mode, size, mtime }))
+}
+
+// ─── Tree parsers ──────────────────────────────────────────────────────────────
+
+/// Parse GNU `find -mindepth 1 -printf '%y\t%s\t%P\0'` (relative paths).
+pub fn parse_gnu_tree(stdout: &[u8]) -> Result<Vec<TreeEntry>, ScpError> {
+    let mut out = Vec::new();
+    for record in stdout.split(|b| *b == 0) {
+        if record.is_empty() {
+            continue;
+        }
+        let line = std::str::from_utf8(record)
+            .map_err(|e| ScpError::ParseError(format!("non-UTF-8 tree record: {e}")))?;
+        let parts: Vec<&str> = line.splitn(3, '\t').collect();
+        if parts.len() != 3 {
+            return Err(ScpError::ParseError(format!(
+                "GNU tree record has {} fields, expected 3: {line:?}",
+                parts.len()
+            )));
+        }
+        let is_dir = parts[0] == "d";
+        let size: u64 = parts[1].parse().unwrap_or(0);
+        let rel_path = parts[2].to_string();
+        if rel_path.is_empty() {
+            continue;
+        }
+        out.push(TreeEntry { rel_path, is_dir, size });
+    }
+    Ok(out)
+}
+
+/// Parse busybox/GNU `find DIR … -exec stat -c '%F\t%s\t%n' {} +` into a tree,
+/// deriving each rel path by stripping the `DIR/` prefix from `%n`.
+pub fn parse_statc_tree(stdout: &[u8], dir: &str) -> Result<Vec<TreeEntry>, ScpError> {
+    // Field 0 is the human type ("directory"), 1 = size, 2 = full path.
+    parse_exec_tree(stdout, dir, |type_field| type_field == "directory")
+}
+
+/// Parse BSD `find DIR … -exec stat -f '%Sp\t%z\t%N' {} +` into a tree.
+pub fn parse_statf_tree(stdout: &[u8], dir: &str) -> Result<Vec<TreeEntry>, ScpError> {
+    // Field 0 is the perm string ("drwx…"); leading 'd' means directory.
+    parse_exec_tree(stdout, dir, |type_field| type_field.starts_with('d'))
+}
+
+/// Shared `-exec stat` tree parser. Records are newline-delimited with three
+/// tab fields: `<type>\t<size>\t<full_path>`. `is_dir` decides directoryness
+/// from the (flavor-specific) type field.
+fn parse_exec_tree(
+    stdout: &[u8],
+    dir: &str,
+    is_dir: impl Fn(&str) -> bool,
+) -> Result<Vec<TreeEntry>, ScpError> {
+    let text = std::str::from_utf8(stdout)
+        .map_err(|e| ScpError::ParseError(format!("non-UTF-8 tree output: {e}")))?;
+    let prefix = format!("{}/", dir.trim_end_matches('/'));
+    let mut out = Vec::new();
+    for line in text.lines() {
+        if line.is_empty() {
+            continue;
+        }
+        let fields: Vec<&str> = line.splitn(3, '\t').collect();
+        if fields.len() != 3 {
+            return Err(ScpError::ParseError(format!(
+                "tree record has {} fields, expected 3: {line:?}",
+                fields.len()
+            )));
+        }
+        let dir_flag = is_dir(fields[0]);
+        let size: u64 = fields[1].parse().unwrap_or(0);
+        let full = fields[2];
+        let rel_path = full.strip_prefix(&prefix).unwrap_or(full);
+        if rel_path.is_empty() {
+            continue;
+        }
+        out.push(TreeEntry { rel_path: rel_path.to_string(), is_dir: dir_flag, size });
+    }
+    Ok(out)
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn flavor_round_trip() {
+        for f in [Flavor::Gnu, Flavor::Busybox, Flavor::Bsd] {
+            assert_eq!(Flavor::parse(f.as_str()), Some(f));
+        }
+        assert_eq!(Flavor::parse("nonsense"), None);
+    }
+
+    #[test]
+    fn rwx_basic() {
+        assert_eq!(rwx_to_mode("rwxr-xr-x"), 0o755);
+        assert_eq!(rwx_to_mode("rw-r--r--"), 0o644);
+        assert_eq!(rwx_to_mode("---------"), 0);
+    }
+
+    #[test]
+    fn rwx_special_bits() {
+        assert_eq!(rwx_to_mode("rwsr-xr-x"), 0o4755);
+        assert_eq!(rwx_to_mode("rwxr-sr-x"), 0o2755);
+        assert_eq!(rwx_to_mode("rwxrwxrwt"), 0o1777);
+        // Capital S/T = special bit set without the exec bit.
+        assert_eq!(rwx_to_mode("rwSr--r--"), 0o4644);
+    }
+
+    #[test]
+    fn gnu_listing_parses_and_sorts() {
+        // NUL-delimited: type, octal mode, size, mtime float, name.
+        let raw = b"f\t644\t10\t1700000000.5\tbeta.txt\0d\t755\t40\t1700000001.0\talpha\0l\t777\t5\t1700000002.0\tlink\0";
+        let entries = parse_gnu_listing(raw, "/home/u").unwrap();
+        // Directory sorts first, then files alphabetically.
+        assert_eq!(entries[0].name, "alpha");
+        assert_eq!(entries[0].entry_type, ScpEntryType::Directory);
+        assert_eq!(entries[0].path, "/home/u/alpha");
+        assert_eq!(entries[1].name, "beta.txt");
+        assert_eq!(entries[1].size, 10);
+        assert_eq!(entries[1].permissions, 0o644);
+        assert_eq!(entries[1].modified, Some(1700000000));
+        assert_eq!(entries[2].name, "link");
+        assert!(entries[2].is_symlink);
+    }
+
+    #[test]
+    fn gnu_listing_root_dir_paths() {
+        let raw = b"d\t755\t40\t1700000001.0\tetc\0";
+        let entries = parse_gnu_listing(raw, "/").unwrap();
+        assert_eq!(entries[0].path, "/etc");
+    }
+
+    #[test]
+    fn gnu_listing_name_with_spaces() {
+        let raw = b"f\t644\t3\t1700000000.0\tmy file.txt\0";
+        let entries = parse_gnu_listing(raw, "/d").unwrap();
+        assert_eq!(entries[0].name, "my file.txt");
+        assert_eq!(entries[0].path, "/d/my file.txt");
+    }
+
+    #[test]
+    fn statc_listing_parses() {
+        // newline-delimited: human-type, octal, size, mtime, full path.
+        let raw = b"regular file\t644\t10\t1700000000\t/home/u/beta.txt\ndirectory\t755\t40\t1700000001\t/home/u/alpha\n";
+        let entries = parse_statc_listing(raw, "/home/u").unwrap();
+        assert_eq!(entries[0].name, "alpha"); // dir first
+        assert_eq!(entries[1].name, "beta.txt");
+        assert_eq!(entries[1].path, "/home/u/beta.txt");
+        assert_eq!(entries[1].permissions, 0o644);
+        assert_eq!(entries[1].modified, Some(1700000000));
+    }
+
+    #[test]
+    fn statc_listing_empty_file_is_file() {
+        let raw = b"regular empty file\t600\t0\t1700000000\t/t/empty\n";
+        let entries = parse_statc_listing(raw, "/t").unwrap();
+        assert_eq!(entries[0].entry_type, ScpEntryType::File);
+    }
+
+    #[test]
+    fn statf_listing_parses() {
+        // BSD: perm-string, size, mtime, full path.
+        let raw = b"-rw-r--r--\t10\t1700000000\t/home/u/beta.txt\ndrwxr-xr-x\t40\t1700000001\t/home/u/alpha\n";
+        let entries = parse_statf_listing(raw, "/home/u").unwrap();
+        assert_eq!(entries[0].name, "alpha");
+        assert_eq!(entries[0].entry_type, ScpEntryType::Directory);
+        assert_eq!(entries[1].name, "beta.txt");
+        assert_eq!(entries[1].permissions, 0o644);
+        assert_eq!(entries[1].size, 10);
+    }
+
+    #[test]
+    fn statc_single_parses() {
+        let info = parse_statc_single(b"directory\t755\t66\t1700000000\n").unwrap().unwrap();
+        assert_eq!(info.entry_type, ScpEntryType::Directory);
+        assert_eq!(info.mode, 0o755);
+        assert_eq!(info.size, 66);
+        assert_eq!(info.mtime, 1700000000);
+    }
+
+    #[test]
+    fn statc_single_empty_is_none() {
+        assert!(parse_statc_single(b"").unwrap().is_none());
+    }
+
+    #[test]
+    fn statf_single_parses() {
+        let info = parse_statf_single(b"drwxr-xr-x\t66\t1700000000\n").unwrap().unwrap();
+        assert_eq!(info.entry_type, ScpEntryType::Directory);
+        assert_eq!(info.mode, 0o755);
+        assert_eq!(info.size, 66);
+    }
+
+    #[test]
+    fn gnu_tree_parses() {
+        let raw = b"d\t40\tsub\0f\t12\tsub/file.txt\0";
+        let tree = parse_gnu_tree(raw).unwrap();
+        assert_eq!(tree.len(), 2);
+        assert!(tree[0].is_dir);
+        assert_eq!(tree[0].rel_path, "sub");
+        assert_eq!(tree[1].rel_path, "sub/file.txt");
+        assert_eq!(tree[1].size, 12);
+    }
+
+    #[test]
+    fn statc_tree_strips_prefix() {
+        let raw = b"directory\t40\t/root/sub\nregular file\t12\t/root/sub/file.txt\n";
+        let tree = parse_statc_tree(raw, "/root").unwrap();
+        assert_eq!(tree[0].rel_path, "sub");
+        assert!(tree[0].is_dir);
+        assert_eq!(tree[1].rel_path, "sub/file.txt");
+        assert_eq!(tree[1].size, 12);
+        assert!(!tree[1].is_dir);
+    }
+
+    #[test]
+    fn statf_tree_strips_prefix() {
+        let raw = b"drwxr-xr-x\t40\t/root/sub\n-rw-r--r--\t12\t/root/sub/file.txt\n";
+        let tree = parse_statf_tree(raw, "/root").unwrap();
+        assert_eq!(tree[0].rel_path, "sub");
+        assert!(tree[0].is_dir);
+        assert_eq!(tree[1].rel_path, "sub/file.txt");
+        assert!(!tree[1].is_dir);
+    }
+
+    #[test]
+    fn malformed_listing_errors() {
+        assert!(parse_gnu_listing(b"f\t644\0", "/d").is_err());
+        assert!(parse_statc_listing(b"directory\t755\n", "/d").is_err());
+    }
+}

--- a/src-tauri/src/scp/mod.rs
+++ b/src-tauri/src/scp/mod.rs
@@ -1,0 +1,305 @@
+pub mod commands;
+pub mod exec;
+pub mod transfer;
+pub mod transfer_manager;
+pub mod wire;
+
+use dashmap::DashMap;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use tokio_util::sync::CancellationToken;
+
+use crate::ssh::handler::SshClientHandler;
+
+// ─── Error ───────────────────────────────────────────────────────────────────
+
+#[derive(Debug, thiserror::Error)]
+pub enum ScpError {
+    #[error("SCP session not found: {0}")]
+    SessionNotFound(String),
+    #[error("SSH session not found: {0}")]
+    SshSessionNotFound(String),
+    #[error("SCP protocol error: {0}")]
+    ProtocolError(String),
+    #[error("Remote error: {0}")]
+    RemoteError(String),
+    #[error("Remote command failed (exit={exit_code}): {stderr}")]
+    CommandFailed { exit_code: i32, stderr: String },
+    #[error("Remote I/O error: {0}")]
+    RemoteIoError(String),
+    #[error("Local I/O error: {0}")]
+    LocalIoError(String),
+    #[error("Transfer cancelled")]
+    TransferCancelled,
+    #[allow(dead_code)]
+    #[error("Permission denied: {0}")]
+    PermissionDenied(String),
+    #[allow(dead_code)]
+    #[error("Path not found: {0}")]
+    NotFound(String),
+    #[error("Channel error: {0}")]
+    ChannelError(String),
+    #[error("Output parse error: {0}")]
+    ParseError(String),
+}
+
+/// Serialize as `{ kind, message }` — same convention as SshError / SftpError.
+impl Serialize for ScpError {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut state = serializer.serialize_struct("ScpError", 2)?;
+        let kind = match self {
+            ScpError::SessionNotFound(_) => "session_not_found",
+            ScpError::SshSessionNotFound(_) => "ssh_session_not_found",
+            ScpError::ProtocolError(_) => "protocol_error",
+            ScpError::RemoteError(_) => "remote_error",
+            ScpError::CommandFailed { .. } => "command_failed",
+            ScpError::RemoteIoError(_) => "remote_io_error",
+            ScpError::LocalIoError(_) => "local_io_error",
+            ScpError::TransferCancelled => "transfer_cancelled",
+            ScpError::PermissionDenied(_) => "permission_denied",
+            ScpError::NotFound(_) => "not_found",
+            ScpError::ChannelError(_) => "channel_error",
+            ScpError::ParseError(_) => "parse_error",
+        };
+        state.serialize_field("kind", kind)?;
+        state.serialize_field("message", &self.to_string())?;
+        state.end()
+    }
+}
+
+impl From<std::io::Error> for ScpError {
+    fn from(err: std::io::Error) -> Self {
+        ScpError::RemoteIoError(err.to_string())
+    }
+}
+
+// ─── Data types ──────────────────────────────────────────────────────────────
+
+/// One directory entry. Field-compatible with `SftpEntry` so the frontend can
+/// treat both uniformly.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScpEntry {
+    pub name: String,
+    pub path: String,
+    pub entry_type: ScpEntryType,
+    pub size: u64,
+    /// Raw Unix permission bits (lower 12 bits of the mode word).
+    pub permissions: u32,
+    /// Human-readable rwxrwxrwx string.
+    pub permissions_display: String,
+    /// Unix mtime as seconds since epoch, or `None` when not available.
+    pub modified: Option<u64>,
+    pub is_symlink: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum ScpEntryType {
+    File,
+    Directory,
+    Symlink,
+    Other,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum TransferDirection {
+    Download,
+    Upload,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum TransferStatus {
+    Queued,
+    InProgress,
+    Completed,
+    Failed(String),
+    Cancelled,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TransferProgress {
+    pub transfer_id: String,
+    pub scp_session_id: String,
+    pub file_name: String,
+    pub direction: TransferDirection,
+    pub bytes_transferred: u64,
+    pub total_bytes: u64,
+    pub status: TransferStatus,
+}
+
+/// Event payload emitted to the frontend on the `scp:transfer` channel.
+/// Field-shape matches `sftp::TransferEvent` with the session-id key renamed,
+/// so the frontend hook can normalize both onto one type.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TransferEvent {
+    pub transfer_id: String,
+    pub scp_session_id: String,
+    pub name: String,
+    pub direction: TransferDirection,
+    pub status: TransferStatus,
+    pub error: Option<String>,
+    pub bytes_transferred: u64,
+    pub total_bytes: u64,
+    pub files_done: u32,
+    pub files_total: u32,
+    pub speed_bps: u64,
+    pub eta_secs: Option<u64>,
+    pub created_at: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TransferInfo {
+    pub transfer_id: String,
+    pub scp_session_id: String,
+    pub name: String,
+    pub direction: TransferDirection,
+    pub status: TransferStatus,
+    pub error: Option<String>,
+    pub bytes_transferred: u64,
+    pub total_bytes: u64,
+    pub files_done: u32,
+    pub files_total: u32,
+    pub speed_bps: u64,
+    pub eta_secs: Option<u64>,
+    pub created_at: u64,
+}
+
+// ─── Manager ─────────────────────────────────────────────────────────────────
+
+/// A registered "SCP session" — really just a reference back to the SSH session
+/// it lives on. SCP is stateless: every filesystem op and every transfer opens
+/// a fresh channel on this SSH connection.
+pub struct ScpSessionWrapper {
+    /// The SSH session this SCP session rides on. Retained for diagnostics /
+    /// future teardown coordination even though transfers only need the handle.
+    #[allow(dead_code)]
+    pub ssh_session_id: String,
+    pub ssh_handle: Arc<Mutex<russh::client::Handle<SshClientHandler>>>,
+}
+
+pub struct ScpManager {
+    sessions: DashMap<String, ScpSessionWrapper>,
+    active_transfers: DashMap<String, CancellationToken>,
+}
+
+impl ScpManager {
+    pub fn new() -> Self {
+        Self {
+            sessions: DashMap::new(),
+            active_transfers: DashMap::new(),
+        }
+    }
+
+    pub fn insert_session(&self, id: String, wrapper: ScpSessionWrapper) {
+        self.sessions.insert(id, wrapper);
+    }
+
+    pub fn get_session(
+        &self,
+        id: &str,
+    ) -> Result<dashmap::mapref::one::Ref<'_, String, ScpSessionWrapper>, ScpError> {
+        self.sessions
+            .get(id)
+            .ok_or_else(|| ScpError::SessionNotFound(id.to_string()))
+    }
+
+    pub fn remove_session(&self, id: &str) {
+        self.sessions.remove(id);
+    }
+
+    pub fn insert_transfer(&self, id: String, token: CancellationToken) {
+        self.active_transfers.insert(id, token);
+    }
+
+    pub fn cancel_transfer(&self, id: &str) -> Result<(), ScpError> {
+        let entry = self
+            .active_transfers
+            .get(id)
+            .ok_or_else(|| ScpError::SessionNotFound(format!("transfer not found: {id}")))?;
+        entry.value().cancel();
+        Ok(())
+    }
+
+    pub fn remove_transfer(&self, id: &str) {
+        self.active_transfers.remove(id);
+    }
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/// Convert a raw Unix mode word into a 9-character `rwxrwxrwx` string.
+pub fn format_permissions(mode: u32) -> String {
+    let mut s = String::with_capacity(9);
+    let flags: [(u32, char); 9] = [
+        (0o400, 'r'),
+        (0o200, 'w'),
+        (0o100, 'x'),
+        (0o040, 'r'),
+        (0o020, 'w'),
+        (0o010, 'x'),
+        (0o004, 'r'),
+        (0o002, 'w'),
+        (0o001, 'x'),
+    ];
+    for (bit, ch) in flags {
+        s.push(if mode & bit != 0 { ch } else { '-' });
+    }
+    s
+}
+
+/// Quote a path for safe substitution into a shell command.
+///
+/// Wraps in single quotes and escapes any embedded single quotes as `'\''`.
+/// Safe for any filename including spaces, $, `, *, etc.
+pub fn shell_quote(path: &str) -> String {
+    let mut out = String::with_capacity(path.len() + 2);
+    out.push('\'');
+    for c in path.chars() {
+        if c == '\'' {
+            out.push_str("'\\''");
+        } else {
+            out.push(c);
+        }
+    }
+    out.push('\'');
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_permissions_rwxr_xr_x() {
+        assert_eq!(format_permissions(0o755), "rwxr-xr-x");
+    }
+
+    #[test]
+    fn format_permissions_rw_r_r() {
+        assert_eq!(format_permissions(0o644), "rw-r--r--");
+    }
+
+    #[test]
+    fn shell_quote_plain() {
+        assert_eq!(shell_quote("/tmp/file"), "'/tmp/file'");
+    }
+
+    #[test]
+    fn shell_quote_with_space() {
+        assert_eq!(shell_quote("/tmp/my file"), "'/tmp/my file'");
+    }
+
+    #[test]
+    fn shell_quote_with_single_quote() {
+        assert_eq!(shell_quote("/tmp/it's.txt"), r"'/tmp/it'\''s.txt'");
+    }
+
+    #[test]
+    fn shell_quote_with_metacharacters() {
+        assert_eq!(shell_quote("/tmp/a;b`c$d*e"), "'/tmp/a;b`c$d*e'");
+    }
+}

--- a/src-tauri/src/scp/mod.rs
+++ b/src-tauri/src/scp/mod.rs
@@ -1,5 +1,6 @@
 pub mod commands;
 pub mod exec;
+pub mod listing;
 pub mod transfer;
 pub mod transfer_manager;
 pub mod wire;
@@ -179,6 +180,9 @@ pub struct ScpSessionWrapper {
     #[allow(dead_code)]
     pub ssh_session_id: String,
     pub ssh_handle: Arc<Mutex<russh::client::Handle<SshClientHandler>>>,
+    /// Remote userland, detected once at open — decides which listing/stat
+    /// commands to issue.
+    pub flavor: listing::Flavor,
 }
 
 pub struct ScpManager {

--- a/src-tauri/src/scp/transfer.rs
+++ b/src-tauri/src/scp/transfer.rs
@@ -1,0 +1,210 @@
+//! Byte-transfer primitives that drive a remote `scp -t` (sink) or
+//! `scp -f` (source) process over a fresh SSH channel, speaking the wire
+//! protocol from [`super::wire`].
+//!
+//! These are the SCP analogue of `russh_sftp`'s file read/write. Directory
+//! transfers are handled one level up (in `transfer_manager` / `commands`) by
+//! recursing in Rust and calling [`upload_file`] / [`download_file`] per file,
+//! which keeps progress accounting and cancellation simple.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use russh::client::Handle;
+use tokio::io::AsyncWriteExt;
+use tokio::sync::Mutex;
+use tokio_util::sync::CancellationToken;
+
+use crate::ssh::handler::SshClientHandler;
+
+use super::wire::{self, ScpMsg};
+use super::{shell_quote, ScpError};
+
+const CHUNK_SIZE: usize = 32 * 1024;
+
+/// Default mode applied to uploaded files when the local mode can't be read.
+const DEFAULT_FILE_MODE: u32 = 0o644;
+
+/// Upload one local file to `remote_path` via `scp -t`.
+///
+/// `on_progress` is called with the cumulative byte count after each chunk.
+/// The remote parent directory must already exist (callers handle `mkdir -p`).
+pub async fn upload_file<F>(
+    handle: Arc<Mutex<Handle<SshClientHandler>>>,
+    local_path: &Path,
+    remote_path: &str,
+    cancel: &CancellationToken,
+    on_progress: F,
+) -> Result<(), ScpError>
+where
+    F: FnMut(u64),
+{
+    let meta = tokio::fs::metadata(local_path)
+        .await
+        .map_err(|e| ScpError::LocalIoError(format!("cannot stat {}: {e}", local_path.display())))?;
+    let size = meta.len();
+    let mode = local_mode(&meta);
+
+    let name = remote_path
+        .rsplit('/')
+        .next()
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| ScpError::ProtocolError(format!("invalid remote path: {remote_path}")))?
+        .to_string();
+
+    let mut local_file = tokio::fs::File::open(local_path)
+        .await
+        .map_err(|e| ScpError::LocalIoError(format!("cannot open {}: {e}", local_path.display())))?;
+
+    // Open a channel and start the remote sink. `-t` = "to" (receive).
+    let channel = {
+        let h = handle.lock().await;
+        h.channel_open_session()
+            .await
+            .map_err(|e| ScpError::ChannelError(e.to_string()))?
+    };
+    let cmd = format!("scp -t -- {}", shell_quote(remote_path));
+    channel
+        .exec(true, cmd.as_bytes())
+        .await
+        .map_err(|e| ScpError::ChannelError(format!("exec scp -t failed: {e}")))?;
+
+    let mut stream = channel.into_stream();
+
+    // Handshake: wait for the sink to signal readiness.
+    wire::read_ack(&mut stream).await?;
+
+    // Send the file header, wait for ack.
+    wire::write_msg(&mut stream, &ScpMsg::File { mode, size, name }).await?;
+    wire::read_ack(&mut stream).await?;
+
+    // Stream the body.
+    wire::stream_bytes(
+        &mut local_file,
+        &mut stream,
+        size,
+        CHUNK_SIZE,
+        || cancel.is_cancelled(),
+        on_progress,
+    )
+    .await?;
+
+    // Trailing \0 = "file complete, status OK", then wait for the sink's ack.
+    stream
+        .write_all(&[0u8])
+        .await
+        .map_err(|e| ScpError::RemoteIoError(e.to_string()))?;
+    stream
+        .flush()
+        .await
+        .map_err(|e| ScpError::RemoteIoError(e.to_string()))?;
+    wire::read_ack(&mut stream).await?;
+
+    // Closing the stream tears down the channel.
+    let _ = stream.shutdown().await;
+    Ok(())
+}
+
+/// Download one remote file (`remote_path`) to `local_path` via `scp -f`.
+pub async fn download_file<F>(
+    handle: Arc<Mutex<Handle<SshClientHandler>>>,
+    remote_path: &str,
+    local_path: &Path,
+    cancel: &CancellationToken,
+    on_progress: F,
+) -> Result<(), ScpError>
+where
+    F: FnMut(u64),
+{
+    let channel = {
+        let h = handle.lock().await;
+        h.channel_open_session()
+            .await
+            .map_err(|e| ScpError::ChannelError(e.to_string()))?
+    };
+    // `-f` = "from" (send). `-p` would also send timestamps; we skip it.
+    let cmd = format!("scp -f -- {}", shell_quote(remote_path));
+    channel
+        .exec(true, cmd.as_bytes())
+        .await
+        .map_err(|e| ScpError::ChannelError(format!("exec scp -f failed: {e}")))?;
+
+    let mut stream = channel.into_stream();
+
+    // Kick off the source by acking.
+    wire::write_ack(&mut stream).await?;
+
+    // Read records until we hit the file header. A `-p`-less source may still
+    // emit a T record on some servers; skip any T records.
+    let (mode, size) = loop {
+        match wire::read_msg(&mut stream).await? {
+            Some(ScpMsg::Time { .. }) => continue,
+            Some(ScpMsg::File { mode, size, .. }) => break (mode, size),
+            Some(ScpMsg::Dir { .. }) | Some(ScpMsg::EndDir) => {
+                return Err(ScpError::ProtocolError(
+                    "expected a file but server sent a directory record".into(),
+                ));
+            }
+            None => {
+                return Err(ScpError::RemoteError(format!(
+                    "no such file: {remote_path}"
+                )));
+            }
+        }
+    };
+    let _ = mode; // local file mode is decided by the OS umask; ignore remote mode.
+
+    // Ack the header so the source starts streaming the body.
+    wire::write_ack(&mut stream).await?;
+
+    let mut local_file = tokio::fs::File::create(local_path)
+        .await
+        .map_err(|e| ScpError::LocalIoError(format!("cannot create {}: {e}", local_path.display())))?;
+
+    let stream_result = wire::stream_bytes(
+        &mut stream,
+        &mut local_file,
+        size,
+        CHUNK_SIZE,
+        || cancel.is_cancelled(),
+        on_progress,
+    )
+    .await;
+
+    if let Err(e) = stream_result {
+        // Clean up the partial local file before surfacing the error.
+        drop(local_file);
+        let _ = tokio::fs::remove_file(local_path).await;
+        return Err(e);
+    }
+
+    local_file
+        .flush()
+        .await
+        .map_err(|e| ScpError::LocalIoError(e.to_string()))?;
+
+    // Read the source's trailing status byte, then ack it.
+    wire::read_ack(&mut stream).await?;
+    wire::write_ack(&mut stream).await?;
+
+    let _ = stream.shutdown().await;
+    Ok(())
+}
+
+/// Read the local file mode (Unix permission bits). On non-Unix, returns the
+/// default. Symlinks are followed because `metadata` follows them.
+#[cfg(unix)]
+fn local_mode(meta: &std::fs::Metadata) -> u32 {
+    use std::os::unix::fs::PermissionsExt;
+    let m = meta.permissions().mode() & 0o777;
+    if m == 0 {
+        DEFAULT_FILE_MODE
+    } else {
+        m
+    }
+}
+
+#[cfg(not(unix))]
+fn local_mode(_meta: &std::fs::Metadata) -> u32 {
+    DEFAULT_FILE_MODE
+}

--- a/src-tauri/src/scp/transfer_manager.rs
+++ b/src-tauri/src/scp/transfer_manager.rs
@@ -286,9 +286,9 @@ impl ScpTransferManager {
         local_dir: PathBuf,
     ) -> Result<Vec<String>, ScpError> {
         self.ensure_worker_spawned();
-        let handle = {
+        let (handle, flavor) = {
             let session = self.scp_manager.get_session(&scp_session_id)?;
-            session.ssh_handle.clone()
+            (session.ssh_handle.clone(), session.flavor)
         };
 
         let mut ids = Vec::with_capacity(remote_paths.len());
@@ -298,13 +298,13 @@ impl ScpTransferManager {
                 .map(|n| n.to_string_lossy().to_string())
                 .unwrap_or_else(|| "unknown".to_string());
 
-            let stat = exec::stat(handle.clone(), &remote_path)
+            let stat = exec::stat(handle.clone(), flavor, &remote_path)
                 .await?
                 .ok_or_else(|| ScpError::NotFound(remote_path.clone()))?;
 
             let local_dest = local_dir.join(&name);
             let job = if stat.entry_type == super::ScpEntryType::Directory {
-                let (bytes, count) = exec::dir_stats(handle.clone(), &remote_path).await?;
+                let (bytes, count) = exec::dir_stats(handle.clone(), flavor, &remote_path).await?;
                 Self::new_job(
                     &scp_session_id,
                     name,
@@ -476,14 +476,14 @@ async fn execute_transfer(
 
     set_job_status(jobs, job_id, TransferStatus::InProgress, None, app_handle);
 
-    // Resolve the SSH handle.
-    let handle = {
+    // Resolve the SSH handle and remote flavor.
+    let (handle, flavor) = {
         let sid = match jobs.get(job_id) {
             Some(j) => j.scp_session_id.clone(),
             None => return,
         };
         match scp_manager.get_session(&sid) {
-            Ok(s) => s.ssh_handle.clone(),
+            Ok(s) => (s.ssh_handle.clone(), s.flavor),
             Err(e) => {
                 set_job_status(
                     jobs,
@@ -552,7 +552,7 @@ async fn execute_transfer(
         KindDesc::DownloadDir {
             remote_path,
             local_dir,
-        } => run_download_dir(jobs, job_id, &handle, &remote_path, &local_dir, &cancel_token, app_handle).await,
+        } => run_download_dir(jobs, job_id, &handle, flavor, &remote_path, &local_dir, &cancel_token, app_handle).await,
     };
 
     let (direction, total_bytes, files_total, bytes_done) = jobs
@@ -779,6 +779,7 @@ async fn run_download_dir(
     jobs: &Arc<DashMap<String, TransferJobState>>,
     job_id: &str,
     handle: &Handle_,
+    flavor: super::listing::Flavor,
     remote_root: &str,
     local_root: &Path,
     cancel: &CancellationToken,
@@ -788,7 +789,7 @@ async fn run_download_dir(
         .await
         .map_err(|e| ScpError::LocalIoError(e.to_string()))?;
 
-    let mut tree = exec::enumerate_tree(handle.clone(), remote_root).await?;
+    let mut tree = exec::enumerate_tree(handle.clone(), flavor, remote_root).await?;
     // Create directories before files: shallower paths first.
     tree.sort_by_key(|e| (!e.is_dir, e.rel_path.matches('/').count()));
 

--- a/src-tauri/src/scp/transfer_manager.rs
+++ b/src-tauri/src/scp/transfer_manager.rs
@@ -1,0 +1,842 @@
+//! Queue-based, concurrency-limited transfer manager for SCP — the SCP
+//! analogue of `sftp::transfer_manager`. Files are transferred with the SCP
+//! wire protocol (see [`super::transfer`]); directories are walked in Rust
+//! and transferred file-by-file, with `mkdir -p` issued over SSH exec.
+//!
+//! Progress is emitted on the `scp:transfer` channel using the same
+//! `TransferEvent` shape as SFTP (with the session id key renamed), so the
+//! frontend can normalize both.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use dashmap::DashMap;
+use russh::client::Handle;
+use tauri::{AppHandle, Emitter};
+use tokio::sync::{mpsc, Mutex, Semaphore};
+use tokio_util::sync::CancellationToken;
+use tracing::instrument;
+
+use crate::ssh::handler::SshClientHandler;
+
+use super::{
+    exec, transfer, ScpError, ScpManager, TransferDirection, TransferEvent, TransferInfo,
+    TransferStatus,
+};
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const EMIT_THROTTLE: Duration = Duration::from_millis(100);
+const SPEED_WINDOW: Duration = Duration::from_secs(2);
+
+// ─── Job state ───────────────────────────────────────────────────────────────
+
+pub enum TransferJobKind {
+    UploadFile {
+        local_path: PathBuf,
+        remote_path: String,
+    },
+    UploadDir {
+        local_path: PathBuf,
+        remote_dir: String,
+    },
+    DownloadFile {
+        remote_path: String,
+        local_path: PathBuf,
+    },
+    DownloadDir {
+        remote_path: String,
+        local_dir: PathBuf,
+    },
+}
+
+pub struct TransferJobState {
+    pub transfer_id: String,
+    pub scp_session_id: String,
+    pub name: String,
+    pub direction: TransferDirection,
+    pub kind: TransferJobKind,
+    pub status: TransferStatus,
+    pub bytes_transferred: u64,
+    pub total_bytes: u64,
+    pub files_done: u32,
+    pub files_total: u32,
+    pub speed_bps: u64,
+    pub cancel_token: CancellationToken,
+    pub error: Option<String>,
+    pub created_at: u64,
+    pub last_emit: Instant,
+    pub speed_window_bytes: u64,
+    pub speed_window_start: Instant,
+}
+
+impl TransferJobState {
+    fn eta(&self) -> Option<u64> {
+        if self.speed_bps > 0 && self.total_bytes > self.bytes_transferred {
+            Some((self.total_bytes - self.bytes_transferred) / self.speed_bps)
+        } else {
+            None
+        }
+    }
+
+    fn to_event(&self) -> TransferEvent {
+        TransferEvent {
+            transfer_id: self.transfer_id.clone(),
+            scp_session_id: self.scp_session_id.clone(),
+            name: self.name.clone(),
+            direction: self.direction.clone(),
+            status: self.status.clone(),
+            error: self.error.clone(),
+            bytes_transferred: self.bytes_transferred,
+            total_bytes: self.total_bytes,
+            files_done: self.files_done,
+            files_total: self.files_total,
+            speed_bps: self.speed_bps,
+            eta_secs: self.eta(),
+            created_at: self.created_at,
+        }
+    }
+
+    fn to_info(&self) -> TransferInfo {
+        TransferInfo {
+            transfer_id: self.transfer_id.clone(),
+            scp_session_id: self.scp_session_id.clone(),
+            name: self.name.clone(),
+            direction: self.direction.clone(),
+            status: self.status.clone(),
+            error: self.error.clone(),
+            bytes_transferred: self.bytes_transferred,
+            total_bytes: self.total_bytes,
+            files_done: self.files_done,
+            files_total: self.files_total,
+            speed_bps: self.speed_bps,
+            eta_secs: self.eta(),
+            created_at: self.created_at,
+        }
+    }
+}
+
+// ─── Manager ─────────────────────────────────────────────────────────────────
+
+pub struct ScpTransferManager {
+    jobs: Arc<DashMap<String, TransferJobState>>,
+    queue_tx: mpsc::UnboundedSender<String>,
+    semaphore: Arc<Semaphore>,
+    scp_manager: Arc<ScpManager>,
+    app_handle: AppHandle,
+    max_concurrent: Arc<AtomicU32>,
+    worker_rx: Arc<std::sync::Mutex<Option<mpsc::UnboundedReceiver<String>>>>,
+}
+
+impl ScpTransferManager {
+    pub fn new(scp_manager: Arc<ScpManager>, app_handle: AppHandle) -> Self {
+        let (queue_tx, queue_rx) = mpsc::unbounded_channel::<String>();
+        Self {
+            jobs: Arc::new(DashMap::new()),
+            queue_tx,
+            semaphore: Arc::new(Semaphore::new(3)),
+            scp_manager,
+            app_handle,
+            max_concurrent: Arc::new(AtomicU32::new(3)),
+            worker_rx: Arc::new(std::sync::Mutex::new(Some(queue_rx))),
+        }
+    }
+
+    fn ensure_worker_spawned(&self) {
+        let mut guard = self.worker_rx.lock().expect("worker_rx mutex poisoned");
+        if let Some(mut queue_rx) = guard.take() {
+            let jobs = self.jobs.clone();
+            let semaphore = self.semaphore.clone();
+            let scp_manager = self.scp_manager.clone();
+            let app_handle = self.app_handle.clone();
+
+            tokio::spawn(async move {
+                while let Some(job_id) = queue_rx.recv().await {
+                    let permit = semaphore
+                        .clone()
+                        .acquire_owned()
+                        .await
+                        .expect("semaphore closed");
+                    let jobs = jobs.clone();
+                    let scp_manager = scp_manager.clone();
+                    let app_handle = app_handle.clone();
+                    tokio::spawn(async move {
+                        execute_transfer(&jobs, &job_id, &scp_manager, &app_handle).await;
+                        drop(permit);
+                    });
+                }
+            });
+        }
+    }
+
+    fn unix_now_millis() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as u64
+    }
+
+    fn emit_initial(&self, job_id: &str) {
+        if let Some(job) = self.jobs.get(job_id) {
+            let _ = self.app_handle.emit("scp:transfer", job.to_event());
+        }
+    }
+
+    fn insert_and_queue(&self, job: TransferJobState) -> Result<String, ScpError> {
+        let id = job.transfer_id.clone();
+        self.jobs.insert(id.clone(), job);
+        self.emit_initial(&id);
+        self.queue_tx
+            .send(id.clone())
+            .map_err(|e| ScpError::ChannelError(e.to_string()))?;
+        Ok(id)
+    }
+
+    fn new_job(
+        scp_session_id: &str,
+        name: String,
+        direction: TransferDirection,
+        kind: TransferJobKind,
+        total_bytes: u64,
+        files_total: u32,
+    ) -> TransferJobState {
+        let now_instant = Instant::now();
+        TransferJobState {
+            transfer_id: uuid::Uuid::new_v4().to_string(),
+            scp_session_id: scp_session_id.to_string(),
+            name,
+            direction,
+            kind,
+            status: TransferStatus::Queued,
+            bytes_transferred: 0,
+            total_bytes,
+            files_done: 0,
+            files_total,
+            speed_bps: 0,
+            cancel_token: CancellationToken::new(),
+            error: None,
+            created_at: Self::unix_now_millis(),
+            last_emit: now_instant,
+            speed_window_bytes: 0,
+            speed_window_start: now_instant,
+        }
+    }
+
+    // ─── Enqueue ───────────────────────────────────────────────────────────
+
+    #[instrument(skip(self), fields(scp_session_id = %scp_session_id))]
+    pub async fn enqueue_upload(
+        &self,
+        scp_session_id: String,
+        local_paths: Vec<PathBuf>,
+        remote_dir: String,
+    ) -> Result<Vec<String>, ScpError> {
+        self.ensure_worker_spawned();
+        let mut ids = Vec::with_capacity(local_paths.len());
+
+        for local_path in local_paths {
+            let meta = tokio::fs::metadata(&local_path)
+                .await
+                .map_err(|e| ScpError::LocalIoError(e.to_string()))?;
+            let name = local_path
+                .file_name()
+                .map(|n| n.to_string_lossy().to_string())
+                .unwrap_or_else(|| "unknown".to_string());
+            let remote_path = format!("{}/{}", remote_dir.trim_end_matches('/'), name);
+
+            let job = if meta.is_dir() {
+                let (bytes, count) = walk_local_dir_stats(&local_path).await;
+                Self::new_job(
+                    &scp_session_id,
+                    name,
+                    TransferDirection::Upload,
+                    TransferJobKind::UploadDir {
+                        local_path,
+                        remote_dir: remote_path,
+                    },
+                    bytes,
+                    count,
+                )
+            } else {
+                Self::new_job(
+                    &scp_session_id,
+                    name,
+                    TransferDirection::Upload,
+                    TransferJobKind::UploadFile {
+                        local_path,
+                        remote_path,
+                    },
+                    meta.len(),
+                    1,
+                )
+            };
+            ids.push(self.insert_and_queue(job)?);
+        }
+        Ok(ids)
+    }
+
+    #[instrument(skip(self), fields(scp_session_id = %scp_session_id))]
+    pub async fn enqueue_download(
+        &self,
+        scp_session_id: String,
+        remote_paths: Vec<String>,
+        local_dir: PathBuf,
+    ) -> Result<Vec<String>, ScpError> {
+        self.ensure_worker_spawned();
+        let handle = {
+            let session = self.scp_manager.get_session(&scp_session_id)?;
+            session.ssh_handle.clone()
+        };
+
+        let mut ids = Vec::with_capacity(remote_paths.len());
+        for remote_path in remote_paths {
+            let name = Path::new(&remote_path)
+                .file_name()
+                .map(|n| n.to_string_lossy().to_string())
+                .unwrap_or_else(|| "unknown".to_string());
+
+            let stat = exec::stat(handle.clone(), &remote_path)
+                .await?
+                .ok_or_else(|| ScpError::NotFound(remote_path.clone()))?;
+
+            let local_dest = local_dir.join(&name);
+            let job = if stat.entry_type == super::ScpEntryType::Directory {
+                let (bytes, count) = exec::dir_stats(handle.clone(), &remote_path).await?;
+                Self::new_job(
+                    &scp_session_id,
+                    name,
+                    TransferDirection::Download,
+                    TransferJobKind::DownloadDir {
+                        remote_path,
+                        local_dir: local_dest,
+                    },
+                    bytes,
+                    count,
+                )
+            } else {
+                Self::new_job(
+                    &scp_session_id,
+                    name,
+                    TransferDirection::Download,
+                    TransferJobKind::DownloadFile {
+                        remote_path,
+                        local_path: local_dest,
+                    },
+                    stat.size,
+                    1,
+                )
+            };
+            ids.push(self.insert_and_queue(job)?);
+        }
+        Ok(ids)
+    }
+
+    // ─── Control ─────────────────────────────────────────────────────────────
+
+    #[instrument(skip(self), fields(transfer_id = %transfer_id))]
+    pub fn cancel(&self, transfer_id: &str) -> Result<(), ScpError> {
+        let mut job = self
+            .jobs
+            .get_mut(transfer_id)
+            .ok_or_else(|| ScpError::SessionNotFound(format!("transfer not found: {transfer_id}")))?;
+        job.cancel_token.cancel();
+        if job.status == TransferStatus::Queued {
+            job.status = TransferStatus::Cancelled;
+            let event = job.to_event();
+            drop(job);
+            let _ = self.app_handle.emit("scp:transfer", event);
+        }
+        Ok(())
+    }
+
+    #[instrument(skip(self), fields(transfer_id = %transfer_id))]
+    pub fn retry(&self, transfer_id: &str) -> Result<(), ScpError> {
+        self.ensure_worker_spawned();
+        {
+            let mut job = self.jobs.get_mut(transfer_id).ok_or_else(|| {
+                ScpError::SessionNotFound(format!("transfer not found: {transfer_id}"))
+            })?;
+            match &job.status {
+                TransferStatus::Failed(_) | TransferStatus::Cancelled => {}
+                _ => {
+                    return Err(ScpError::ProtocolError(format!(
+                        "transfer {transfer_id} is not in a failed/cancelled state"
+                    )));
+                }
+            }
+            job.status = TransferStatus::Queued;
+            job.bytes_transferred = 0;
+            job.files_done = 0;
+            job.speed_bps = 0;
+            job.error = None;
+            job.cancel_token = CancellationToken::new();
+            job.last_emit = Instant::now();
+            job.speed_window_bytes = 0;
+            job.speed_window_start = Instant::now();
+            let event = job.to_event();
+            drop(job);
+            let _ = self.app_handle.emit("scp:transfer", event);
+        }
+        self.queue_tx
+            .send(transfer_id.to_string())
+            .map_err(|e| ScpError::ChannelError(e.to_string()))?;
+        Ok(())
+    }
+
+    pub fn list_all(&self) -> Vec<TransferInfo> {
+        self.jobs.iter().map(|r| r.value().to_info()).collect()
+    }
+
+    pub fn clear_finished(&self) {
+        self.jobs.retain(|_, job| {
+            !matches!(
+                &job.status,
+                TransferStatus::Completed | TransferStatus::Failed(_) | TransferStatus::Cancelled
+            )
+        });
+    }
+
+    pub fn set_max_concurrent(&self, n: u32) {
+        let old = self.max_concurrent.swap(n, Ordering::SeqCst);
+        let current = self.semaphore.available_permits() as u32;
+        match n.cmp(&old) {
+            std::cmp::Ordering::Greater => self.semaphore.add_permits((n - old) as usize),
+            std::cmp::Ordering::Less => {
+                let to_remove = (old - n).min(current);
+                for _ in 0..to_remove {
+                    if let Ok(permit) = self.semaphore.try_acquire() {
+                        permit.forget();
+                    }
+                }
+            }
+            std::cmp::Ordering::Equal => {}
+        }
+    }
+}
+
+// ─── Local directory statistics ──────────────────────────────────────────────
+
+async fn walk_local_dir_stats(path: &Path) -> (u64, u32) {
+    let mut visited = HashSet::new();
+    Box::pin(walk_local_dir_inner(path, &mut visited)).await
+}
+
+async fn walk_local_dir_inner(path: &Path, visited: &mut HashSet<PathBuf>) -> (u64, u32) {
+    let canonical = match tokio::fs::canonicalize(path).await {
+        Ok(p) => p,
+        Err(_) => return (0, 0),
+    };
+    if !visited.insert(canonical) {
+        return (0, 0);
+    }
+    let mut total_bytes = 0u64;
+    let mut file_count = 0u32;
+    let mut rd = match tokio::fs::read_dir(path).await {
+        Ok(rd) => rd,
+        Err(_) => return (0, 0),
+    };
+    while let Ok(Some(entry)) = rd.next_entry().await {
+        let meta = match entry.metadata().await {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+        if meta.is_dir() {
+            let (b, c) = Box::pin(walk_local_dir_inner(&entry.path(), visited)).await;
+            total_bytes += b;
+            file_count += c;
+        } else {
+            total_bytes += meta.len();
+            file_count += 1;
+        }
+    }
+    (total_bytes, file_count)
+}
+
+// ─── Execute ───────────────────────────────────────────────────────────────────
+
+async fn execute_transfer(
+    jobs: &Arc<DashMap<String, TransferJobState>>,
+    job_id: &str,
+    scp_manager: &Arc<ScpManager>,
+    app_handle: &AppHandle,
+) {
+    // Cancelled before we got a permit?
+    if let Some(job) = jobs.get(job_id) {
+        if job.cancel_token.is_cancelled() {
+            drop(job);
+            set_job_status(jobs, job_id, TransferStatus::Cancelled, None, app_handle);
+            return;
+        }
+    } else {
+        return;
+    }
+
+    set_job_status(jobs, job_id, TransferStatus::InProgress, None, app_handle);
+
+    // Resolve the SSH handle.
+    let handle = {
+        let sid = match jobs.get(job_id) {
+            Some(j) => j.scp_session_id.clone(),
+            None => return,
+        };
+        match scp_manager.get_session(&sid) {
+            Ok(s) => s.ssh_handle.clone(),
+            Err(e) => {
+                set_job_status(
+                    jobs,
+                    job_id,
+                    TransferStatus::Failed(e.to_string()),
+                    Some(e.to_string()),
+                    app_handle,
+                );
+                return;
+            }
+        }
+    };
+
+    // Snapshot the kind + cancel token without holding the DashMap lock across awaits.
+    let (kind_desc, cancel_token) = {
+        let job = match jobs.get(job_id) {
+            Some(j) => j,
+            None => return,
+        };
+        let desc = match &job.kind {
+            TransferJobKind::UploadFile {
+                local_path,
+                remote_path,
+            } => KindDesc::UploadFile {
+                local_path: local_path.clone(),
+                remote_path: remote_path.clone(),
+            },
+            TransferJobKind::UploadDir {
+                local_path,
+                remote_dir,
+            } => KindDesc::UploadDir {
+                local_path: local_path.clone(),
+                remote_dir: remote_dir.clone(),
+            },
+            TransferJobKind::DownloadFile {
+                remote_path,
+                local_path,
+            } => KindDesc::DownloadFile {
+                remote_path: remote_path.clone(),
+                local_path: local_path.clone(),
+            },
+            TransferJobKind::DownloadDir {
+                remote_path,
+                local_dir,
+            } => KindDesc::DownloadDir {
+                remote_path: remote_path.clone(),
+                local_dir: local_dir.clone(),
+            },
+        };
+        (desc, job.cancel_token.clone())
+    };
+
+    let result = match kind_desc {
+        KindDesc::UploadFile {
+            local_path,
+            remote_path,
+        } => run_upload_file(jobs, job_id, &handle, &local_path, &remote_path, &cancel_token, app_handle).await,
+        KindDesc::UploadDir {
+            local_path,
+            remote_dir,
+        } => run_upload_dir(jobs, job_id, &handle, &local_path, &remote_dir, &cancel_token, app_handle).await,
+        KindDesc::DownloadFile {
+            remote_path,
+            local_path,
+        } => run_download_file(jobs, job_id, &handle, &remote_path, &local_path, &cancel_token, app_handle).await,
+        KindDesc::DownloadDir {
+            remote_path,
+            local_dir,
+        } => run_download_dir(jobs, job_id, &handle, &remote_path, &local_dir, &cancel_token, app_handle).await,
+    };
+
+    let (direction, total_bytes, files_total, bytes_done) = jobs
+        .get(job_id)
+        .map(|j| (j.direction.clone(), j.total_bytes, j.files_total, j.bytes_transferred))
+        .unwrap_or((TransferDirection::Upload, 0, 0, 0));
+
+    match result {
+        Ok(()) => {
+            crate::telemetry::capture("transfer_completed", serde_json::json!({
+                "protocol": "scp",
+                "direction": if direction == TransferDirection::Upload { "upload" } else { "download" },
+                "total_bytes": total_bytes,
+                "files_total": files_total,
+            }));
+            set_job_status(jobs, job_id, TransferStatus::Completed, None, app_handle);
+        }
+        Err(ScpError::TransferCancelled) => {
+            set_job_status(jobs, job_id, TransferStatus::Cancelled, None, app_handle)
+        }
+        Err(e) => {
+            crate::telemetry::capture("transfer_failed", serde_json::json!({
+                "protocol": "scp",
+                "direction": if direction == TransferDirection::Upload { "upload" } else { "download" },
+                "bytes_transferred": bytes_done,
+                "total_bytes": total_bytes,
+            }));
+            set_job_status(
+                jobs,
+                job_id,
+                TransferStatus::Failed(e.to_string()),
+                Some(e.to_string()),
+                app_handle,
+            );
+        }
+    }
+}
+
+enum KindDesc {
+    UploadFile { local_path: PathBuf, remote_path: String },
+    UploadDir { local_path: PathBuf, remote_dir: String },
+    DownloadFile { remote_path: String, local_path: PathBuf },
+    DownloadDir { remote_path: String, local_dir: PathBuf },
+}
+
+// ─── Status / progress helpers ─────────────────────────────────────────────────
+
+fn set_job_status(
+    jobs: &Arc<DashMap<String, TransferJobState>>,
+    job_id: &str,
+    status: TransferStatus,
+    error: Option<String>,
+    app_handle: &AppHandle,
+) {
+    if let Some(mut job) = jobs.get_mut(job_id) {
+        job.status = status;
+        job.error = error;
+        let event = job.to_event();
+        drop(job);
+        let _ = app_handle.emit("scp:transfer", event);
+    }
+}
+
+/// Set the absolute cumulative byte count for the current transfer and emit a
+/// throttled progress event. `base_bytes` is the bytes completed by prior
+/// files in a multi-file job; `file_bytes` is progress within the current file.
+fn report_progress(
+    jobs: &Arc<DashMap<String, TransferJobState>>,
+    job_id: &str,
+    cumulative: u64,
+    app_handle: &AppHandle,
+) {
+    if let Some(mut job) = jobs.get_mut(job_id) {
+        let delta = cumulative.saturating_sub(job.bytes_transferred);
+        job.bytes_transferred = cumulative;
+        job.speed_window_bytes += delta;
+
+        let window_elapsed = job.speed_window_start.elapsed();
+        if window_elapsed >= SPEED_WINDOW {
+            let secs = window_elapsed.as_secs_f64().max(0.001);
+            job.speed_bps = (job.speed_window_bytes as f64 / secs) as u64;
+            job.speed_window_bytes = 0;
+            job.speed_window_start = Instant::now();
+        } else if job.speed_bps == 0 && window_elapsed.as_millis() > 200 {
+            let secs = window_elapsed.as_secs_f64().max(0.001);
+            job.speed_bps = (job.speed_window_bytes as f64 / secs) as u64;
+        }
+
+        if job.last_emit.elapsed() >= EMIT_THROTTLE {
+            job.last_emit = Instant::now();
+            let event = job.to_event();
+            drop(job);
+            let _ = app_handle.emit("scp:transfer", event);
+        }
+    }
+}
+
+fn mark_file_done(jobs: &Arc<DashMap<String, TransferJobState>>, job_id: &str) {
+    if let Some(mut job) = jobs.get_mut(job_id) {
+        job.files_done += 1;
+    }
+}
+
+// ─── Runners ───────────────────────────────────────────────────────────────────
+
+type Handle_ = Arc<Mutex<Handle<SshClientHandler>>>;
+
+async fn run_upload_file(
+    jobs: &Arc<DashMap<String, TransferJobState>>,
+    job_id: &str,
+    handle: &Handle_,
+    local_path: &Path,
+    remote_path: &str,
+    cancel: &CancellationToken,
+    app_handle: &AppHandle,
+) -> Result<(), ScpError> {
+    // Ensure the remote parent exists.
+    if let Some(parent) = Path::new(remote_path).parent() {
+        let p = parent.to_string_lossy();
+        if !p.is_empty() && p != "/" {
+            exec::mkdir_p(handle.clone(), &p).await?;
+        }
+    }
+
+    let jobs_cl = jobs.clone();
+    let app_cl = app_handle.clone();
+    let jid = job_id.to_string();
+    transfer::upload_file(handle.clone(), local_path, remote_path, cancel, move |done| {
+        report_progress(&jobs_cl, &jid, done, &app_cl);
+    })
+    .await?;
+    mark_file_done(jobs, job_id);
+    Ok(())
+}
+
+async fn run_download_file(
+    jobs: &Arc<DashMap<String, TransferJobState>>,
+    job_id: &str,
+    handle: &Handle_,
+    remote_path: &str,
+    local_path: &Path,
+    cancel: &CancellationToken,
+    app_handle: &AppHandle,
+) -> Result<(), ScpError> {
+    if let Some(parent) = local_path.parent() {
+        tokio::fs::create_dir_all(parent)
+            .await
+            .map_err(|e| ScpError::LocalIoError(e.to_string()))?;
+    }
+
+    let jobs_cl = jobs.clone();
+    let app_cl = app_handle.clone();
+    let jid = job_id.to_string();
+    transfer::download_file(handle.clone(), remote_path, local_path, cancel, move |done| {
+        report_progress(&jobs_cl, &jid, done, &app_cl);
+    })
+    .await?;
+    mark_file_done(jobs, job_id);
+    Ok(())
+}
+
+async fn run_upload_dir(
+    jobs: &Arc<DashMap<String, TransferJobState>>,
+    job_id: &str,
+    handle: &Handle_,
+    local_root: &Path,
+    remote_root: &str,
+    cancel: &CancellationToken,
+    app_handle: &AppHandle,
+) -> Result<(), ScpError> {
+    exec::mkdir_p(handle.clone(), remote_root).await?;
+
+    // base_bytes accumulates completed-file totals so the per-file callback
+    // can report a job-wide cumulative count.
+    let mut base_bytes: u64 = 0;
+    let mut stack = vec![local_root.to_path_buf()];
+
+    while let Some(dir) = stack.pop() {
+        if cancel.is_cancelled() {
+            return Err(ScpError::TransferCancelled);
+        }
+        let rel = dir.strip_prefix(local_root).unwrap_or(Path::new(""));
+        let remote_dir = join_under(remote_root, rel);
+        exec::mkdir_p(handle.clone(), &remote_dir).await?;
+
+        let mut rd = tokio::fs::read_dir(&dir)
+            .await
+            .map_err(|e| ScpError::LocalIoError(e.to_string()))?;
+        while let Ok(Some(entry)) = rd.next_entry().await {
+            if cancel.is_cancelled() {
+                return Err(ScpError::TransferCancelled);
+            }
+            let meta = match entry.metadata().await {
+                Ok(m) => m,
+                Err(_) => continue,
+            };
+            let entry_path = entry.path();
+            if meta.is_dir() {
+                stack.push(entry_path);
+            } else {
+                let file_name = entry.file_name().to_string_lossy().to_string();
+                let remote_file = format!("{}/{}", remote_dir.trim_end_matches('/'), file_name);
+                let jobs_cl = jobs.clone();
+                let app_cl = app_handle.clone();
+                let jid = job_id.to_string();
+                let start = base_bytes;
+                transfer::upload_file(
+                    handle.clone(),
+                    &entry_path,
+                    &remote_file,
+                    cancel,
+                    move |done| report_progress(&jobs_cl, &jid, start + done, &app_cl),
+                )
+                .await?;
+                base_bytes += meta.len();
+                mark_file_done(jobs, job_id);
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn run_download_dir(
+    jobs: &Arc<DashMap<String, TransferJobState>>,
+    job_id: &str,
+    handle: &Handle_,
+    remote_root: &str,
+    local_root: &Path,
+    cancel: &CancellationToken,
+    app_handle: &AppHandle,
+) -> Result<(), ScpError> {
+    tokio::fs::create_dir_all(local_root)
+        .await
+        .map_err(|e| ScpError::LocalIoError(e.to_string()))?;
+
+    let mut tree = exec::enumerate_tree(handle.clone(), remote_root).await?;
+    // Create directories before files: shallower paths first.
+    tree.sort_by_key(|e| (!e.is_dir, e.rel_path.matches('/').count()));
+
+    let mut base_bytes: u64 = 0;
+    for entry in tree {
+        if cancel.is_cancelled() {
+            return Err(ScpError::TransferCancelled);
+        }
+        let local_path = local_root.join(&entry.rel_path);
+        if entry.is_dir {
+            tokio::fs::create_dir_all(&local_path)
+                .await
+                .map_err(|e| ScpError::LocalIoError(e.to_string()))?;
+            continue;
+        }
+        if let Some(parent) = local_path.parent() {
+            tokio::fs::create_dir_all(parent)
+                .await
+                .map_err(|e| ScpError::LocalIoError(e.to_string()))?;
+        }
+        let remote_file = format!("{}/{}", remote_root.trim_end_matches('/'), entry.rel_path);
+        let jobs_cl = jobs.clone();
+        let app_cl = app_handle.clone();
+        let jid = job_id.to_string();
+        let start = base_bytes;
+        transfer::download_file(
+            handle.clone(),
+            &remote_file,
+            &local_path,
+            cancel,
+            move |done| report_progress(&jobs_cl, &jid, start + done, &app_cl),
+        )
+        .await?;
+        base_bytes += entry.size;
+        mark_file_done(jobs, job_id);
+    }
+    Ok(())
+}
+
+/// Join `base` with a relative path, yielding a remote-style `/`-separated
+/// path. An empty `rel` returns `base` unchanged.
+fn join_under(base: &str, rel: &Path) -> String {
+    let rel_str = rel.to_string_lossy();
+    if rel_str.is_empty() {
+        base.to_string()
+    } else {
+        // Normalize Windows separators just in case (local paths on Windows).
+        let rel_norm = rel_str.replace('\\', "/");
+        format!("{}/{}", base.trim_end_matches('/'), rel_norm)
+    }
+}

--- a/src-tauri/src/scp/wire.rs
+++ b/src-tauri/src/scp/wire.rs
@@ -1,0 +1,488 @@
+//! SCP (rcp-over-ssh) wire protocol.
+//!
+//! Reference: the on-the-wire format used by OpenSSH `scp -t` (sink) and
+//! `scp -f` (source). Messages are byte-oriented and synchronous:
+//!
+//! - **Ack byte**: `\0` = success. `\1 <msg>\n` = warning (continue).
+//!   `\2 <msg>\n` = fatal (abort).
+//! - **C record**: `C<mode_octal_4> <size_decimal> <name>\n` — a file
+//!   header. After the ack, exactly `size` bytes follow, then the sender
+//!   writes one `\0` byte and waits for an ack.
+//! - **D record**: `D<mode_octal_4> 0 <name>\n` — enter a subdirectory.
+//! - **E record**: `E\n` — leave the current subdirectory.
+//! - **T record**: `T<mtime> 0 <atime> 0\n` — set timestamps on the next
+//!   C or D record (only used with `-p`).
+//!
+//! This module operates on any `AsyncRead + AsyncWrite` so it can be unit
+//! tested against a `tokio::io::duplex` pair without an SSH connection.
+
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+
+use super::ScpError;
+
+/// Maximum length of a single header line. Real scp lines are well under
+/// 4 KiB; cap reads to prevent a malicious peer from forcing unbounded
+/// allocation.
+const MAX_LINE_LEN: usize = 4096;
+
+/// A single rcp-protocol record.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ScpMsg {
+    /// `C<mode> <size> <name>\n` — file header.
+    File { mode: u32, size: u64, name: String },
+    /// `D<mode> 0 <name>\n` — enter directory.
+    Dir { mode: u32, name: String },
+    /// `E\n` — leave the current directory.
+    EndDir,
+    /// `T<mtime> 0 <atime> 0\n` — timestamp metadata for the next File/Dir.
+    Time { mtime: u64, atime: u64 },
+}
+
+// ─── Ack handling ────────────────────────────────────────────────────────────
+
+/// Read a single ack byte. `\0` returns Ok; `\1` / `\2` read the trailing
+/// error message and surface it as `ScpError::RemoteError`.
+pub async fn read_ack<R: AsyncRead + Unpin>(reader: &mut R) -> Result<(), ScpError> {
+    let mut buf = [0u8; 1];
+    reader.read_exact(&mut buf).await?;
+    match buf[0] {
+        0 => Ok(()),
+        1 | 2 => {
+            let msg = read_line(reader).await?;
+            Err(ScpError::RemoteError(msg))
+        }
+        b => Err(ScpError::ProtocolError(format!(
+            "unexpected ack byte: 0x{b:02x}"
+        ))),
+    }
+}
+
+/// Write a single `\0` ack byte and flush.
+pub async fn write_ack<W: AsyncWrite + Unpin>(writer: &mut W) -> Result<(), ScpError> {
+    writer.write_all(&[0u8]).await?;
+    writer.flush().await?;
+    Ok(())
+}
+
+// ─── Line reader ─────────────────────────────────────────────────────────────
+
+/// Read bytes until `\n` (not included). Errors on EOF or oversized line.
+async fn read_line<R: AsyncRead + Unpin>(reader: &mut R) -> Result<String, ScpError> {
+    let mut buf = Vec::with_capacity(64);
+    let mut byte = [0u8; 1];
+    loop {
+        let n = reader.read(&mut byte).await?;
+        if n == 0 {
+            return Err(ScpError::ProtocolError(
+                "unexpected EOF while reading line".into(),
+            ));
+        }
+        if byte[0] == b'\n' {
+            break;
+        }
+        if buf.len() >= MAX_LINE_LEN {
+            return Err(ScpError::ProtocolError("line exceeded 4 KiB".into()));
+        }
+        buf.push(byte[0]);
+    }
+    String::from_utf8(buf).map_err(|e| ScpError::ProtocolError(format!("invalid UTF-8: {e}")))
+}
+
+// ─── Message read/write ──────────────────────────────────────────────────────
+
+/// Read the next protocol message from the source side.
+///
+/// Returns `Ok(None)` if the stream EOFs cleanly between records (this is
+/// how `scp -f` signals "no more entries"). Errors on partial reads or
+/// malformed records.
+pub async fn read_msg<R: AsyncRead + Unpin>(reader: &mut R) -> Result<Option<ScpMsg>, ScpError> {
+    let mut byte = [0u8; 1];
+    let n = reader.read(&mut byte).await?;
+    if n == 0 {
+        return Ok(None);
+    }
+    let kind = byte[0];
+    let line = read_line(reader).await?;
+
+    match kind {
+        b'C' => {
+            let (mode, size, name) = parse_c_or_d_payload(&line, true)?;
+            Ok(Some(ScpMsg::File { mode, size, name }))
+        }
+        b'D' => {
+            let (mode, _, name) = parse_c_or_d_payload(&line, false)?;
+            Ok(Some(ScpMsg::Dir { mode, name }))
+        }
+        b'E' => {
+            if !line.is_empty() {
+                return Err(ScpError::ProtocolError(format!(
+                    "E record had trailing data: {line:?}"
+                )));
+            }
+            Ok(Some(ScpMsg::EndDir))
+        }
+        b'T' => {
+            let (mtime, atime) = parse_t_payload(&line)?;
+            Ok(Some(ScpMsg::Time { mtime, atime }))
+        }
+        1 | 2 => Err(ScpError::RemoteError(line)),
+        b => Err(ScpError::ProtocolError(format!(
+            "unexpected message kind: 0x{b:02x}"
+        ))),
+    }
+}
+
+/// Write a single record (header line only — caller is responsible for the
+/// body bytes after a `File` record).
+pub async fn write_msg<W: AsyncWrite + Unpin>(
+    writer: &mut W,
+    msg: &ScpMsg,
+) -> Result<(), ScpError> {
+    let line = match msg {
+        ScpMsg::File { mode, size, name } => {
+            validate_name(name)?;
+            format!("C{:04o} {} {}\n", mode & 0o7777, size, name)
+        }
+        ScpMsg::Dir { mode, name } => {
+            validate_name(name)?;
+            format!("D{:04o} 0 {}\n", mode & 0o7777, name)
+        }
+        ScpMsg::EndDir => "E\n".to_string(),
+        ScpMsg::Time { mtime, atime } => format!("T{mtime} 0 {atime} 0\n"),
+    };
+    writer.write_all(line.as_bytes()).await?;
+    writer.flush().await?;
+    Ok(())
+}
+
+fn validate_name(name: &str) -> Result<(), ScpError> {
+    // Names must not contain '/' (path separators) or '\n' (record terminator),
+    // and must not be empty. scp itself wraps them as "basename only".
+    if name.is_empty() {
+        return Err(ScpError::ProtocolError("name is empty".into()));
+    }
+    if name.contains('/') {
+        return Err(ScpError::ProtocolError(format!(
+            "name contains '/': {name}"
+        )));
+    }
+    if name.contains('\n') {
+        return Err(ScpError::ProtocolError("name contains newline".into()));
+    }
+    Ok(())
+}
+
+// ─── Payload parsers ────────────────────────────────────────────────────────
+
+/// Parse the payload after the leading `C` or `D` byte:
+/// `<mode_octal> <size> <name>`. For directories `<size>` is always 0.
+fn parse_c_or_d_payload(line: &str, _is_file: bool) -> Result<(u32, u64, String), ScpError> {
+    // Format: "0644 1234 filename\n" — split into 3 fields, with name being
+    // the rest after the second space (names may contain spaces themselves).
+    let first_sp = line.find(' ').ok_or_else(|| {
+        ScpError::ProtocolError(format!("C/D record missing first space: {line:?}"))
+    })?;
+    let mode_str = &line[..first_sp];
+    let rest = &line[first_sp + 1..];
+
+    let second_sp = rest.find(' ').ok_or_else(|| {
+        ScpError::ProtocolError(format!("C/D record missing second space: {line:?}"))
+    })?;
+    let size_str = &rest[..second_sp];
+    let name = &rest[second_sp + 1..];
+
+    let mode = u32::from_str_radix(mode_str, 8)
+        .map_err(|e| ScpError::ProtocolError(format!("invalid mode {mode_str:?}: {e}")))?;
+    let size: u64 = size_str
+        .parse()
+        .map_err(|e| ScpError::ProtocolError(format!("invalid size {size_str:?}: {e}")))?;
+
+    if name.is_empty() {
+        return Err(ScpError::ProtocolError("C/D record has empty name".into()));
+    }
+
+    Ok((mode, size, name.to_string()))
+}
+
+/// Parse the payload after the leading `T` byte:
+/// `<mtime> 0 <atime> 0`.
+fn parse_t_payload(line: &str) -> Result<(u64, u64), ScpError> {
+    let parts: Vec<&str> = line.split_whitespace().collect();
+    if parts.len() != 4 {
+        return Err(ScpError::ProtocolError(format!(
+            "T record expected 4 fields, got {}: {line:?}",
+            parts.len()
+        )));
+    }
+    let mtime: u64 = parts[0]
+        .parse()
+        .map_err(|e| ScpError::ProtocolError(format!("invalid mtime: {e}")))?;
+    let atime: u64 = parts[2]
+        .parse()
+        .map_err(|e| ScpError::ProtocolError(format!("invalid atime: {e}")))?;
+    Ok((mtime, atime))
+}
+
+// ─── Streaming helpers ───────────────────────────────────────────────────────
+
+/// Stream `total` bytes from `reader` into `writer` in `CHUNK`-sized blocks,
+/// invoking `on_progress(bytes_done_so_far, chunk_len)` after each write.
+/// Polls `cancel()` between chunks — returns `TransferCancelled` if it goes
+/// high.
+///
+/// The callback receives the *cumulative* bytes_transferred so far so it
+/// matches the existing SFTP progress shape.
+pub async fn stream_bytes<R, W, F, C>(
+    reader: &mut R,
+    writer: &mut W,
+    total: u64,
+    chunk_size: usize,
+    cancel: C,
+    mut on_progress: F,
+) -> Result<(), ScpError>
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+    F: FnMut(u64),
+    C: Fn() -> bool,
+{
+    let mut buf = vec![0u8; chunk_size];
+    let mut remaining = total;
+    let mut transferred: u64 = 0;
+
+    while remaining > 0 {
+        if cancel() {
+            return Err(ScpError::TransferCancelled);
+        }
+        let want = (remaining as usize).min(chunk_size);
+        let n = reader.read(&mut buf[..want]).await?;
+        if n == 0 {
+            return Err(ScpError::ProtocolError(format!(
+                "unexpected EOF: {remaining} bytes still expected"
+            )));
+        }
+        writer.write_all(&buf[..n]).await?;
+        transferred += n as u64;
+        remaining -= n as u64;
+        on_progress(transferred);
+    }
+    writer.flush().await?;
+    Ok(())
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::{duplex, AsyncWriteExt};
+
+    #[tokio::test]
+    async fn ack_ok_round_trip() {
+        let (mut a, mut b) = duplex(64);
+        write_ack(&mut a).await.unwrap();
+        read_ack(&mut b).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn ack_warning_surfaces_message() {
+        let (mut a, mut b) = duplex(64);
+        a.write_all(b"\x01boom\n").await.unwrap();
+        let err = read_ack(&mut b).await.unwrap_err();
+        assert!(matches!(err, ScpError::RemoteError(m) if m == "boom"));
+    }
+
+    #[tokio::test]
+    async fn ack_fatal_surfaces_message() {
+        let (mut a, mut b) = duplex(64);
+        a.write_all(b"\x02file not found\n").await.unwrap();
+        let err = read_ack(&mut b).await.unwrap_err();
+        assert!(matches!(err, ScpError::RemoteError(m) if m == "file not found"));
+    }
+
+    #[tokio::test]
+    async fn read_c_record() {
+        let (mut a, mut b) = duplex(64);
+        a.write_all(b"C0644 1234 hello.txt\n").await.unwrap();
+        let msg = read_msg(&mut b).await.unwrap().unwrap();
+        assert_eq!(
+            msg,
+            ScpMsg::File {
+                mode: 0o644,
+                size: 1234,
+                name: "hello.txt".to_string(),
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn read_d_then_e() {
+        let (mut a, mut b) = duplex(64);
+        a.write_all(b"D0755 0 subdir\nE\n").await.unwrap();
+        let msg1 = read_msg(&mut b).await.unwrap().unwrap();
+        let msg2 = read_msg(&mut b).await.unwrap().unwrap();
+        assert_eq!(
+            msg1,
+            ScpMsg::Dir {
+                mode: 0o755,
+                name: "subdir".into()
+            }
+        );
+        assert_eq!(msg2, ScpMsg::EndDir);
+    }
+
+    #[tokio::test]
+    async fn read_t_record() {
+        let (mut a, mut b) = duplex(64);
+        a.write_all(b"T1700000000 0 1700000001 0\n").await.unwrap();
+        let msg = read_msg(&mut b).await.unwrap().unwrap();
+        assert_eq!(
+            msg,
+            ScpMsg::Time {
+                mtime: 1700000000,
+                atime: 1700000001
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn read_eof_returns_none() {
+        let (a, mut b) = duplex(64);
+        drop(a);
+        let msg = read_msg(&mut b).await.unwrap();
+        assert_eq!(msg, None);
+    }
+
+    #[tokio::test]
+    async fn read_name_with_spaces() {
+        let (mut a, mut b) = duplex(64);
+        a.write_all(b"C0644 10 my file.txt\n").await.unwrap();
+        let msg = read_msg(&mut b).await.unwrap().unwrap();
+        assert_eq!(
+            msg,
+            ScpMsg::File {
+                mode: 0o644,
+                size: 10,
+                name: "my file.txt".into()
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn write_c_record_formats_correctly() {
+        let (mut a, mut b) = duplex(64);
+        write_msg(
+            &mut a,
+            &ScpMsg::File {
+                mode: 0o644,
+                size: 99,
+                name: "data.bin".into(),
+            },
+        )
+        .await
+        .unwrap();
+        let mut buf = [0u8; 32];
+        let n = b.read(&mut buf).await.unwrap();
+        assert_eq!(&buf[..n], b"C0644 99 data.bin\n");
+    }
+
+    #[tokio::test]
+    async fn write_d_e_round_trip() {
+        let (mut a, mut b) = duplex(64);
+        write_msg(
+            &mut a,
+            &ScpMsg::Dir {
+                mode: 0o755,
+                name: "sub".into(),
+            },
+        )
+        .await
+        .unwrap();
+        write_msg(&mut a, &ScpMsg::EndDir).await.unwrap();
+        let msg1 = read_msg(&mut b).await.unwrap().unwrap();
+        let msg2 = read_msg(&mut b).await.unwrap().unwrap();
+        assert!(matches!(msg1, ScpMsg::Dir { mode: 0o755, .. }));
+        assert_eq!(msg2, ScpMsg::EndDir);
+    }
+
+    #[tokio::test]
+    async fn write_rejects_name_with_slash() {
+        let (mut a, _b) = duplex(64);
+        let err = write_msg(
+            &mut a,
+            &ScpMsg::File {
+                mode: 0o644,
+                size: 1,
+                name: "a/b".into(),
+            },
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(err, ScpError::ProtocolError(_)));
+    }
+
+    #[tokio::test]
+    async fn malformed_c_record_errors() {
+        let (mut a, mut b) = duplex(64);
+        a.write_all(b"C0644\n").await.unwrap();
+        let err = read_msg(&mut b).await.unwrap_err();
+        assert!(matches!(err, ScpError::ProtocolError(_)));
+    }
+
+    #[tokio::test]
+    async fn invalid_octal_mode_errors() {
+        let (mut a, mut b) = duplex(64);
+        a.write_all(b"C9999 10 file\n").await.unwrap();
+        let err = read_msg(&mut b).await.unwrap_err();
+        assert!(matches!(err, ScpError::ProtocolError(_)));
+    }
+
+    #[tokio::test]
+    async fn stream_bytes_copies_exact_count() {
+        let (mut a, mut b) = duplex(1024);
+        let payload = b"hello world".to_vec();
+        let total = payload.len() as u64;
+
+        // Writer drains into `a`, reader reads from a separate cursor.
+        let (mut src_w, mut src_r) = duplex(1024);
+        src_w.write_all(&payload).await.unwrap();
+        drop(src_w);
+
+        let mut progress_calls: Vec<u64> = Vec::new();
+        stream_bytes(
+            &mut src_r,
+            &mut a,
+            total,
+            4,
+            || false,
+            |done| progress_calls.push(done),
+        )
+        .await
+        .unwrap();
+
+        let mut received = vec![0u8; payload.len()];
+        b.read_exact(&mut received).await.unwrap();
+        assert_eq!(received, payload);
+        assert_eq!(*progress_calls.last().unwrap(), total);
+    }
+
+    #[tokio::test]
+    async fn stream_bytes_honors_cancel() {
+        let (mut sink, _drain) = duplex(1024);
+        let (mut src_w, mut src_r) = duplex(1024);
+        src_w.write_all(&vec![0u8; 100]).await.unwrap();
+        drop(src_w);
+
+        let err = stream_bytes(
+            &mut src_r,
+            &mut sink,
+            100,
+            8,
+            || true, // cancelled from the start
+            |_| {},
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(err, ScpError::TransferCancelled));
+    }
+}

--- a/src/components/dashboard/HostsDashboard.tsx
+++ b/src/components/dashboard/HostsDashboard.tsx
@@ -258,9 +258,11 @@ export function HostsDashboard() {
     [],
   );
 
-  // Explore: connect SSH + open SFTP + switch to Files page
+  // Explore: connect SSH + open a file browser + switch to Files page.
+  // Prefers SFTP; transparently falls back to SCP on the same SSH connection
+  // when the server has the SFTP subsystem disabled — the user never picks.
   // NOTE: We don't call addSession — the SSH connection lives in Rust's SshManager
-  // but we don't need a terminal pane for SFTP-only connections.
+  // but we don't need a terminal pane for file-only connections.
   const exploreHost = useCallback(
     async (host: SavedHost) => {
       const label = host.label || `${host.username}@${host.host}`;
@@ -269,11 +271,26 @@ export function HostsDashboard() {
         const { invoke } = await import("@tauri-apps/api/core");
 
         const sessionId = await invoke<string>("connect_saved_host_no_pty", { hostId: host.id });
-        const sftpSessionId = await invoke<string>("sftp_open", { sessionId });
-        useSftpStore.getState().openSession(sftpSessionId, sessionId, label);
+
+        let explorerSessionId: string;
+        let transport: "sftp" | "scp" = "sftp";
+        try {
+          explorerSessionId = await invoke<string>("sftp_open", { sessionId });
+        } catch (sftpErr) {
+          // SFTP subsystem unavailable — retry over SCP on the same connection.
+          try {
+            explorerSessionId = await invoke<string>("scp_open", { sessionId });
+            transport = "scp";
+          } catch {
+            // Surface the original SFTP error if SCP also fails.
+            throw sftpErr;
+          }
+        }
+
+        useSftpStore.getState().openSession(explorerSessionId, sessionId, label);
 
         setConnectingHost(null);
-        useTabStore.getState().addTab({ type: "sftp", id: sftpSessionId, label });
+        useTabStore.getState().addTab({ type: "sftp", id: explorerSessionId, label, transport });
       } catch (err) {
         const msg = err && typeof err === "object" && "message" in err
           ? String((err as { message: string }).message)

--- a/src/components/history/HistoryPage.tsx
+++ b/src/components/history/HistoryPage.tsx
@@ -125,10 +125,25 @@ export function HistoryPage() {
     try {
       const { invoke } = await import("@tauri-apps/api/core");
       const sessionId = await invoke<string>("connect_saved_host_no_pty", { hostId: entry.host_id });
-      const sftpSessionId = await invoke<string>("sftp_open", { sessionId });
       const label = entry.host_label || `${entry.username}@${entry.host}`;
-      useSftpStore.getState().openSession(sftpSessionId, sessionId, label);
-      useTabStore.getState().addTab({ type: "sftp", id: sftpSessionId, label });
+
+      // Prefer SFTP; fall back to SCP on the same connection when the SFTP
+      // subsystem is disabled.
+      let explorerSessionId: string;
+      let transport: "sftp" | "scp" = "sftp";
+      try {
+        explorerSessionId = await invoke<string>("sftp_open", { sessionId });
+      } catch (sftpErr) {
+        try {
+          explorerSessionId = await invoke<string>("scp_open", { sessionId });
+          transport = "scp";
+        } catch {
+          throw sftpErr;
+        }
+      }
+
+      useSftpStore.getState().openSession(explorerSessionId, sessionId, label);
+      useTabStore.getState().addTab({ type: "sftp", id: explorerSessionId, label, transport });
     } catch {
       // Errors surface via SFTP page
     }

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -266,7 +266,7 @@ export function AppShell() {
             {activeTab && activeTab.type !== "terminal" && (
               <div className="absolute inset-0 z-10">
                 {activeTab.type === "sftp" ? (
-                  <ExplorerPage sftpSessionId={activeTab.id} />
+                  <ExplorerPage sftpSessionId={activeTab.id} transport={activeTab.transport ?? "sftp"} />
                 ) : activeTab.type === "s3" ? (
                   <ExplorerPage s3SessionId={activeTab.id} />
                 ) : activePageType === "hosts" ? (

--- a/src/components/sftp/ExplorerPage.tsx
+++ b/src/components/sftp/ExplorerPage.tsx
@@ -1,19 +1,26 @@
 import { FolderOpen, Cloud } from "lucide-react";
-import { SftpBrowser } from "./SftpBrowser";
+import { ExplorerView } from "./ExplorerView";
 import { S3Browser } from "../s3/S3Browser";
 import { useSftpStore } from "../../stores/sftp-store";
 import { useS3Store } from "../../stores/s3-store";
+import type { Transport } from "../../lib/explorer-transport";
 
 interface ExplorerPageProps {
+  /** SFTP/SCP transport session id (both live in the sftp store). */
   sftpSessionId?: string;
+  /** Defaults to "sftp"; "scp" when the host fell back to SCP. */
+  transport?: Transport;
   s3SessionId?: string;
 }
 
-export function ExplorerPage({ sftpSessionId, s3SessionId }: ExplorerPageProps) {
+export function ExplorerPage({ sftpSessionId, transport = "sftp", s3SessionId }: ExplorerPageProps) {
   const sftpSession = useSftpStore((s) => sftpSessionId ? s.sessions.get(sftpSessionId) : null);
   const s3Session = useS3Store((s) => s3SessionId ? s.sessions.get(s3SessionId) : null);
 
-  const label = sftpSession?.label ?? s3Session?.label ?? "Explorer";
+  const baseLabel = sftpSession?.label ?? s3Session?.label ?? "Explorer";
+  // Surface SCP fallback subtly so the user understands why server-side
+  // metadata (timestamps, etc.) may look slightly different.
+  const label = sftpSessionId && transport === "scp" ? `${baseLabel} · SCP` : baseLabel;
   const isSftp = !!sftpSessionId;
   const Icon = isSftp ? FolderOpen : Cloud;
 
@@ -30,7 +37,7 @@ export function ExplorerPage({ sftpSessionId, s3SessionId }: ExplorerPageProps) 
 
         {/* Browser content */}
         <div className="flex-1 min-h-0 bg-bg-base">
-          {sftpSessionId && <SftpBrowser sftpSessionId={sftpSessionId} />}
+          {sftpSessionId && <ExplorerView sessionId={sftpSessionId} transport={transport} />}
           {s3SessionId && <S3Browser sessionId={s3SessionId} />}
         </div>
       </div>

--- a/src/components/sftp/ExplorerPage.tsx
+++ b/src/components/sftp/ExplorerPage.tsx
@@ -36,7 +36,10 @@ export function ExplorerPage({ sftpSessionId, transport = "sftp", s3SessionId }:
         </div>
 
         {/* Browser content */}
-        <div className="flex-1 min-h-0 bg-bg-base">
+        <div
+          className="flex-1 min-h-0 bg-bg-base"
+          data-explorer-transport={sftpSessionId ? transport : s3SessionId ? "s3" : undefined}
+        >
           {sftpSessionId && <ExplorerView sessionId={sftpSessionId} transport={transport} />}
           {s3SessionId && <S3Browser sessionId={s3SessionId} />}
         </div>

--- a/src/components/sftp/ExplorerView.tsx
+++ b/src/components/sftp/ExplorerView.tsx
@@ -5,13 +5,21 @@ import type { SftpEntry } from "../../types";
 import type { ExplorerEntry, ExplorerClipboard } from "../../types/explorer";
 import { ExplorerToolbar, ExplorerFileTable, ExplorerDropZone } from "../explorer";
 import { createSftpProvider, toExplorerEntry } from "../../providers/sftp-provider";
+import { explorerInvoke, transferEventName, type Transport } from "../../lib/explorer-transport";
 
-interface SftpBrowserProps {
-  sftpSessionId: string;
+interface ExplorerViewProps {
+  /** The transport session id (sftp_session_id or scp_session_id). */
+  sessionId: string;
+  /**
+   * Which transport backs this view. SCP is selected automatically as a
+   * fallback when the host lacks the SFTP subsystem; SFTP and SCP share the
+   * same command surface and session store, differing only in dispatch.
+   */
+  transport?: Transport;
 }
 
-export function SftpBrowser({ sftpSessionId }: SftpBrowserProps) {
-  const session = useSftpStore((s) => s.sessions.get(sftpSessionId));
+export function ExplorerView({ sessionId, transport = "sftp" }: ExplorerViewProps) {
+  const session = useSftpStore((s) => s.sessions.get(sessionId));
   const setEntries = useSftpStore((s) => s.setEntries);
   const setLoading = useSftpStore((s) => s.setLoading);
   const setError = useSftpStore((s) => s.setError);
@@ -19,7 +27,7 @@ export function SftpBrowser({ sftpSessionId }: SftpBrowserProps) {
   const clipboard = useSftpStore((s) => s.clipboard);
   const setClipboard = useSftpStore((s) => s.setClipboard);
 
-  const provider = useMemo(() => createSftpProvider(sftpSessionId), [sftpSessionId]);
+  const provider = useMemo(() => createSftpProvider(sessionId), [sessionId]);
 
   // ─── Drag-and-drop (OS → App) ─────────────────────────────────────────────
 
@@ -68,9 +76,7 @@ export function SftpBrowser({ sftpSessionId }: SftpBrowserProps) {
 
             void (async () => {
               try {
-                const { invoke } = await import("@tauri-apps/api/core");
-                await invoke("sftp_enqueue_upload", {
-                  sftpSessionId,
+                await explorerInvoke(transport, "enqueue_upload", sessionId, {
                   localPaths: paths,
                   remoteDir,
                 });
@@ -93,7 +99,7 @@ export function SftpBrowser({ sftpSessionId }: SftpBrowserProps) {
 
     return () => { aborted = true; unlisten?.(); };
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sftpSessionId]);
+  }, [sessionId, transport]);
 
   // ─── Auto-refresh on upload completion ────────────────────────────────────
 
@@ -106,16 +112,14 @@ export function SftpBrowser({ sftpSessionId }: SftpBrowserProps) {
         if (aborted) return;
 
         const unsub = await listen<{
-          sftp_session_id: string;
+          sftp_session_id?: string;
+          scp_session_id?: string;
           direction: string;
           status: string;
-        }>("sftp:transfer", (event) => {
-          const { sftp_session_id, direction, status } = event.payload;
-          if (
-            sftp_session_id === sftpSessionId &&
-            direction === "Upload" &&
-            status === "Completed"
-          ) {
+        }>(transferEventName(transport), (event) => {
+          const { direction, status } = event.payload;
+          const sid = transport === "scp" ? event.payload.scp_session_id : event.payload.sftp_session_id;
+          if (sid === sessionId && direction === "Upload" && status === "Completed") {
             setTimeout(() => {
               const path = currentPathRef.current;
               if (path) void loadDirectory(path);
@@ -130,44 +134,39 @@ export function SftpBrowser({ sftpSessionId }: SftpBrowserProps) {
     })();
     return () => { aborted = true; unlisten?.(); };
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sftpSessionId]);
+  }, [sessionId, transport]);
 
   // ─── Navigation ──────────────────────────────────────────────────────────
 
   const loadDirectory = useCallback(
     async (path: string) => {
-      setLoading(sftpSessionId, true);
+      setLoading(sessionId, true);
       try {
-        const { invoke } = await import("@tauri-apps/api/core");
-        const entries = await invoke<SftpEntry[]>("sftp_list_dir", {
-          sftpSessionId,
-          path,
-        });
-        setEntries(sftpSessionId, path, entries);
+        const entries = await explorerInvoke<SftpEntry[]>(transport, "list_dir", sessionId, { path });
+        setEntries(sessionId, path, entries);
       } catch (err: unknown) {
         const msg =
           err && typeof err === "object" && "message" in err
             ? String((err as { message: string }).message)
             : "Failed to list directory";
-        setError(sftpSessionId, msg);
+        setError(sessionId, msg);
       }
     },
-    [sftpSessionId, setLoading, setEntries, setError],
+    [sessionId, transport, setLoading, setEntries, setError],
   );
 
   // On mount: resolve home dir, then load it
   useEffect(() => {
     (async () => {
       try {
-        const { invoke } = await import("@tauri-apps/api/core");
-        const homeDir = await invoke<string>("sftp_home_dir", { sftpSessionId });
+        const homeDir = await explorerInvoke<string>(transport, "home_dir", sessionId);
         await loadDirectory(homeDir);
       } catch {
         await loadDirectory("/");
       }
     })();
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sftpSessionId]);
+  }, [sessionId, transport]);
 
   // ─── Download (enqueue) ───────────────────────────────────────────────────
 
@@ -188,16 +187,14 @@ export function SftpBrowser({ sftpSessionId }: SftpBrowserProps) {
 
       if (!localDir) return;
 
-      const { invoke } = await import("@tauri-apps/api/core");
-      await invoke("sftp_enqueue_download", {
-        sftpSessionId,
+      await explorerInvoke(transport, "enqueue_download", sessionId, {
         remotePaths: [entry.id],
         localDir,
       });
     } catch (err) {
       console.error("Download enqueue failed:", err);
     }
-  }, [sftpSessionId]);
+  }, [sessionId, transport]);
 
   // ─── Upload (dialog) ─────────────────────────────────────────────────────
 
@@ -220,13 +217,12 @@ export function SftpBrowser({ sftpSessionId }: SftpBrowserProps) {
         ? `${session.currentPath}${fileName}`
         : `${session.currentPath}/${fileName}`;
 
-      const { invoke } = await import("@tauri-apps/api/core");
-      await invoke("sftp_upload", { sftpSessionId, localPath, remotePath });
+      await explorerInvoke(transport, "upload", sessionId, { localPath, remotePath });
       void loadDirectory(session.currentPath);
     } catch {
       // Upload errors show in transfer overlay
     }
-  }, [sftpSessionId, session, loadDirectory]);
+  }, [sessionId, transport, session, loadDirectory]);
 
   // ─── New folder/file (inline) ─────────────────────────────────────────────
 
@@ -254,14 +250,13 @@ export function SftpBrowser({ sftpSessionId }: SftpBrowserProps) {
       if (!name.trim() || !session) return;
       const filePath = provider.joinPath(session.currentPath, name.trim());
       try {
-        const { invoke } = await import("@tauri-apps/api/core");
-        await invoke("sftp_create_file", { sftpSessionId, path: filePath });
+        await explorerInvoke(transport, "create_file", sessionId, { path: filePath });
         await loadDirectory(session.currentPath);
       } catch {
         // Error shown via refresh
       }
     },
-    [sftpSessionId, session, loadDirectory, provider],
+    [sessionId, transport, session, loadDirectory, provider],
   );
 
   const handleCreateFolder = useCallback(
@@ -270,24 +265,21 @@ export function SftpBrowser({ sftpSessionId }: SftpBrowserProps) {
       if (!name.trim() || !session) return;
       const dirPath = provider.joinPath(session.currentPath, name.trim());
       try {
-        const { invoke } = await import("@tauri-apps/api/core");
-        await invoke("sftp_mkdir", { sftpSessionId, path: dirPath });
+        await explorerInvoke(transport, "mkdir", sessionId, { path: dirPath });
         await loadDirectory(session.currentPath);
       } catch {
         // Error shown via refresh
       }
     },
-    [sftpSessionId, session, loadDirectory, provider],
+    [sessionId, transport, session, loadDirectory, provider],
   );
 
   // ─── Delete ──────────────────────────────────────────────────────────────
 
   const handleDelete = useCallback(async (entriesToDelete: ExplorerEntry[]) => {
     try {
-      const { invoke } = await import("@tauri-apps/api/core");
       for (const entry of entriesToDelete) {
-        await invoke("sftp_delete", {
-          sftpSessionId,
+        await explorerInvoke(transport, "delete", sessionId, {
           path: entry.id,
           isDir: entry.entryType === "Directory",
         });
@@ -296,7 +288,7 @@ export function SftpBrowser({ sftpSessionId }: SftpBrowserProps) {
       // Partial deletes may occur
     }
     if (session) void loadDirectory(session.currentPath);
-  }, [sftpSessionId, session, loadDirectory]);
+  }, [sessionId, transport, session, loadDirectory]);
 
   // ─── Rename ──────────────────────────────────────────────────────────────
 
@@ -304,26 +296,24 @@ export function SftpBrowser({ sftpSessionId }: SftpBrowserProps) {
     const parentPath = entry.id.substring(0, entry.id.lastIndexOf("/")) || "/";
     const newPath = `${parentPath}/${newName}`;
     try {
-      const { invoke } = await import("@tauri-apps/api/core");
-      await invoke("sftp_rename", { sftpSessionId, oldPath: entry.id, newPath });
+      await explorerInvoke(transport, "rename", sessionId, { oldPath: entry.id, newPath });
       if (session) void loadDirectory(session.currentPath);
     } catch (err) {
       console.error("Rename failed:", err);
     }
-  }, [sftpSessionId, session, loadDirectory]);
+  }, [sessionId, transport, session, loadDirectory]);
 
   // ─── Edit in VS Code ─────────────────────────────────────────────────────
 
   const handleEditInEditor = useCallback((entry: ExplorerEntry) => {
     void (async () => {
       try {
-        const { invoke } = await import("@tauri-apps/api/core");
-        await invoke("sftp_edit_in_vscode", { sftpSessionId, remotePath: entry.id });
+        await explorerInvoke(transport, "edit_in_vscode", sessionId, { remotePath: entry.id });
       } catch {
         // VS Code may not be installed
       }
     })();
-  }, [sftpSessionId]);
+  }, [sessionId, transport]);
 
   // ─── Paste / Move / Copy ─────────────────────────────────────────────────
 
@@ -331,53 +321,50 @@ export function SftpBrowser({ sftpSessionId }: SftpBrowserProps) {
 
   const handlePaste = useCallback(async () => {
     const clip = useSftpStore.getState().clipboard;
-    if (!clip || clip.sourceSessionId !== sftpSessionId || !session) return;
+    if (!clip || clip.sourceSessionId !== sessionId || !session) return;
 
     const sourcePaths = clip.entries.map((e) => e.path);
     const targetDir = session.currentPath;
 
     setBusy(true);
     try {
-      const { invoke } = await import("@tauri-apps/api/core");
       if (clip.operation === "cut") {
-        await invoke("sftp_move_entries", { sftpSessionId, sourcePaths, targetDir });
+        await explorerInvoke(transport, "move_entries", sessionId, { sourcePaths, targetDir });
         useSftpStore.getState().setClipboard(null);
       } else {
-        await invoke("sftp_copy_entries", { sftpSessionId, sourcePaths, targetDir });
+        await explorerInvoke(transport, "copy_entries", sessionId, { sourcePaths, targetDir });
       }
       await loadDirectory(session.currentPath);
     } catch (err) {
-      setError(sftpSessionId, err instanceof Error ? err.message : "Paste failed");
+      setError(sessionId, err instanceof Error ? err.message : "Paste failed");
     } finally {
       setBusy(false);
     }
-  }, [sftpSessionId, session, loadDirectory, setError]);
+  }, [sessionId, transport, session, loadDirectory, setError]);
 
   const handleMoveEntries = useCallback(async (sourceIds: string[], targetDir: string) => {
     setBusy(true);
     try {
-      const { invoke } = await import("@tauri-apps/api/core");
-      await invoke("sftp_move_entries", { sftpSessionId, sourcePaths: sourceIds, targetDir });
+      await explorerInvoke(transport, "move_entries", sessionId, { sourcePaths: sourceIds, targetDir });
       if (session) await loadDirectory(session.currentPath);
     } catch (err) {
-      setError(sftpSessionId, err instanceof Error ? err.message : "Move failed");
+      setError(sessionId, err instanceof Error ? err.message : "Move failed");
     } finally {
       setBusy(false);
     }
-  }, [sftpSessionId, session, loadDirectory, setError]);
+  }, [sessionId, transport, session, loadDirectory, setError]);
 
   const handleCopyEntries = useCallback(async (sourceIds: string[], targetDir: string) => {
     setBusy(true);
     try {
-      const { invoke } = await import("@tauri-apps/api/core");
-      await invoke("sftp_copy_entries", { sftpSessionId, sourcePaths: sourceIds, targetDir });
+      await explorerInvoke(transport, "copy_entries", sessionId, { sourcePaths: sourceIds, targetDir });
       if (session) await loadDirectory(session.currentPath);
     } catch (err) {
-      setError(sftpSessionId, err instanceof Error ? err.message : "Copy failed");
+      setError(sessionId, err instanceof Error ? err.message : "Copy failed");
     } finally {
       setBusy(false);
     }
-  }, [sftpSessionId, session, loadDirectory, setError]);
+  }, [sessionId, transport, session, loadDirectory, setError]);
 
   // ─── Clipboard adapter ───────────────────────────────────────────────────
   // SftpClipboard uses SftpEntry with `path`, ExplorerClipboard uses ExplorerEntry with `id`.
@@ -471,7 +458,7 @@ export function SftpBrowser({ sftpSessionId }: SftpBrowserProps) {
         entries={explorerEntries}
         sortBy={session.sortBy}
         sortAsc={session.sortAsc}
-        onSortChange={(sortBy, sortAsc) => setSort(sftpSessionId, sortBy, sortAsc)}
+        onSortChange={(sortBy, sortAsc) => setSort(sessionId, sortBy, sortAsc)}
         clipboard={explorerClipboard}
         onSetClipboard={handleSetClipboard}
         onNavigate={(path) => void loadDirectory(path)}

--- a/src/components/sftp/SftpPage.tsx
+++ b/src/components/sftp/SftpPage.tsx
@@ -1,5 +1,5 @@
 import { useSftpStore } from "../../stores/sftp-store";
-import { SftpBrowser } from "./SftpBrowser";
+import { ExplorerView } from "./ExplorerView";
 import { SftpSessionPicker } from "./SftpSessionPicker";
 import { SftpTabs } from "./SftpTabs";
 
@@ -16,7 +16,7 @@ export function SftpPage() {
       <SftpTabs />
       {activeSftpSessionId && (
         <div className="flex-1 min-h-0">
-          <SftpBrowser sftpSessionId={activeSftpSessionId} />
+          <ExplorerView sessionId={activeSftpSessionId} />
         </div>
       )}
     </div>

--- a/src/components/sftp/index.ts
+++ b/src/components/sftp/index.ts
@@ -1,7 +1,7 @@
 export { SftpPage } from "./SftpPage";
 export { ExplorerPage } from "./ExplorerPage";
 export { SftpTabs } from "./SftpTabs";
-export { SftpBrowser } from "./SftpBrowser";
+export { ExplorerView } from "./ExplorerView";
 export { SftpSessionPicker } from "./SftpSessionPicker";
 export { PathBar } from "./PathBar";
 export { ExplorerFileTable, ExplorerToolbar, ExplorerDropZone } from "../explorer";

--- a/src/components/transfers/TransferPopover.tsx
+++ b/src/components/transfers/TransferPopover.tsx
@@ -82,33 +82,33 @@ export function TransferPopover({ anchorRect, onClose }: TransferPopoverProps) {
 
   // ─── Actions ────────────────────────────────────────────────────────────────
 
-  /** Determine if a transfer is S3-based (vs SFTP) */
-  const isS3Transfer = useCallback((id: string): boolean => {
+  /** Which backend owns a transfer, inferred from its session-id field. */
+  const protocolOf = useCallback((id: string): "s3" | "scp" | "sftp" => {
     const t = transfers.get(id);
-    return t ? !!t.s3_session_id : false;
+    if (t?.s3_session_id) return "s3";
+    if (t?.scp_session_id) return "scp";
+    return "sftp";
   }, [transfers]);
 
   const handleCancel = useCallback((id: string) => {
     void (async () => {
       try {
         const { invoke } = await import("@tauri-apps/api/core");
-        const cmd = isS3Transfer(id) ? "s3_cancel_transfer" : "sftp_cancel_transfer";
-        await invoke(cmd, { transferId: id });
+        await invoke(`${protocolOf(id)}_cancel_transfer`, { transferId: id });
       } catch {
         removeTransfer(id);
       }
     })();
-  }, [removeTransfer, isS3Transfer]);
+  }, [removeTransfer, protocolOf]);
 
   const handleRetry = useCallback((id: string) => {
     void (async () => {
       try {
         const { invoke } = await import("@tauri-apps/api/core");
-        const cmd = isS3Transfer(id) ? "s3_retry_transfer" : "sftp_retry_transfer";
-        await invoke(cmd, { transferId: id });
+        await invoke(`${protocolOf(id)}_retry_transfer`, { transferId: id });
       } catch { /* best-effort */ }
     })();
-  }, [isS3Transfer]);
+  }, [protocolOf]);
 
   const handleDismiss = useCallback((id: string) => {
     removeTransfer(id);
@@ -120,6 +120,7 @@ export function TransferPopover({ anchorRect, onClose }: TransferPopoverProps) {
       try {
         const { invoke } = await import("@tauri-apps/api/core");
         await invoke("sftp_clear_finished_transfers");
+        await invoke("scp_clear_finished_transfers");
         await invoke("s3_clear_finished_transfers");
       } catch { /* best-effort */ }
     })();

--- a/src/components/transfers/TransferRow.tsx
+++ b/src/components/transfers/TransferRow.tsx
@@ -109,7 +109,7 @@ export const TransferRow = memo(function TransferRow({
   onRetry,
   onDismiss,
 }: TransferRowProps) {
-  const sessionId = t.sftp_session_id ?? t.s3_session_id ?? "";
+  const sessionId = t.sftp_session_id ?? t.scp_session_id ?? t.s3_session_id ?? "";
   const hostLabel = useTransferStore((s) => s.hostLabels.get(sessionId));
 
   const pct = getProgressPercent(t);

--- a/src/hooks/use-sftp-transfers.ts
+++ b/src/hooks/use-sftp-transfers.ts
@@ -30,6 +30,12 @@ export function useSftpTransfers() {
           hydrate(items);
         } catch { /* Backend may not have this command yet */ }
 
+        // Hydrate SCP transfers
+        try {
+          const scpItems = await invoke<TransferEvent[]>("scp_list_transfers");
+          hydrate(scpItems);
+        } catch { /* Backend may not have this command yet */ }
+
         // Hydrate S3 transfers
         try {
           const s3Items = await invoke<TransferEvent[]>("s3_list_transfers");
@@ -59,6 +65,44 @@ export function useSftpTransfers() {
             const sftpSession = useSftpStore.getState().sessions.get(transfer.sftp_session_id);
             if (sftpSession) {
               setHostLabel(transfer.sftp_session_id, sftpSession.label);
+            }
+          }
+
+          // Auto-open popover when a new transfer starts
+          if (transfer.status === "InProgress" || transfer.status === "Queued") {
+            if (!useTransferStore.getState().popoverOpen) {
+              setPopoverOpen(true);
+            }
+          }
+        });
+
+        if (aborted) { unsub(); } else { unlisten = unsub; }
+      } catch { /* Tauri API not available */ }
+    })();
+
+    return () => { aborted = true; unlisten?.(); };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [updateTransfer, setPopoverOpen, setHostLabel]);
+
+  // Listen for live SCP transfer events (SCP sessions share the sftp store)
+  useEffect(() => {
+    let aborted = false;
+    let unlisten: (() => void) | undefined;
+
+    (async () => {
+      try {
+        const { listen } = await import("@tauri-apps/api/event");
+        if (aborted) return;
+
+        const unsub = await listen<TransferEvent>("scp:transfer", (event) => {
+          const transfer = event.payload;
+          updateTransfer(transfer);
+
+          // Cache the host label for this session
+          if (transfer.scp_session_id) {
+            const scpSession = useSftpStore.getState().sessions.get(transfer.scp_session_id);
+            if (scpSession) {
+              setHostLabel(transfer.scp_session_id, scpSession.label);
             }
           }
 

--- a/src/lib/explorer-transport.ts
+++ b/src/lib/explorer-transport.ts
@@ -1,0 +1,40 @@
+// Explorer transport dispatch.
+//
+// SFTP and SCP expose an identical command surface — same operation names,
+// same argument shapes, same return types — differing only in the command
+// prefix (`sftp_` vs `scp_`) and the session-id argument key (`sftpSessionId`
+// vs `scpSessionId`). This module centralises that difference so the Explorer
+// UI can stay transport-agnostic.
+//
+// SCP is used transparently as a fallback when a host has the SFTP subsystem
+// disabled; the user never picks it explicitly (see exploreHost).
+
+export type Transport = "sftp" | "scp";
+
+/** The Tauri event channel that carries transfer progress for a transport. */
+export function transferEventName(transport: Transport): string {
+  return `${transport}:transfer`;
+}
+
+/** The session-id argument key a transport's commands expect. */
+function sessionKey(transport: Transport): "sftpSessionId" | "scpSessionId" {
+  return transport === "scp" ? "scpSessionId" : "sftpSessionId";
+}
+
+/**
+ * Invoke a transport command. `op` is the bare operation (e.g. "list_dir");
+ * the prefix and session-id key are derived from `transport`. `extra` holds
+ * the operation-specific arguments (path, oldPath, sourcePaths, …).
+ */
+export async function explorerInvoke<T>(
+  transport: Transport,
+  op: string,
+  sessionId: string,
+  extra: Record<string, unknown> = {},
+): Promise<T> {
+  const { invoke } = await import("@tauri-apps/api/core");
+  return invoke<T>(`${transport}_${op}`, {
+    [sessionKey(transport)]: sessionId,
+    ...extra,
+  });
+}

--- a/src/stores/sftp-store.ts
+++ b/src/stores/sftp-store.ts
@@ -156,4 +156,30 @@ if (typeof window !== "undefined") {
       sftpSessionId: sessionId, sourcePaths, targetDir,
     });
   };
+
+  // SCP equivalents — same surface, scp_* commands + scpSessionId key. Used by
+  // the SCP fallback E2E spec to drive the wire-protocol transfers.
+  const wScp = window as unknown as {
+    __e2eScpUpload?: (sessionId: string, localPath: string, remotePath: string) => Promise<string>;
+    __e2eScpDownload?: (sessionId: string, remotePath: string, localPath: string) => Promise<string>;
+    __e2eScpEnqueueUpload?: (sessionId: string, localPaths: string[], remoteDir: string) => Promise<string[]>;
+  };
+  wScp.__e2eScpUpload = async (sessionId, localPath, remotePath) => {
+    const { invoke } = await import("@tauri-apps/api/core");
+    return await invoke<string>("scp_upload", {
+      scpSessionId: sessionId, localPath, remotePath,
+    });
+  };
+  wScp.__e2eScpDownload = async (sessionId, remotePath, localPath) => {
+    const { invoke } = await import("@tauri-apps/api/core");
+    return await invoke<string>("scp_download", {
+      scpSessionId: sessionId, remotePath, localPath,
+    });
+  };
+  wScp.__e2eScpEnqueueUpload = async (sessionId, localPaths, remoteDir) => {
+    const { invoke } = await import("@tauri-apps/api/core");
+    return await invoke<string[]>("scp_enqueue_upload", {
+      scpSessionId: sessionId, localPaths, remoteDir,
+    });
+  };
 }

--- a/src/stores/tab-store.ts
+++ b/src/stores/tab-store.ts
@@ -9,7 +9,7 @@ export type PageId = "hosts" | "snippets" | "port-forwarding" | "history" | "set
 
 export type UnifiedTab =
   | { type: "terminal"; id: string; label: string }
-  | { type: "sftp"; id: string; label: string }
+  | { type: "sftp"; id: string; label: string; transport?: "sftp" | "scp" }
   | { type: "s3"; id: string; label: string }
   | { type: "page"; id: string; label: string; page: PageId };
 

--- a/src/types/sftp.ts
+++ b/src/types/sftp.ts
@@ -23,6 +23,8 @@ export interface TransferEvent {
   transfer_id: string;
   /** Present for SFTP transfers */
   sftp_session_id?: string;
+  /** Present for SCP transfers */
+  scp_session_id?: string;
   /** Present for S3 transfers */
   s3_session_id?: string;
   name: string;

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -70,8 +70,19 @@ unauthenticated (`-nopw`) because the port is only exposed on localhost.
 | `05-persistence` | SQLite DB survives an app restart. |
 | `06-error-bad-creds` | Auth-failure path surfaces an error banner in the modal. |
 | `07-sftp-flow` | `vault_save_credential` → keychain → Explorer button → `sftp_open` → `sftp_list_dir`. |
+| `52-scp-flow` | SFTP→SCP fallback against SFTP-disabled targets, run as a matrix over GNU and busybox userlands: lists, create/delete, and a `scp -t`/`-f` upload+download round-trip. |
 
 ## How it's wired together
+
+SSH targets (all on port 2222 inside the compose network):
+
+- **sshd-pass / sshd-key** — linuxserver/openssh, full SFTP. Password and key auth.
+- **sshd-scp** — linuxserver/openssh with the SFTP subsystem stripped (GNU
+  userland). Forces the SCP fallback; exercises the GNU `find -printf` listing.
+- **sshd-scp-busybox** — bare Alpine (busybox only, no GNU coreutils/findutils),
+  SFTP stripped. Exercises the busybox `find -exec stat -c` listing path.
+  (BSD/macOS — the third listing flavor — can't run as a Linux container, so
+  it's covered by `scp/listing.rs` unit tests + manual checks.)
 
 ```
 ┌──────────────────────────┐         ┌───────────────────────────┐
@@ -79,7 +90,8 @@ unauthenticated (`-nopw`) because the port is only exposed on localhost.
 │ linuxserver/openssh:2222 │         │ linuxserver/openssh:2222  │
 │ testuser / testpass      │         │ testuser / ssh key        │
 └──────────┬───────────────┘         └───────────┬───────────────┘
-           │                                     │
+           │   sshd-scp (GNU, no SFTP)            │
+           │   sshd-scp-busybox (busybox, no SFTP)│
            │       docker compose network        │
            └─────────────────┬───────────────────┘
                              │

--- a/tests/e2e/docker-compose.yml
+++ b/tests/e2e/docker-compose.yml
@@ -39,6 +39,25 @@ services:
       timeout: 2s
       retries: 30
 
+  # SCP-only target — SFTP subsystem stripped (see tests/scp-server). Exercises
+  # the transparent SFTP→SCP fallback: sftp_open fails here, the app retries
+  # over SCP on the same connection.
+  sshd-scp:
+    build:
+      context: ../scp-server
+      dockerfile: Dockerfile
+    image: anyscp-test-scp-only:latest
+    container_name: anyscp-e2e-sshd-scp
+    environment:
+      PUID: "1000"
+      PGID: "1000"
+      TZ: Etc/UTC
+      USER_NAME: testuser
+      USER_PASSWORD: testpass
+      PASSWORD_ACCESS: "true"
+      SUDO_ACCESS: "true"
+    networks: [e2e]
+
   # ─── S3-compatible storage (MinIO) ──────────────────────────────────────────
   minio:
     image: minio/minio:latest
@@ -105,6 +124,8 @@ services:
         condition: service_started
       sshd-key:
         condition: service_started
+      sshd-scp:
+        condition: service_started
       minio-seed:
         condition: service_completed_successfully
     environment:
@@ -112,6 +133,8 @@ services:
       SSHD_PASS_PORT: "2222"
       SSHD_KEY_HOST: sshd-key
       SSHD_KEY_PORT: "2222"
+      SSHD_SCP_HOST: sshd-scp
+      SSHD_SCP_PORT: "2222"
       SSH_USER: testuser
       SSH_PASS: testpass
       SSH_KEY_PATH: /keys/id_ed25519

--- a/tests/e2e/docker-compose.yml
+++ b/tests/e2e/docker-compose.yml
@@ -58,6 +58,17 @@ services:
       SUDO_ACCESS: "true"
     networks: [e2e]
 
+  # Pure-busybox SCP-only target (no GNU coreutils/findutils). Exercises the
+  # busybox listing path (find -exec stat -c, since busybox find has no
+  # -printf). Home is /home/testuser (vs /config on the linuxserver target).
+  sshd-scp-busybox:
+    build:
+      context: ../scp-server-busybox
+      dockerfile: Dockerfile
+    image: anyscp-test-scp-busybox:latest
+    container_name: anyscp-e2e-sshd-scp-busybox
+    networks: [e2e]
+
   # ─── S3-compatible storage (MinIO) ──────────────────────────────────────────
   minio:
     image: minio/minio:latest
@@ -126,6 +137,8 @@ services:
         condition: service_started
       sshd-scp:
         condition: service_started
+      sshd-scp-busybox:
+        condition: service_started
       minio-seed:
         condition: service_completed_successfully
     environment:
@@ -135,6 +148,8 @@ services:
       SSHD_KEY_PORT: "2222"
       SSHD_SCP_HOST: sshd-scp
       SSHD_SCP_PORT: "2222"
+      SSHD_SCP_BUSYBOX_HOST: sshd-scp-busybox
+      SSHD_SCP_BUSYBOX_PORT: "2222"
       SSH_USER: testuser
       SSH_PASS: testpass
       SSH_KEY_PATH: /keys/id_ed25519

--- a/tests/e2e/entrypoint.sh
+++ b/tests/e2e/entrypoint.sh
@@ -30,6 +30,7 @@ wait_for() {
 wait_for "${SSHD_PASS_HOST:-sshd-pass}" "${SSHD_PASS_PORT:-2222}" sshd-pass
 wait_for "${SSHD_KEY_HOST:-sshd-key}"   "${SSHD_KEY_PORT:-2222}"   sshd-key
 wait_for "${SSHD_SCP_HOST:-sshd-scp}"   "${SSHD_SCP_PORT:-2222}"   sshd-scp
+wait_for "${SSHD_SCP_BUSYBOX_HOST:-sshd-scp-busybox}" "${SSHD_SCP_BUSYBOX_PORT:-2222}" sshd-scp-busybox
 
 # ── 2. Install JS deps ────────────────────────────────────────────────────────
 echo "[entrypoint] installing app deps"

--- a/tests/e2e/entrypoint.sh
+++ b/tests/e2e/entrypoint.sh
@@ -29,6 +29,7 @@ wait_for() {
 
 wait_for "${SSHD_PASS_HOST:-sshd-pass}" "${SSHD_PASS_PORT:-2222}" sshd-pass
 wait_for "${SSHD_KEY_HOST:-sshd-key}"   "${SSHD_KEY_PORT:-2222}"   sshd-key
+wait_for "${SSHD_SCP_HOST:-sshd-scp}"   "${SSHD_SCP_PORT:-2222}"   sshd-scp
 
 # ── 2. Install JS deps ────────────────────────────────────────────────────────
 echo "[entrypoint] installing app deps"

--- a/tests/e2e/helpers/transfers.ts
+++ b/tests/e2e/helpers/transfers.ts
@@ -116,6 +116,48 @@ export async function sftpMove(
     );
 }
 
+// ─── SCP transfer wrappers ───────────────────────────────────────────────────
+// SCP sessions live in the same tab type ("sftp") and store as SFTP, so
+// activeSftpSessionId() returns the SCP session id too.
+
+export async function scpUpload(
+    sessionId: string,
+    localPath: string,
+    remotePath: string,
+): Promise<string> {
+    return await browser.execute(
+        async (sid: string, lp: string, rp: string) => {
+            const fn = (window as unknown as {
+                __e2eScpUpload?: (s: string, l: string, r: string) => Promise<string>;
+            }).__e2eScpUpload;
+            if (!fn) throw new Error("__e2eScpUpload not registered");
+            return await fn(sid, lp, rp);
+        },
+        sessionId,
+        localPath,
+        remotePath,
+    );
+}
+
+export async function scpDownload(
+    sessionId: string,
+    remotePath: string,
+    localPath: string,
+): Promise<string> {
+    return await browser.execute(
+        async (sid: string, rp: string, lp: string) => {
+            const fn = (window as unknown as {
+                __e2eScpDownload?: (s: string, r: string, l: string) => Promise<string>;
+            }).__e2eScpDownload;
+            if (!fn) throw new Error("__e2eScpDownload not registered");
+            return await fn(sid, rp, lp);
+        },
+        sessionId,
+        remotePath,
+        localPath,
+    );
+}
+
 // ─── S3 transfer wrappers ────────────────────────────────────────────────────
 
 export async function s3Upload(

--- a/tests/e2e/specs/52-scp-flow.spec.ts
+++ b/tests/e2e/specs/52-scp-flow.spec.ts
@@ -1,7 +1,12 @@
-// SCP fallback flow. The sshd-scp target has the SFTP subsystem stripped,
-// so opening the Explorer must transparently fall back to SCP on the same
-// SSH connection. This exercises the full SCP path end-to-end: exec-based
-// listing/mkdir/create/delete, plus wire-protocol upload + download.
+// SCP fallback flow, run against a matrix of remote userlands. Each target
+// has the SFTP subsystem stripped, so opening the Explorer must transparently
+// fall back to SCP. The two targets cover the two Linux listing code paths:
+//
+//   - GNU     (linuxserver/Alpine + GNU findutils): `find -printf`
+//   - busybox (bare Alpine, no GNU tools):          `find -exec stat -c`
+//
+// BSD/macOS (the third flavor) can't run as a Linux Docker container, so it's
+// covered by unit tests (scp/listing.rs) + manual verification instead.
 
 import { expect } from "chai";
 import { mkdtemp, readFile, writeFile } from "node:fs/promises";
@@ -27,109 +32,130 @@ import {
 } from "../helpers/sftp-ops.js";
 import { activeSftpSessionId, scpDownload, scpUpload } from "../helpers/transfers.js";
 
-const SSHD_SCP_HOST = process.env.SSHD_SCP_HOST ?? "sshd-scp";
-const SSHD_SCP_PORT = Number(process.env.SSHD_SCP_PORT ?? 2222);
 const SSH_USER = process.env.SSH_USER ?? "testuser";
 const SSH_PASS = process.env.SSH_PASS ?? "testpass";
-const REMOTE_HOME = "/config";
 
-describe("SCP fallback", () => {
-    beforeEach(async () => {
-        await resetApp();
-        await waitForDashboard();
-    });
+interface Target {
+    name: string;
+    host: string;
+    port: number;
+    /** Remote home dir — where the upload/download round-trip writes. */
+    home: string;
+}
 
-    async function openScpExplorer(label: string): Promise<string> {
-        await openNewHostModal();
-        await fillPasswordHostForm({
-            label,
-            host: SSHD_SCP_HOST,
-            port: SSHD_SCP_PORT,
-            username: SSH_USER,
-            password: SSH_PASS,
-        });
-        await clickSave();
-        await waitForModalClosed();
-        await findHostCardByLabel(label);
+const TARGETS: Target[] = [
+    {
+        name: "GNU",
+        host: process.env.SSHD_SCP_HOST ?? "sshd-scp",
+        port: Number(process.env.SSHD_SCP_PORT ?? 2222),
+        home: "/config",
+    },
+    {
+        name: "busybox",
+        host: process.env.SSHD_SCP_BUSYBOX_HOST ?? "sshd-scp-busybox",
+        port: Number(process.env.SSHD_SCP_BUSYBOX_PORT ?? 2222),
+        home: "/home/testuser",
+    },
+];
 
-        const hostId = await getHostId(label);
-        const explorerBtn = await $(`[data-testid='host-card-${hostId}-explorer']`);
-        await explorerBtn.waitForClickable({ timeout: 10_000 });
-        await explorerBtn.click();
-        await waitForExplorer();
-        return await activeSftpSessionId();
-    }
-
-    it("falls back to SCP and lists the remote directory", async () => {
-        await openScpExplorer("scp-target");
-
-        // The Explorer must report SCP transport — proof the SFTP subsystem
-        // failed and we fell back rather than silently using SFTP.
-        const content = await $("[data-explorer-transport='scp']");
-        await content.waitForExist({
-            timeout: 15_000,
-            timeoutMsg: "explorer did not report SCP transport (fallback failed)",
+for (const target of TARGETS) {
+    describe(`SCP fallback (${target.name})`, () => {
+        beforeEach(async () => {
+            await resetApp();
+            await waitForDashboard();
         });
 
-        // Listing comes from `find -printf` over SSH exec — must render entries.
-        await browser.waitUntil(
-            async () => (await $$("[data-entry-row='true']")).length > 0,
-            { timeout: 15_000, timeoutMsg: "no entries rendered over SCP" },
-        );
-        expect((await $$("[data-entry-row='true']")).length).to.be.greaterThan(0);
+        async function openScpExplorer(label: string): Promise<string> {
+            await openNewHostModal();
+            await fillPasswordHostForm({
+                label,
+                host: target.host,
+                port: target.port,
+                username: SSH_USER,
+                password: SSH_PASS,
+            });
+            await clickSave();
+            await waitForModalClosed();
+            await findHostCardByLabel(label);
+
+            const hostId = await getHostId(label);
+            const explorerBtn = await $(`[data-testid='host-card-${hostId}-explorer']`);
+            await explorerBtn.waitForClickable({ timeout: 10_000 });
+            await explorerBtn.click();
+            await waitForExplorer();
+            return await activeSftpSessionId();
+        }
+
+        it("falls back to SCP and lists the remote directory", async () => {
+            await openScpExplorer(`scp-${target.name}-list`);
+
+            // Must report SCP transport — proof SFTP failed and we fell back.
+            const content = await $("[data-explorer-transport='scp']");
+            await content.waitForExist({
+                timeout: 15_000,
+                timeoutMsg: "explorer did not report SCP transport (fallback failed)",
+            });
+
+            // Listing comes from the flavor-specific command over SSH exec.
+            await browser.waitUntil(
+                async () => (await $$("[data-entry-row='true']")).length > 0,
+                { timeout: 15_000, timeoutMsg: "no entries rendered over SCP" },
+            );
+            expect((await $$("[data-entry-row='true']")).length).to.be.greaterThan(0);
+        });
+
+        it("creates and deletes a folder and file over SCP", async () => {
+            await openScpExplorer(`scp-${target.name}-fsops`);
+            const stamp = Date.now();
+            const folder = `scp-dir-${stamp}`;
+            const file = `scp-file-${stamp}.txt`;
+
+            await createFolder(folder);
+            await waitForEntry(folder);
+            await createFile(file);
+            await waitForEntry(file);
+
+            await deleteEntry(file);
+            await deleteEntry(folder);
+        });
+
+        it("uploads and downloads a file over the SCP wire protocol", async () => {
+            const sessionId = await openScpExplorer(`scp-${target.name}-xfer`);
+
+            const stamp = Date.now();
+            const payload = `scp-wire-payload-${stamp}\nsecond line\n`;
+            const dir = await mkdtemp(join(tmpdir(), "e2e-scp-"));
+            const uploadLocal = join(dir, "src.txt");
+            const downloadLocal = join(dir, "dst.txt");
+            const remoteName = `scp-up-${stamp}.txt`;
+            const remotePath = `${target.home}/${remoteName}`;
+            await writeFile(uploadLocal, payload, "utf8");
+
+            // Upload via `scp -t` wire protocol.
+            await scpUpload(sessionId, uploadLocal, remotePath);
+            await browser.waitUntil(
+                async () => {
+                    await refreshExplorer();
+                    return await (await $(`[data-entry-name='${remoteName}']`)).isExisting();
+                },
+                { timeout: 15_000, timeoutMsg: `uploaded file '${remoteName}' never appeared` },
+            );
+
+            // Download it back via `scp -f` and verify byte-for-byte content.
+            await scpDownload(sessionId, remotePath, downloadLocal);
+            await browser.waitUntil(
+                async () => {
+                    try {
+                        return (await readFile(downloadLocal, "utf8")) === payload;
+                    } catch {
+                        return false;
+                    }
+                },
+                { timeout: 15_000, timeoutMsg: "downloaded content never matched" },
+            );
+            expect(await readFile(downloadLocal, "utf8")).to.equal(payload);
+
+            await deleteEntry(remoteName);
+        });
     });
-
-    it("creates and deletes a folder and file over SCP", async () => {
-        await openScpExplorer("scp-fsops");
-        const stamp = Date.now();
-        const folder = `scp-dir-${stamp}`;
-        const file = `scp-file-${stamp}.txt`;
-
-        await createFolder(folder);
-        await waitForEntry(folder);
-        await createFile(file);
-        await waitForEntry(file);
-
-        await deleteEntry(file);
-        await deleteEntry(folder);
-    });
-
-    it("uploads and downloads a file over the SCP wire protocol", async () => {
-        const sessionId = await openScpExplorer("scp-xfer");
-
-        const stamp = Date.now();
-        const payload = `scp-wire-payload-${stamp}\nsecond line\n`;
-        const dir = await mkdtemp(join(tmpdir(), "e2e-scp-"));
-        const uploadLocal = join(dir, "src.txt");
-        const downloadLocal = join(dir, "dst.txt");
-        const remoteName = `scp-up-${stamp}.txt`;
-        const remotePath = `${REMOTE_HOME}/${remoteName}`;
-        await writeFile(uploadLocal, payload, "utf8");
-
-        // Upload via `scp -t` wire protocol.
-        await scpUpload(sessionId, uploadLocal, remotePath);
-        await browser.waitUntil(
-            async () => {
-                await refreshExplorer();
-                return await (await $(`[data-entry-name='${remoteName}']`)).isExisting();
-            },
-            { timeout: 15_000, timeoutMsg: `uploaded file '${remoteName}' never appeared` },
-        );
-
-        // Download it back via `scp -f` and verify byte-for-byte content.
-        await scpDownload(sessionId, remotePath, downloadLocal);
-        await browser.waitUntil(
-            async () => {
-                try {
-                    return (await readFile(downloadLocal, "utf8")) === payload;
-                } catch {
-                    return false;
-                }
-            },
-            { timeout: 15_000, timeoutMsg: "downloaded content never matched" },
-        );
-        expect(await readFile(downloadLocal, "utf8")).to.equal(payload);
-
-        await deleteEntry(remoteName);
-    });
-});
+}

--- a/tests/e2e/specs/52-scp-flow.spec.ts
+++ b/tests/e2e/specs/52-scp-flow.spec.ts
@@ -1,0 +1,135 @@
+// SCP fallback flow. The sshd-scp target has the SFTP subsystem stripped,
+// so opening the Explorer must transparently fall back to SCP on the same
+// SSH connection. This exercises the full SCP path end-to-end: exec-based
+// listing/mkdir/create/delete, plus wire-protocol upload + download.
+
+import { expect } from "chai";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { resetApp } from "../helpers/reset.js";
+import { waitForDashboard } from "../helpers/dashboard.js";
+import {
+    clickSave,
+    fillPasswordHostForm,
+    findHostCardByLabel,
+    getHostId,
+    openNewHostModal,
+    waitForModalClosed,
+} from "../helpers/host.js";
+import {
+    createFile,
+    createFolder,
+    deleteEntry,
+    refreshExplorer,
+    waitForEntry,
+    waitForExplorer,
+} from "../helpers/sftp-ops.js";
+import { activeSftpSessionId, scpDownload, scpUpload } from "../helpers/transfers.js";
+
+const SSHD_SCP_HOST = process.env.SSHD_SCP_HOST ?? "sshd-scp";
+const SSHD_SCP_PORT = Number(process.env.SSHD_SCP_PORT ?? 2222);
+const SSH_USER = process.env.SSH_USER ?? "testuser";
+const SSH_PASS = process.env.SSH_PASS ?? "testpass";
+const REMOTE_HOME = "/config";
+
+describe("SCP fallback", () => {
+    beforeEach(async () => {
+        await resetApp();
+        await waitForDashboard();
+    });
+
+    async function openScpExplorer(label: string): Promise<string> {
+        await openNewHostModal();
+        await fillPasswordHostForm({
+            label,
+            host: SSHD_SCP_HOST,
+            port: SSHD_SCP_PORT,
+            username: SSH_USER,
+            password: SSH_PASS,
+        });
+        await clickSave();
+        await waitForModalClosed();
+        await findHostCardByLabel(label);
+
+        const hostId = await getHostId(label);
+        const explorerBtn = await $(`[data-testid='host-card-${hostId}-explorer']`);
+        await explorerBtn.waitForClickable({ timeout: 10_000 });
+        await explorerBtn.click();
+        await waitForExplorer();
+        return await activeSftpSessionId();
+    }
+
+    it("falls back to SCP and lists the remote directory", async () => {
+        await openScpExplorer("scp-target");
+
+        // The Explorer must report SCP transport — proof the SFTP subsystem
+        // failed and we fell back rather than silently using SFTP.
+        const content = await $("[data-explorer-transport='scp']");
+        await content.waitForExist({
+            timeout: 15_000,
+            timeoutMsg: "explorer did not report SCP transport (fallback failed)",
+        });
+
+        // Listing comes from `find -printf` over SSH exec — must render entries.
+        await browser.waitUntil(
+            async () => (await $$("[data-entry-row='true']")).length > 0,
+            { timeout: 15_000, timeoutMsg: "no entries rendered over SCP" },
+        );
+        expect((await $$("[data-entry-row='true']")).length).to.be.greaterThan(0);
+    });
+
+    it("creates and deletes a folder and file over SCP", async () => {
+        await openScpExplorer("scp-fsops");
+        const stamp = Date.now();
+        const folder = `scp-dir-${stamp}`;
+        const file = `scp-file-${stamp}.txt`;
+
+        await createFolder(folder);
+        await waitForEntry(folder);
+        await createFile(file);
+        await waitForEntry(file);
+
+        await deleteEntry(file);
+        await deleteEntry(folder);
+    });
+
+    it("uploads and downloads a file over the SCP wire protocol", async () => {
+        const sessionId = await openScpExplorer("scp-xfer");
+
+        const stamp = Date.now();
+        const payload = `scp-wire-payload-${stamp}\nsecond line\n`;
+        const dir = await mkdtemp(join(tmpdir(), "e2e-scp-"));
+        const uploadLocal = join(dir, "src.txt");
+        const downloadLocal = join(dir, "dst.txt");
+        const remoteName = `scp-up-${stamp}.txt`;
+        const remotePath = `${REMOTE_HOME}/${remoteName}`;
+        await writeFile(uploadLocal, payload, "utf8");
+
+        // Upload via `scp -t` wire protocol.
+        await scpUpload(sessionId, uploadLocal, remotePath);
+        await browser.waitUntil(
+            async () => {
+                await refreshExplorer();
+                return await (await $(`[data-entry-name='${remoteName}']`)).isExisting();
+            },
+            { timeout: 15_000, timeoutMsg: `uploaded file '${remoteName}' never appeared` },
+        );
+
+        // Download it back via `scp -f` and verify byte-for-byte content.
+        await scpDownload(sessionId, remotePath, downloadLocal);
+        await browser.waitUntil(
+            async () => {
+                try {
+                    return (await readFile(downloadLocal, "utf8")) === payload;
+                } catch {
+                    return false;
+                }
+            },
+            { timeout: 15_000, timeoutMsg: "downloaded content never matched" },
+        );
+        expect(await readFile(downloadLocal, "utf8")).to.equal(payload);
+
+        await deleteEntry(remoteName);
+    });
+});

--- a/tests/scp-server-busybox/Dockerfile
+++ b/tests/scp-server-busybox/Dockerfile
@@ -1,0 +1,32 @@
+# Pure-busybox SCP-only SSH server.
+#
+# Unlike tests/scp-server (linuxserver, which ships GNU coreutils/findutils),
+# this is a bare Alpine with ONLY busybox `find`/`stat` — no GNU tools. It
+# exercises the SCP backend's busybox flavor path (`find … -exec stat -c …`,
+# since busybox find has no `-printf`). The SFTP subsystem is stripped so the
+# app must fall back to SCP.
+#
+# Built by the e2e compose stack (service: sshd-scp-busybox).
+FROM alpine:3.20
+
+# openssh meta-package brings sshd + scp (openssh-client). We deliberately do
+# NOT install coreutils/findutils, so find/stat stay busybox.
+RUN apk add --no-cache openssh \
+    && ssh-keygen -A \
+    && adduser -D testuser \
+    && echo 'testuser:testpass' | chpasswd \
+    # Strip the SFTP subsystem so only SCP works.
+    && sed -i -E 's|^[[:space:]]*Subsystem[[:space:]]+sftp.*|# sftp disabled (busybox scp-only)|' /etc/ssh/sshd_config \
+    && sed -i -E 's|^#?[[:space:]]*PasswordAuthentication.*|PasswordAuthentication yes|' /etc/ssh/sshd_config \
+    # Seed the home dir so listing has something to render.
+    && mkdir -p /home/testuser/seeddir \
+    && echo 'hello from busybox' > /home/testuser/seed.txt \
+    && echo 'nested' > /home/testuser/seeddir/inner.txt \
+    && chown -R testuser:testuser /home/testuser
+
+# Confirm at build time that find is busybox (no -printf) — documents intent.
+RUN ! find / -maxdepth 0 -printf '' 2>/dev/null && echo "confirmed: busybox find (no -printf)"
+
+EXPOSE 2222
+# Run sshd in the foreground on 2222 to match the other test targets.
+CMD ["/usr/sbin/sshd", "-D", "-e", "-p", "2222"]

--- a/tests/scp-server/.gitignore
+++ b/tests/scp-server/.gitignore
@@ -1,0 +1,1 @@
+.image-stamp

--- a/tests/scp-server/Dockerfile
+++ b/tests/scp-server/Dockerfile
@@ -1,0 +1,14 @@
+# SCP-only test SSH server.
+#
+# Extends the upstream linuxserver/openssh-server image with a single init
+# script that comments out the `Subsystem sftp` line in sshd_config after
+# the base image has generated it. SSH sessions and the legacy SCP protocol
+# (scp -O) still work; SFTP and modern scp (>= OpenSSH 9.0, which defaults
+# to SFTP) fail at channel-open.
+#
+# Built by `make scp-build` (or implicitly by `make start-scp-pass` and
+# `make start-scp-key`).
+FROM lscr.io/linuxserver/openssh-server:latest
+
+COPY disable-sftp.sh /custom-cont-init.d/disable-sftp.sh
+RUN chmod +x /custom-cont-init.d/disable-sftp.sh

--- a/tests/scp-server/Dockerfile
+++ b/tests/scp-server/Dockerfile
@@ -10,11 +10,10 @@
 # `make start-scp-key`).
 FROM lscr.io/linuxserver/openssh-server:latest
 
-# The base image is Alpine, whose busybox `find`/`stat` lack the GNU flags
-# (`find -printf`, `stat -c`) the SCP backend uses for directory listings.
-# Install GNU coreutils + findutils so this fixture behaves like a typical
-# GNU/Linux server — the documented target for SCP-mode browsing.
-RUN apk add --no-cache coreutils findutils
+# NOTE: SCP-mode directory listings use GNU `find -printf` / `stat -c`. This
+# base image already ships GNU findutils + coreutils (verified: findutils
+# 4.10.0), so no extra packages are needed — but that GNU dependency is the
+# documented target for SCP browsing. A pure-busybox host would not list.
 
 COPY disable-sftp.sh /custom-cont-init.d/disable-sftp.sh
 RUN chmod +x /custom-cont-init.d/disable-sftp.sh

--- a/tests/scp-server/Dockerfile
+++ b/tests/scp-server/Dockerfile
@@ -10,5 +10,11 @@
 # `make start-scp-key`).
 FROM lscr.io/linuxserver/openssh-server:latest
 
+# The base image is Alpine, whose busybox `find`/`stat` lack the GNU flags
+# (`find -printf`, `stat -c`) the SCP backend uses for directory listings.
+# Install GNU coreutils + findutils so this fixture behaves like a typical
+# GNU/Linux server — the documented target for SCP-mode browsing.
+RUN apk add --no-cache coreutils findutils
+
 COPY disable-sftp.sh /custom-cont-init.d/disable-sftp.sh
 RUN chmod +x /custom-cont-init.d/disable-sftp.sh

--- a/tests/scp-server/disable-sftp.sh
+++ b/tests/scp-server/disable-sftp.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Runs from /custom-cont-init.d/ after the linuxserver base has generated
+# /config/sshd/sshd_config and before sshd starts. Strips the SFTP
+# subsystem so the container only serves SCP (legacy rcp-over-ssh).
+set -eu
+
+config=/config/sshd/sshd_config
+if [ -f "$config" ]; then
+    sed -i -E 's|^[[:space:]]*Subsystem[[:space:]]+sftp.*|# Subsystem sftp disabled (SCP-only test container)|' "$config"
+    echo "[scp-only] SFTP subsystem disabled in $config"
+else
+    echo "[scp-only] WARNING: $config not found; SFTP disabling skipped" >&2
+fi


### PR DESCRIPTION
## Summary

Adds a full SCP transport so the Explorer keeps working against SSH servers that have the **SFTP subsystem disabled**. The Explorer prefers SFTP and **silently falls back to SCP** on the same connection — the user never picks a transport.

Since SCP has no native filesystem ops, listing/stat/mkdir/rm/mv/cp/touch are implemented via SSH exec of POSIX commands, and byte transfers drive remote `scp -t`/`scp -f` over the rcp-on-ssh wire protocol.

## Backend (`src-tauri/src/scp/`)
- **wire.rs** — protocol codec (C/D/E/T records, acks, byte streaming)
- **exec.rs** — SSH-exec FS helpers (ls/stat/mkdir/rm/mv/cp/touch, tree walk)
- **listing.rs** — portable listing across **GNU / busybox / BSD** userlands; flavor detected once at `scp_open` and the right command issued per family (GNU `find -printf`, busybox `find -exec stat -c`, BSD `find -exec stat -f`). Pure, unit-tested parsers.
- **transfer.rs / transfer_manager.rs** — `scp -t`/`-f` transfer primitives + concurrency-limited queue emitting `scp:transfer`
- **commands.rs** — 20 `scp_*` Tauri commands mirroring `sftp_*`

## Frontend
- `lib/explorer-transport.ts` — dispatcher mapping `(transport, op)` → command + session-arg key; SFTP and SCP share an identical surface
- `SftpBrowser` → `ExplorerView` — transport-aware; every `invoke()` routes through the dispatcher
- `exploreHost` / `HistoryPage` — try `sftp_open`, fall back to `scp_open`, tag the tab
- ExplorerPage shows a subtle "· SCP" suffix on the fallback path
- Transfer hooks/popover/rows hydrate + listen on `scp:transfer`

## Testing
- **37 scp unit tests** (was 21)
- E2E `52-scp-flow.spec.ts`: matrix over **GNU + busybox** SCP-only targets (SFTP subsystem stripped) — verifies fallback, exec-based FS ops, and a full file round-trip through the wire protocol
- SCP-only server fixtures + Makefile targets for manual testing