### PR TITLE
fix(terminal): readable ANSI colors in light mode

### DIFF
--- a/src/components/terminal/Terminal.tsx
+++ b/src/components/terminal/Terminal.tsx
@@ -9,6 +9,49 @@ import { useSettingsStore } from "../../stores/settings-store";
 import type { SessionId } from "../../types";
 
 /**
+ * ANSI 16-color palettes. xterm.js falls back to its built-in palette when these
+ * are unset, and that default green (#0DBC79) is nearly illegible on a light
+ * background — so we ship palettes tuned for each background's contrast.
+ */
+const ANSI_PALETTE_DARK = {
+  black: "#2e3436",
+  red: "#cd3131",
+  green: "#0dbc79",
+  yellow: "#e5e510",
+  blue: "#2472c8",
+  magenta: "#bc3fbc",
+  cyan: "#11a8cd",
+  white: "#e5e5e5",
+  brightBlack: "#666666",
+  brightRed: "#f14c4c",
+  brightGreen: "#23d18b",
+  brightYellow: "#f5f543",
+  brightBlue: "#3b8eea",
+  brightMagenta: "#d670d6",
+  brightCyan: "#29b8db",
+  brightWhite: "#ffffff",
+};
+
+const ANSI_PALETTE_LIGHT = {
+  black: "#24292e",
+  red: "#cf222e",
+  green: "#116329",
+  yellow: "#953800",
+  blue: "#0969da",
+  magenta: "#8250df",
+  cyan: "#1b7c83",
+  white: "#6e7781",
+  brightBlack: "#57606a",
+  brightRed: "#a40e26",
+  brightGreen: "#1a7f37",
+  brightYellow: "#633c01",
+  brightBlue: "#0550ae",
+  brightMagenta: "#8250df",
+  brightCyan: "#3192aa",
+  brightWhite: "#8c959f",
+};
+
+/**
  * Read OKLCH CSS custom properties and convert to hex for xterm.js.
  */
 function getTerminalTheme(): Record<string, string> {
@@ -28,6 +71,9 @@ function getTerminalTheme(): Record<string, string> {
     return `#${r.toString(16).padStart(2, "0")}${g.toString(16).padStart(2, "0")}${b.toString(16).padStart(2, "0")}`;
   }
 
+  const ansi =
+    document.documentElement.dataset.theme === "light" ? ANSI_PALETTE_LIGHT : ANSI_PALETTE_DARK;
+
   return {
     background: toHex("--color-bg-base"),
     foreground: toHex("--color-text-primary"),
@@ -35,6 +81,7 @@ function getTerminalTheme(): Record<string, string> {
     cursorAccent: toHex("--color-bg-base"),
     selectionBackground: toHex("--color-accent-muted"),
     selectionForeground: toHex("--color-text-primary"),
+    ...ansi,
   };
 }
 


### PR DESCRIPTION
Fixes #31

## Problem
In light mode the terminal was hard to read — notably command output rendered in green (e.g. `ls --color`, `git status`) appeared washed-out and low-contrast against the pale background.

## Root cause
`getTerminalTheme()` set only `background` / `foreground` / `cursor` / `selection`. It never defined the 16 ANSI colors, so xterm.js fell back to its **built-in** palette. That palette's green (`#0DBC79`) and yellow are tuned for dark backgrounds and are nearly illegible on the light theme's pale surface.

## Fix
- Add two ANSI palettes in `Terminal.tsx`: `ANSI_PALETTE_DARK` (standard VS Code-style colors) and `ANSI_PALETTE_LIGHT` (GitHub-light-style hues with darkened green/yellow/etc. for proper contrast on a light background).
- `getTerminalTheme()` now selects the palette from the active `data-theme` and spreads the full 16 colors into the xterm theme.
- The existing `themeMode` effect already re-applies the theme, so colors adapt live on light/dark switch — no reconnect needed.

## Verification
- `tsc --noEmit` — clean.
- Visual check pending: open a terminal, switch to light mode, and confirm colored output (`ls --color`, `git status`) is legible.

## Notes
This also lays the groundwork for a follow-up **terminal theme customization** feature (preset themes), where this adaptive palette becomes the built-in "Default" preset.
