### PR TITLE
fix(ci): declare packages in pnpm-workspace.yaml so the release build runs

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,5 @@
+packages:
+  - '.'
+
 allowBuilds:
   esbuild: false


### PR DESCRIPTION
## Problem

The `v0.6.0` release workflow **failed on all four runners** at the `actions/setup-node` pnpm-cache step, before any build ran — so the release produced no artifacts.

```
ERROR  packages field missing or empty
```

The `pnpm-workspace.yaml` added in #20 declared only `allowBuilds:` and no `packages:` field. The release workflow pins **pnpm 9** (`pnpm/action-setup@v4` with `version: 9`), and pnpm 9 treats a workspace manifest without a `packages:` field as a hard error. (Local dev uses pnpm 11, which tolerates it — so it wasn't caught.)

## Fix

Declare `packages: ['.']` (root only). This matches the existing single-importer lockfile (`importers: { .: }`), so `--frozen-lockfile` stays green, and keeps `tests/e2e` installed independently as before.

## Verification

Reproduced against **real pnpm 9.15**:
- Without `packages:` → `ERROR packages field missing or empty` (the CI failure)
- With `packages: ['.']` → `pnpm store path` succeeds and `pnpm install --frozen-lockfile` resolves cleanly