### PR TITLE
fix(explorer): keep open directory when switching tabs (#17)

### DIFF
--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -268,14 +268,35 @@ export function AppShell() {
               })}
 
 
-            {/* Page / SFTP / S3 content — rendered on top when active */}
-            {activeTab && activeTab.type !== "terminal" && (
+            {/* Explorer (SFTP/S3) tabs — render ALL and toggle visibility, like
+                terminals, so the open directory and selection survive switching
+                tabs instead of resetting to the home/default dir (issue #17). */}
+            {Array.from(allTabs.entries())
+              .filter(([, tab]) => tab.type === "sftp" || tab.type === "s3")
+              .map(([tabId, tab]) => {
+                const isVisible = tabId === activeTabId;
+                return (
+                  <div
+                    key={tabId}
+                    className={`absolute inset-0 ${isVisible ? "z-10 visible" : "z-0 invisible"}`}
+                  >
+                    {tab.type === "sftp" ? (
+                      <ExplorerPage
+                        sftpSessionId={tabId}
+                        transport={tab.transport ?? "sftp"}
+                        isActive={isVisible}
+                      />
+                    ) : (
+                      <ExplorerPage s3SessionId={tabId} isActive={isVisible} />
+                    )}
+                  </div>
+                );
+              })}
+
+            {/* Page content — rendered on top when its tab is active */}
+            {activeTab && activeTab.type === "page" && (
               <div className="absolute inset-0 z-10">
-                {activeTab.type === "sftp" ? (
-                  <ExplorerPage sftpSessionId={activeTab.id} transport={activeTab.transport ?? "sftp"} />
-                ) : activeTab.type === "s3" ? (
-                  <ExplorerPage s3SessionId={activeTab.id} />
-                ) : activePageType === "hosts" ? (
+                {activePageType === "hosts" ? (
                   <HostsDashboard />
                 ) : activePageType === "snippets" ? (
                   <SnippetsPage />

--- a/src/components/s3/S3Browser.tsx
+++ b/src/components/s3/S3Browser.tsx
@@ -8,9 +8,13 @@ import { createS3Provider, toS3ExplorerEntry } from "../../providers/s3-provider
 
 interface S3BrowserProps {
   sessionId: string;
+  /** Whether this explorer's tab is currently active/visible. S3 tabs stay
+   *  mounted (issue #17), so document-level listeners are gated to the active
+   *  instance to avoid every open explorer reacting to one event. */
+  isActive?: boolean;
 }
 
-export function S3Browser({ sessionId }: S3BrowserProps) {
+export function S3Browser({ sessionId, isActive = true }: S3BrowserProps) {
   const session = useS3Store((s) => s.sessions.get(sessionId));
   const setEntries = useS3Store((s) => s.setEntries);
   const setBuckets = useS3Store((s) => s.setBuckets);
@@ -197,6 +201,9 @@ export function S3Browser({ sessionId }: S3BrowserProps) {
   const [creatingFile, setCreatingFile] = useState(false);
 
   useEffect(() => {
+    // Only the active (visible) explorer reacts to document-level new-folder/
+    // new-file events — S3 tabs now stay mounted (issue #17).
+    if (!isActive) return;
     const folderHandler = () => setCreatingFolder(true);
     const fileHandler = () => setCreatingFile(true);
     document.addEventListener("explorer:new-folder", folderHandler);
@@ -205,7 +212,7 @@ export function S3Browser({ sessionId }: S3BrowserProps) {
       document.removeEventListener("explorer:new-folder", folderHandler);
       document.removeEventListener("explorer:new-file", fileHandler);
     };
-  }, []);
+  }, [isActive]);
 
   const handleCreateFile = useCallback(async (name: string) => {
     setCreatingFile(false);

--- a/src/components/sftp/ExplorerPage.tsx
+++ b/src/components/sftp/ExplorerPage.tsx
@@ -11,9 +11,12 @@ interface ExplorerPageProps {
   /** Defaults to "sftp"; "scp" when the host fell back to SCP. */
   transport?: Transport;
   s3SessionId?: string;
+  /** Whether this tab is the active/visible one. Explorer tabs stay mounted
+   *  (issue #17), so document-level listeners must only fire for the active one. */
+  isActive?: boolean;
 }
 
-export function ExplorerPage({ sftpSessionId, transport = "sftp", s3SessionId }: ExplorerPageProps) {
+export function ExplorerPage({ sftpSessionId, transport = "sftp", s3SessionId, isActive = true }: ExplorerPageProps) {
   const sftpSession = useSftpStore((s) => sftpSessionId ? s.sessions.get(sftpSessionId) : null);
   const s3Session = useS3Store((s) => s3SessionId ? s.sessions.get(s3SessionId) : null);
 
@@ -40,8 +43,8 @@ export function ExplorerPage({ sftpSessionId, transport = "sftp", s3SessionId }:
           className="flex-1 min-h-0 bg-bg-base"
           data-explorer-transport={sftpSessionId ? transport : s3SessionId ? "s3" : undefined}
         >
-          {sftpSessionId && <ExplorerView sessionId={sftpSessionId} transport={transport} />}
-          {s3SessionId && <S3Browser sessionId={s3SessionId} />}
+          {sftpSessionId && <ExplorerView sessionId={sftpSessionId} transport={transport} isActive={isActive} />}
+          {s3SessionId && <S3Browser sessionId={s3SessionId} isActive={isActive} />}
         </div>
       </div>
     </div>

--- a/src/components/sftp/ExplorerView.tsx
+++ b/src/components/sftp/ExplorerView.tsx
@@ -16,9 +16,13 @@ interface ExplorerViewProps {
    * same command surface and session store, differing only in dispatch.
    */
   transport?: Transport;
+  /** Whether this explorer's tab is currently active/visible. Explorer tabs
+   *  stay mounted (issue #17), so document-level listeners are gated to the
+   *  active instance to avoid every open explorer reacting to one event. */
+  isActive?: boolean;
 }
 
-export function ExplorerView({ sessionId, transport = "sftp" }: ExplorerViewProps) {
+export function ExplorerView({ sessionId, transport = "sftp", isActive = true }: ExplorerViewProps) {
   const session = useSftpStore((s) => s.sessions.get(sessionId));
   const setEntries = useSftpStore((s) => s.setEntries);
   const setLoading = useSftpStore((s) => s.setLoading);
@@ -230,6 +234,10 @@ export function ExplorerView({ sessionId, transport = "sftp" }: ExplorerViewProp
   const [creatingFile, setCreatingFile] = useState(false);
 
   useEffect(() => {
+    // Only the active (visible) explorer should react to the document-level
+    // new-folder/new-file events, otherwise every mounted explorer would open
+    // an inline create input at once (issue #17 keeps them all mounted).
+    if (!isActive) return;
     const folderHandler = () => setCreatingFolder(true);
     const fileHandler = () => setCreatingFile(true);
     document.addEventListener("sftp:new-folder", folderHandler);
@@ -242,7 +250,7 @@ export function ExplorerView({ sessionId, transport = "sftp" }: ExplorerViewProp
       document.removeEventListener("explorer:new-folder", folderHandler);
       document.removeEventListener("explorer:new-file", fileHandler);
     };
-  }, []);
+  }, [isActive]);
 
   const handleCreateFile = useCallback(
     async (name: string) => {

--- a/tests/e2e/specs/54-explorer-keeps-directory.spec.ts
+++ b/tests/e2e/specs/54-explorer-keeps-directory.spec.ts
@@ -1,0 +1,84 @@
+// Issue #17: the explorer must keep its current directory when you switch to
+// another tab and back, instead of resetting to the home/default dir.
+
+import { expect } from "chai";
+import { resetApp } from "../helpers/reset.js";
+import { waitForDashboard } from "../helpers/dashboard.js";
+import {
+    clickSave,
+    fillPasswordHostForm,
+    findHostCardByLabel,
+    getHostId,
+    openNewHostModal,
+    waitForModalClosed,
+} from "../helpers/host.js";
+import {
+    createFolder,
+    deleteEntry,
+    openEntry,
+    waitForExplorer,
+} from "../helpers/sftp-ops.js";
+
+const SSHD_PASS_HOST = process.env.SSHD_PASS_HOST ?? "sshd-pass";
+const SSHD_PASS_PORT = Number(process.env.SSHD_PASS_PORT ?? 2222);
+const SSH_USER = process.env.SSH_USER ?? "testuser";
+const SSH_PASS = process.env.SSH_PASS ?? "testpass";
+
+async function openSftp(label: string): Promise<void> {
+    await openNewHostModal();
+    await fillPasswordHostForm({
+        label,
+        host: SSHD_PASS_HOST,
+        port: SSHD_PASS_PORT,
+        username: SSH_USER,
+        password: SSH_PASS,
+    });
+    await clickSave();
+    await waitForModalClosed();
+    await findHostCardByLabel(label);
+    const hostId = await getHostId(label);
+    await (await $(`[data-testid='host-card-${hostId}-explorer']`)).click();
+    await waitForExplorer();
+}
+
+describe("explorer keeps directory across tab switches", () => {
+    beforeEach(async () => {
+        await resetApp();
+        await waitForDashboard();
+    });
+
+    it("stays in the navigated subdirectory after switching tabs and back", async () => {
+        await openSftp("keepdir-target");
+
+        // Create a uniquely-named folder and navigate into it.
+        const dirName = "e2e-keepdir-" + Date.now();
+        await createFolder(dirName);
+        await openEntry(dirName);
+        await browser.waitUntil(
+            async () => (await $(`button*=${dirName}`)).isExisting(),
+            { timeout: 5_000, timeoutMsg: "did not enter the subdir" },
+        );
+
+        // Switch away to the Hosts page tab, then back to the explorer tab.
+        await (await $("[data-tab-type='page']")).click();
+        await waitForDashboard();
+        await (await $("[data-tab-type='sftp']")).click();
+        await waitForExplorer();
+
+        // The explorer must still be inside the subdir — pre-fix it reset to home.
+        const crumb = await $(`button*=${dirName}`);
+        await crumb.waitForExist({ timeout: 5_000 });
+        expect(await crumb.isExisting()).to.equal(true);
+
+        // Cleanup: go to the parent and delete the folder.
+        await browser.execute(() => {
+            const buttons = Array.from(
+                document.querySelectorAll<HTMLButtonElement>(
+                    "[aria-label='Current path'] button",
+                ),
+            );
+            buttons.at(-2)?.click();
+        });
+        await deleteEntry(dirName);
+    });
+});


### PR DESCRIPTION
Fixes #17 — the SFTP/S3 explorer jumped back to the home/default directory whenever you switched to another tab (e.g. a terminal) and back.

## Root cause
`AppShell` keeps **terminals** mounted (visibility-toggled) but rendered only the **active** SFTP/S3 tab, so switching away unmounted `ExplorerPage`. On remount, `ExplorerView`'s mount effect unconditionally re-ran `home_dir`, discarding the `currentPath` the store had preserved. (The backend connection was never dropped — it was purely UI re-initialization.)

## Fix
Render **all** SFTP/S3 tabs at once and toggle visibility (`z-10 visible` / `z-0 invisible`), exactly like terminals, so explorer tabs never unmount. The open directory, scroll position, and selection now survive tab switches, and the `home_dir` effect runs **once per tab lifetime** instead of on every re-activation — so no store/effect changes were needed. Covers SFTP, SCP, and S3.

Because multiple explorers are now mounted simultaneously, the document-level `explorer:new-folder` / `explorer:new-file` events (dispatched globally from the toolbar/context menu) would otherwise open an inline create-input in *every* open explorer. Added an `isActive` prop and gated those listeners to the active (visible) instance. Element-level key handlers (F2/Delete) are focus-scoped and modal Escape handlers are conditionally mounted, so those were already safe.

## Changes
- `AppShell.tsx` — render-all + visibility-toggle for SFTP/S3 tabs; page block becomes active-only.
- `ExplorerPage.tsx` / `ExplorerView.tsx` / `S3Browser.tsx` — `isActive` prop; gate the global new-folder/new-file listeners to the active tab.
- `tests/e2e/specs/54-explorer-keeps-directory.spec.ts` — navigate into a subdir, switch to the Hosts tab and back, assert the explorer is still in that subdir.

## Verification
- `tsc --noEmit` — clean.
- Full e2e (`make e2e`) runs in CI as the gate.