### PR TITLE
ci: shard e2e suite across 4 parallel runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,24 +92,36 @@ jobs:
         run: cargo test
 
   e2e:
-    name: E2E (WebdriverIO + Docker)
+    name: E2E shard ${{ matrix.shard }}/4
     runs-on: ubuntu-latest
     # Only spend the (expensive) E2E run once the cheap checks are green.
     needs: [frontend, rust]
     timeout-minutes: 60
+    strategy:
+      # Don't cancel the other shards when one fails — we want the full picture.
+      fail-fast: false
+      matrix:
+        # Specs are split round-robin across these shards (see wdio.conf.ts).
+        # SHARD_TOTAL below must equal the number of entries here.
+        shard: [1, 2, 3, 4]
+    env:
+      SHARD_INDEX: ${{ matrix.shard }}
+      SHARD_TOTAL: 4
     steps:
       - uses: actions/checkout@v4
 
       # Brings up the SSH/SCP/MinIO target containers, builds the runner image,
-      # compiles the Tauri debug binary in-container, then runs the WDIO suite.
-      - name: Run E2E suite
+      # compiles the Tauri debug binary in-container, then runs this shard's
+      # slice of the WDIO suite.
+      - name: Run E2E suite (shard ${{ matrix.shard }}/4)
         run: make e2e
 
       - name: Upload E2E artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: e2e-artifacts
+          # Artifact names must be unique per job in upload-artifact v4.
+          name: e2e-artifacts-shard${{ matrix.shard }}
           path: |
             tests/e2e/screenshots
             tests/e2e/videos

--- a/tests/e2e/docker-compose.yml
+++ b/tests/e2e/docker-compose.yml
@@ -165,6 +165,10 @@ services:
       E2E_FORCE_BUILD: ""
       # WDIO log level
       LOG_LEVEL: warn
+      # Spec sharding across parallel CI runners (see wdio.conf.ts). Passed
+      # through from the host env; empty/unset runs the full suite.
+      SHARD_INDEX: ${SHARD_INDEX:-}
+      SHARD_TOTAL: ${SHARD_TOTAL:-}
     volumes:
       - ../..:/workspace                            # repo source (rw, so we can build)
       - cargo-cache:/root/.cargo/registry           # persist crate downloads

--- a/tests/e2e/wdio.conf.ts
+++ b/tests/e2e/wdio.conf.ts
@@ -6,6 +6,7 @@
 // the Tauri binary specified in `tauri:options.application`.
 
 import { spawn, type ChildProcess } from "node:child_process";
+import { readdirSync } from "node:fs";
 import { appendFile, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -160,9 +161,34 @@ function renderReport(records: TestRecord[]): string {
     return lines.join("\n");
 }
 
+/**
+ * Resolve the spec list, optionally sharded across parallel CI runners.
+ *
+ * When SHARD_INDEX (1-based) and SHARD_TOTAL are set, each runner takes a
+ * round-robin slice of the (sorted) specs. Round-robin — not contiguous
+ * blocks — because the heavy SFTP/S3 transfer specs are clustered at the end
+ * (44-54); striping them spreads that cost evenly instead of dumping it all on
+ * the last shard. Without the env vars, fall back to the full glob.
+ */
+function resolveSpecs(): string[] {
+    const total = Number(process.env.SHARD_TOTAL);
+    const index = Number(process.env.SHARD_INDEX);
+    const sharded =
+        Number.isInteger(total) && total >= 2 && Number.isInteger(index) && index >= 1 && index <= total;
+    if (!sharded) return ["./specs/**/*.spec.ts"];
+
+    const all = readdirSync(path.join(__dirname, "specs"))
+        .filter((f) => f.endsWith(".spec.ts"))
+        .sort()
+        .map((f) => `./specs/${f}`);
+    const shard = all.filter((_, i) => i % total === index - 1);
+    console.log(`[wdio] shard ${index}/${total}: ${shard.length}/${all.length} specs`);
+    return shard;
+}
+
 export const config: WebdriverIO.Config = {
     runner: "local",
-    specs: ["./specs/**/*.spec.ts"],
+    specs: resolveSpecs(),
     maxInstances: 1,
 
     hostname: "127.0.0.1",


### PR DESCRIPTION
## Motivation
The e2e job ran all **54 WDIO specs sequentially in one container**, making it by far the longest pole in CI. Since public-repo runners are free and unlimited, we can trade more concurrent runners for wall-clock time.

## Why it's safe to shard
The specs are fully independent — each calls `resetApp()` in `beforeEach` (wipes the app DB + reloads the session), there are no `beforeAll`/`afterAll` hooks, and no spec depends on another's state or ordering. The SSH/SCP/MinIO target containers hold no cross-run persistent state. So specs can run in any order, in separate runners, with zero coordination.

## Changes
- **`tests/e2e/wdio.conf.ts`** — `resolveSpecs()`: when `SHARD_INDEX` (1-based) and `SHARD_TOTAL` are set, take a **round-robin** slice of the sorted spec files. Round-robin rather than contiguous blocks because the heavy SFTP/S3 transfer specs (44–51) are clustered at the end; striping spreads that cost evenly. Unset → full glob, so **local `make e2e` is unchanged**.
- **`tests/e2e/docker-compose.yml`** — forward `SHARD_INDEX`/`SHARD_TOTAL` from the host env into the runner container.
- **`.github/workflows/ci.yml`** — matrix the e2e job into 4 shards (`fail-fast: false` so all shards report), with unique per-shard artifact names (required by upload-artifact v4).

## Split verification
Simulated the partition over the current 54 specs:

| Shard | Count |
|-------|-------|
| 1 | 14 |
| 2 | 14 |
| 3 | 13 |
| 4 | 13 |

All 54 covered, **no gaps, no overlap**, heavy transfer specs spread one-per-shard.

## Tradeoff
Each shard runs in an isolated runner and rebuilds the Tauri debug binary in-container (the `rust-target` volume isn't shared across runners), so the **build overhead is paid 4×**. The test-time parallelism still nets a large wall-clock reduction, but if build dominates we can revisit (fewer shards, or caching the build across runners). `SHARD_TOTAL` in `ci.yml` must stay equal to the matrix length.

## Note
Typecheck of `wdio.conf.ts` can't run locally (e2e type deps live only in the Docker image); the added code is plain TS and CI validates it in-container.