### PR TITLE
fix(theme): inject persisted theme before first paint to remove startup flash

### DIFF
--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -1,6 +1,6 @@
 pub mod commands;
 
-use rusqlite::{params, Connection};
+use rusqlite::{params, Connection, OptionalExtension};
 use serde::{Deserialize, Serialize};
 use std::sync::Mutex;
 use tracing::instrument;
@@ -1208,6 +1208,22 @@ impl HostDb {
             params![key, value],
         )?;
         Ok(())
+    }
+
+    /// Fetch a single setting by key. Returns `None` if the key is not present.
+    pub fn get_setting(&self, key: &str) -> Result<Option<String>, DbError> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| DbError::InitError(format!("db lock poisoned: {e}")))?;
+        let value = conn
+            .query_row(
+                "SELECT value FROM app_settings WHERE key = ?1",
+                params![key],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?;
+        Ok(value)
     }
 
     // -----------------------------------------------------------------------

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -21,7 +21,7 @@ use sftp::transfer_manager::TransferManager;
 use sftp::SftpManager;
 use ssh::manager::SshManager;
 use std::sync::Arc;
-use tauri::Manager;
+use tauri::{Manager, WebviewUrl, WebviewWindowBuilder};
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -41,6 +41,28 @@ pub fn run() {
 
             let host_db = HostDb::new(&app_data_dir)
                 .map_err(|e| format!("failed to initialise database: {e}"))?;
+
+            // Resolve the persisted theme up-front and inject it onto <html>
+            // *before* the page loads, so the very first paint already carries
+            // the correct theme — no dark→light flash on startup. SQLite stays
+            // the single source of truth; the frontend store seeds itself from
+            // this attribute (see settings-store.ts). The window is created here
+            // (rather than declaratively in tauri.conf.json) specifically so we
+            // can attach this initialization script before first paint.
+            let theme = match host_db.get_setting("app_theme") {
+                Ok(Some(v)) if v == "light" => "light",
+                _ => "dark",
+            };
+            let theme_script =
+                format!("document.documentElement.dataset.theme = {theme:?};");
+
+            WebviewWindowBuilder::new(app.handle(), "main", WebviewUrl::App("index.html".into()))
+                .title("anySCP")
+                .inner_size(1200.0, 800.0)
+                .min_inner_size(800.0, 500.0)
+                .initialization_script(&theme_script)
+                .build()
+                .map_err(|e| format!("failed to create main window: {e}"))?;
 
             app.manage(Arc::new(host_db));
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -53,8 +53,7 @@ pub fn run() {
                 Ok(Some(v)) if v == "light" => "light",
                 _ => "dark",
             };
-            let theme_script =
-                format!("document.documentElement.dataset.theme = {theme:?};");
+            let theme_script = format!("document.documentElement.dataset.theme = {theme:?};");
 
             WebviewWindowBuilder::new(app.handle(), "main", WebviewUrl::App("index.html".into()))
                 .title("anySCP")

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -10,15 +10,7 @@
     "frontendDist": "../dist"
   },
   "app": {
-    "windows": [
-      {
-        "title": "anySCP",
-        "width": 1200,
-        "height": 800,
-        "minWidth": 800,
-        "minHeight": 500
-      }
-    ],
+    "windows": [],
     "security": {
       "csp": null
     }

--- a/src/stores/settings-store.ts
+++ b/src/stores/settings-store.ts
@@ -45,6 +45,20 @@ const DEFAULTS = {
   transferConcurrency: 3,
 };
 
+/**
+ * The Rust setup() hook injects the persisted theme onto <html> before the page
+ * paints (see src-tauri/src/lib.rs). Seed the store from that attribute so the
+ * initial render matches it — otherwise the default below would briefly override
+ * the injected theme and re-introduce the startup flash. Falls back to the
+ * default when the attribute is absent (e.g. a plain web/dev context).
+ */
+function initialThemeMode(): ThemeMode {
+  if (typeof document !== "undefined" && document.documentElement.dataset.theme === "light") {
+    return "light";
+  }
+  return DEFAULTS.themeMode;
+}
+
 /** Persist a single setting to the backend. Fire-and-forget. */
 function persist(key: string, value: string) {
   void (async () => {
@@ -57,6 +71,7 @@ function persist(key: string, value: string) {
 
 export const useSettingsStore = create<SettingsState>((set) => ({
   ...DEFAULTS,
+  themeMode: initialThemeMode(),
   loaded: false,
 
   setThemeMode: (mode) => {


### PR DESCRIPTION
## Problem

The light theme added in #23 caused a visible **dark→light flash on startup** for users whose saved theme is light. The window painted with the default dark theme first, then switched once the persisted theme was loaded asynchronously from SQLite. This was the non-blocking follow-up called out in the #23 review.

## Approach

Fix it at the source — apply the theme **before the page paints**, keeping SQLite as the single source of truth:

- The main window is now created in `lib.rs` `setup()` via `WebviewWindowBuilder`, which reads the saved theme from SQLite and attaches an `initialization_script` that sets `data-theme` on `<html>` **before the frontend bundle runs**.
- The frontend store seeds its initial `themeMode` from that injected attribute, so React's first render matches it and never overrides it back to dark.
- No `localStorage` / second source of truth; SQLite stays authoritative.

### Why not a hidden window?

An earlier iteration used `visible: false` + `WebviewWindow.show()` after load. On Linux/GTK that triggers a known bug where the title-bar controls (close / minimize / maximize) become unresponsive until the window is resized/remapped ([tauri-apps/tauri#11856](https://github.com/tauri-apps/tauri/issues/11856)). The window is now created visible/decorated as before, so it avoids that entirely.

## Changes

- `db/mod.rs` — add `get_setting(key)` single-key lookup.
- `lib.rs` — build the main window with the theme init script.
- `tauri.conf.json` — `windows: []` (window now created in Rust; size/min-size moved into the builder).
- `settings-store.ts` — seed initial `themeMode` from the injected `data-theme`.

## Testing

- `pnpm tsc --noEmit` ✅
- `cargo check` ✅
- Manual: launch with a saved **light** theme → no flash; title-bar controls work on launch; theme toggle in Settings still works.