### PR TITLE
Feature request: Sudo mode toggle for SFTP browser

### DIFF
--- a/src-tauri/src/sftp/commands.rs
+++ b/src-tauri/src/sftp/commands.rs
@@ -112,14 +112,46 @@ pub async fn sftp_open(
             .map_err(|e| SftpError::ChannelError(e.to_string()))?
     };
 
-    // 3. Request the SFTP subsystem, or exec sudo sftp-server.
+    // 3. Request the SFTP subsystem, or (sudo) preflight + exec sudo sftp-server.
     if use_sudo.unwrap_or(false) {
-        // `-n` makes sudo fail fast and non-interactively: without it, a host
-        // that requires a password blocks reading the SFTP byte stream as the
-        // (wrong) password and the open hangs until the init timeout. The shell
-        // loop probes sftp-server on $PATH first (portable `command -v`, not the
-        // non-POSIX `which`) then the known per-distro install paths, so this
-        // works on Debian/Ubuntu, RHEL/Fedora, Alpine and Arch.
+        // Preflight on a throwaway channel: confirm the user actually has
+        // *passwordless* sudo before committing the SFTP channel. Without this,
+        // a host that prompts for a password leaves the SFTP init blocked until
+        // the timeout — russh-sftp does not cancel the pending init when the
+        // channel hits EOF — so we'd hang ~30 s instead of failing cleanly.
+        // `sudo -n true` exits non-zero immediately when a password is required.
+        let mut check = {
+            let handle = handle_arc.lock().await;
+            handle
+                .channel_open_session()
+                .await
+                .map_err(|e| SftpError::ChannelError(e.to_string()))?
+        };
+        check
+            .exec(true, "sudo -n true")
+            .await
+            .map_err(|e| SftpError::ChannelError(e.to_string()))?;
+        let mut sudo_exit = None;
+        while let Some(msg) = check.wait().await {
+            match msg {
+                russh::ChannelMsg::ExitStatus { exit_status } => sudo_exit = Some(exit_status),
+                russh::ChannelMsg::Eof | russh::ChannelMsg::Close => break,
+                _ => {}
+            }
+        }
+        if sudo_exit != Some(0) {
+            return Err(SftpError::PermissionDenied(
+                "passwordless sudo is required to browse as root, but it is not configured \
+                 for this user"
+                    .to_string(),
+            ));
+        }
+
+        // Passwordless sudo confirmed — exec sudo sftp-server on the real
+        // channel. `-n` keeps it non-interactive; the shell loop probes
+        // sftp-server on $PATH first (portable `command -v`, not the non-POSIX
+        // `which`) then the known per-distro install paths, so this works on
+        // Debian/Ubuntu, RHEL/Fedora, Alpine and Arch.
         channel
             .exec(
                 true,

--- a/src-tauri/src/sftp/commands.rs
+++ b/src-tauri/src/sftp/commands.rs
@@ -173,10 +173,13 @@ pub async fn sftp_open(
             .map_err(|e| SftpError::ChannelError(e.to_string()))?;
     }
 
-    // 4. Hand the channel's byte-stream to the russh-sftp client.
-    //    Raise the per-request timeout to 30 s (russh-sftp defaults to 10 s),
-    //    which covers init + every later request on high-latency servers.
-    let sftp = russh_sftp::client::SftpSession::new_opts(channel.into_stream(), Some(30))
+    // 4. Hand the channel's byte-stream to the russh-sftp client (10 s default
+    //    init timeout). Do NOT raise this: russh's request_subsystem above
+    //    returns *before* the server's accept/reject reply, so on a host
+    //    without the SFTP subsystem (e.g. SCP-only) this init is what fails —
+    //    a longer timeout just delays the frontend's SFTP→SCP fallback by that
+    //    much (a 30 s value broke the SCP-fallback e2e specs).
+    let sftp = russh_sftp::client::SftpSession::new(channel.into_stream())
         .await
         .map_err(|e| SftpError::ProtocolError(e.to_string()))?;
 

--- a/src-tauri/src/sftp/commands.rs
+++ b/src-tauri/src/sftp/commands.rs
@@ -131,11 +131,14 @@ pub async fn sftp_open(
             .exec(true, "sudo -n true")
             .await
             .map_err(|e| SftpError::ChannelError(e.to_string()))?;
+        // Read until the channel closes. NB: the server often sends `Eof`
+        // BEFORE the `exit-status` request, so we must NOT break on `Eof` or
+        // we'd miss the status and treat a passwordless host as a failure.
         let mut sudo_exit = None;
         while let Some(msg) = check.wait().await {
             match msg {
                 russh::ChannelMsg::ExitStatus { exit_status } => sudo_exit = Some(exit_status),
-                russh::ChannelMsg::Eof | russh::ChannelMsg::Close => break,
+                russh::ChannelMsg::Close => break,
                 _ => {}
             }
         }

--- a/src-tauri/src/sftp/commands.rs
+++ b/src-tauri/src/sftp/commands.rs
@@ -94,6 +94,7 @@ async fn delete_dir_recursive(
 #[instrument(skip(ssh_manager, sftp_manager), fields(ssh_session_id = %session_id))]
 pub async fn sftp_open(
     session_id: String,
+    use_sudo: Option<bool>,
     ssh_manager: State<'_, SshManager>,
     sftp_manager: State<'_, Arc<SftpManager>>,
 ) -> Result<String, SftpError> {
@@ -111,14 +112,22 @@ pub async fn sftp_open(
             .map_err(|e| SftpError::ChannelError(e.to_string()))?
     };
 
-    // 3. Request the SFTP subsystem on that channel.
-    channel
-        .request_subsystem(true, "sftp")
-        .await
-        .map_err(|e| SftpError::ChannelError(e.to_string()))?;
+    // 3. Request the SFTP subsystem, or exec sudo sftp-server.
+    if use_sudo.unwrap_or(false) {
+        channel
+            .exec(true, "sudo /bin/sh -c 'exec $(which sftp-server 2>/dev/null || echo /usr/lib/openssh/sftp-server)'")
+            .await
+            .map_err(|e| SftpError::ChannelError(e.to_string()))?;
+    } else {
+        channel
+            .request_subsystem(true, "sftp")
+            .await
+            .map_err(|e| SftpError::ChannelError(e.to_string()))?;
+    }
 
     // 4. Hand the channel's byte-stream to the russh-sftp client.
-    let sftp = russh_sftp::client::SftpSession::new(channel.into_stream())
+    //    Use a 30 s init timeout (default is 10 s, too short for high-latency servers).
+    let sftp = russh_sftp::client::SftpSession::new_opts(channel.into_stream(), Some(30))
         .await
         .map_err(|e| SftpError::ProtocolError(e.to_string()))?;
 

--- a/src-tauri/src/sftp/commands.rs
+++ b/src-tauri/src/sftp/commands.rs
@@ -114,8 +114,21 @@ pub async fn sftp_open(
 
     // 3. Request the SFTP subsystem, or exec sudo sftp-server.
     if use_sudo.unwrap_or(false) {
+        // `-n` makes sudo fail fast and non-interactively: without it, a host
+        // that requires a password blocks reading the SFTP byte stream as the
+        // (wrong) password and the open hangs until the init timeout. The shell
+        // loop probes sftp-server on $PATH first (portable `command -v`, not the
+        // non-POSIX `which`) then the known per-distro install paths, so this
+        // works on Debian/Ubuntu, RHEL/Fedora, Alpine and Arch.
         channel
-            .exec(true, "sudo /bin/sh -c 'exec $(which sftp-server 2>/dev/null || echo /usr/lib/openssh/sftp-server)'")
+            .exec(
+                true,
+                "sudo -n /bin/sh -c 'for p in \"$(command -v sftp-server 2>/dev/null)\" \
+                 /usr/lib/openssh/sftp-server /usr/libexec/openssh/sftp-server \
+                 /usr/lib/ssh/sftp-server /usr/libexec/sftp-server; do \
+                 [ -x \"$p\" ] && exec \"$p\"; done; \
+                 echo \"sftp-server: not found\" >&2; exit 127'",
+            )
             .await
             .map_err(|e| SftpError::ChannelError(e.to_string()))?;
     } else {
@@ -126,7 +139,8 @@ pub async fn sftp_open(
     }
 
     // 4. Hand the channel's byte-stream to the russh-sftp client.
-    //    Use a 30 s init timeout (default is 10 s, too short for high-latency servers).
+    //    Raise the per-request timeout to 30 s (russh-sftp defaults to 10 s),
+    //    which covers init + every later request on high-latency servers.
     let sftp = russh_sftp::client::SftpSession::new_opts(channel.into_stream(), Some(30))
         .await
         .map_err(|e| SftpError::ProtocolError(e.to_string()))?;
@@ -141,8 +155,9 @@ pub async fn sftp_open(
         },
     );
 
-    tracing::info!(sftp_session_id = %sftp_id, "SFTP session opened");
-    crate::telemetry::capture("sftp_opened", serde_json::json!({}));
+    let sudo = use_sudo.unwrap_or(false);
+    tracing::info!(sftp_session_id = %sftp_id, sudo, "SFTP session opened");
+    crate::telemetry::capture("sftp_opened", serde_json::json!({ "sudo": sudo }));
     Ok(sftp_id)
 }
 

--- a/src/components/dashboard/HostsDashboard.tsx
+++ b/src/components/dashboard/HostsDashboard.tsx
@@ -287,7 +287,7 @@ export function HostsDashboard() {
           }
         }
 
-        useSftpStore.getState().openSession(explorerSessionId, sessionId, label);
+        useSftpStore.getState().openSession(explorerSessionId, sessionId, label, host.username);
 
         setConnectingHost(null);
         useTabStore.getState().addTab({ type: "sftp", id: explorerSessionId, label, transport });

--- a/src/components/explorer/ExplorerToolbar.tsx
+++ b/src/components/explorer/ExplorerToolbar.tsx
@@ -1,4 +1,4 @@
-import { Upload, FolderPlus, FilePlus, RefreshCw, ChevronRight, Home, Loader2 } from "lucide-react";
+import { Upload, FolderPlus, FilePlus, RefreshCw, ChevronRight, Home, Loader2, Shield } from "lucide-react";
 import type { FileSystemProvider } from "../../types/explorer";
 
 interface BreadcrumbSegment {
@@ -17,6 +17,8 @@ interface ExplorerToolbarProps {
   onNavigate: (path: string) => void;
   onUpload: () => void;
   busy?: boolean;
+  sudoMode?: boolean;
+  onToggleSudo?: () => void;
 }
 
 export function ExplorerToolbar({
@@ -30,6 +32,8 @@ export function ExplorerToolbar({
   onNavigate,
   onUpload,
   busy,
+  sudoMode,
+  onToggleSudo,
 }: ExplorerToolbarProps) {
   const caps = provider.capabilities;
 
@@ -169,6 +173,23 @@ export function ExplorerToolbar({
           className={loading ? "motion-safe:animate-spin" : ""}
         />
       </button>
+
+      {onToggleSudo && (
+        <button
+          onClick={onToggleSudo}
+          title={sudoMode ? "Disable sudo mode" : "Enable sudo mode"}
+          aria-label={sudoMode ? "Disable sudo mode" : "Enable sudo mode"}
+          aria-pressed={sudoMode}
+          className={[
+            iconBtn,
+            sudoMode
+              ? "text-accent bg-accent/15 hover:bg-accent/25 hover:text-accent"
+              : "",
+          ].join(" ")}
+        >
+          <Shield size={15} strokeWidth={1.8} aria-hidden="true" />
+        </button>
+      )}
     </div>
   );
 }

--- a/src/components/explorer/ExplorerToolbar.tsx
+++ b/src/components/explorer/ExplorerToolbar.tsx
@@ -178,6 +178,7 @@ export function ExplorerToolbar({
 
       {onToggleSudo && (
         <button
+          data-testid="explorer-sudo-toggle"
           onClick={onToggleSudo}
           disabled={sudoBusy}
           aria-busy={sudoBusy}

--- a/src/components/explorer/ExplorerToolbar.tsx
+++ b/src/components/explorer/ExplorerToolbar.tsx
@@ -18,6 +18,7 @@ interface ExplorerToolbarProps {
   onUpload: () => void;
   busy?: boolean;
   sudoMode?: boolean;
+  sudoBusy?: boolean;
   onToggleSudo?: () => void;
 }
 
@@ -33,6 +34,7 @@ export function ExplorerToolbar({
   onUpload,
   busy,
   sudoMode,
+  sudoBusy,
   onToggleSudo,
 }: ExplorerToolbarProps) {
   const caps = provider.capabilities;
@@ -177,9 +179,11 @@ export function ExplorerToolbar({
       {onToggleSudo && (
         <button
           onClick={onToggleSudo}
+          disabled={sudoBusy}
+          aria-busy={sudoBusy}
           title={sudoMode ? "Disable sudo mode" : "Enable sudo mode"}
           aria-label={sudoMode ? "Disable sudo mode" : "Enable sudo mode"}
-          aria-pressed={sudoMode}
+          aria-pressed={!!sudoMode}
           className={[
             iconBtn,
             sudoMode
@@ -187,7 +191,11 @@ export function ExplorerToolbar({
               : "",
           ].join(" ")}
         >
-          <Shield size={15} strokeWidth={1.8} aria-hidden="true" />
+          {sudoBusy ? (
+            <Loader2 size={15} strokeWidth={1.8} aria-hidden="true" className="motion-safe:animate-spin" />
+          ) : (
+            <Shield size={15} strokeWidth={1.8} aria-hidden="true" />
+          )}
         </button>
       )}
     </div>

--- a/src/components/history/HistoryPage.tsx
+++ b/src/components/history/HistoryPage.tsx
@@ -142,7 +142,7 @@ export function HistoryPage() {
         }
       }
 
-      useSftpStore.getState().openSession(explorerSessionId, sessionId, label);
+      useSftpStore.getState().openSession(explorerSessionId, sessionId, label, entry.username);
       useTabStore.getState().addTab({ type: "sftp", id: explorerSessionId, label, transport });
     } catch {
       // Errors surface via SFTP page

--- a/src/components/layout/UnifiedTabBar.tsx
+++ b/src/components/layout/UnifiedTabBar.tsx
@@ -81,7 +81,11 @@ export function UnifiedTabBar() {
 
   return (
     <div className="flex items-center h-[var(--tabbar-height)] no-select px-2">
-      <div className="flex items-center gap-1.5 overflow-x-auto overflow-y-hidden flex-1 min-w-0">
+      <div
+        className="flex items-center gap-1.5 overflow-x-auto overflow-y-hidden flex-1 min-w-0"
+        role="tablist"
+        aria-label="Open sessions"
+      >
         {tabOrder.map((tabId) => {
           const tab = tabs.get(tabId);
           if (!tab) return null;

--- a/src/components/layout/UnifiedTabBar.tsx
+++ b/src/components/layout/UnifiedTabBar.tsx
@@ -116,16 +116,20 @@ export function UnifiedTabBar() {
           const closeable = !(tab.type === "page" && tab.page === "hosts");
 
           return (
-            <button
+            <div
               key={tabId}
+              role="tab"
+              tabIndex={0}
+              aria-selected={isActive}
               data-testid={`tab-${tabId}`}
               data-tab-type={tab.type}
               data-tab-label={tab.label}
               onClick={() => setActiveTab(tabId)}
+              onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); setActiveTab(tabId); } }}
               title={tab.label + (paneCount > 1 ? ` (${paneCount} panes)` : "")}
               className={[
                 "group relative flex items-center gap-2 px-3.5 h-[30px] shrink-0 max-w-[220px]",
-                "text-[length:var(--text-sm)] leading-none rounded-lg",
+                "text-[length:var(--text-sm)] leading-none rounded-lg cursor-pointer",
                 "transition-[color,background-color] duration-[var(--duration-fast)]",
                 "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
                 isActive
@@ -195,7 +199,7 @@ export function UnifiedTabBar() {
                   <X size={12} strokeWidth={2} aria-hidden="true" />
                 </button>
               )}
-            </button>
+            </div>
           );
         })}
 

--- a/src/components/sftp/ExplorerView.tsx
+++ b/src/components/sftp/ExplorerView.tsx
@@ -517,7 +517,10 @@ export function ExplorerView({ sessionId, transport = "sftp", isActive = true }:
 
       {/* Error banner */}
       {session.error && (
-        <div className="flex items-center gap-2.5 px-4 py-2.5 bg-status-error/10 border-b border-status-error/20 text-status-error">
+        <div
+          data-testid="explorer-error"
+          className="flex items-center gap-2.5 px-4 py-2.5 bg-status-error/10 border-b border-status-error/20 text-status-error"
+        >
           <AlertCircle size={15} strokeWidth={2} aria-hidden="true" className="shrink-0" />
           <p className="text-[length:var(--text-sm)]">{session.error}</p>
         </div>

--- a/src/components/sftp/ExplorerView.tsx
+++ b/src/components/sftp/ExplorerView.tsx
@@ -168,31 +168,59 @@ export function ExplorerView({ sessionId, transport = "sftp", isActive = true }:
 
   // ─── Sudo toggle (SFTP only) ──────────────────────────────────────────────
 
+  const [togglingSudo, setTogglingSudo] = useState(false);
+
   const handleToggleSudo = useCallback(async () => {
-    if (transport !== "sftp") return;
+    // Re-entrancy guard: the open round-trip can take seconds, and a second
+    // toggle would open (and orphan) a second server-side SFTP session.
+    if (transport !== "sftp" || togglingSudo) return;
     const newSudoMode = !sudoMode;
+    setTogglingSudo(true);
 
-    // 1. Open the new session BEFORE closing the old one.
-    const newSftpSessionId = await invoke<string>("sftp_open", {
-      sessionId: sshSessionId,
-      useSudo: newSudoMode,
-    });
+    try {
+      // 1. Open the new session BEFORE closing the old one.
+      const newSftpSessionId = await invoke<string>("sftp_open", {
+        sessionId: sshSessionId,
+        useSudo: newSudoMode,
+      });
 
-    // 2. Close old session on the server (best-effort).
-    try { await invoke("sftp_close", { sftpSessionId: sessionId }); } catch { /* ignore */ }
+      // 2. Close old session on the server (best-effort).
+      try { await invoke("sftp_close", { sftpSessionId: sessionId }); } catch { /* ignore */ }
 
-    // 3. Atomically swap the store entry (keeps same key reference for a
-    //    split second, then the tab ID change causes a clean remount).
-    swapSession(sessionId, newSftpSessionId, newSudoMode);
+      // 3. Swap the store entry (preserves currentPath so the remount lands
+      //    in the same directory).
+      swapSession(sessionId, newSftpSessionId, newSudoMode);
 
-    // 4. Update the tab store so AppShell passes the new session ID as prop.
-    //    This triggers a React key change → ExplorerView remounts cleanly.
-    replaceTabId(sessionId, newSftpSessionId);
-  }, [transport, sudoMode, sessionId, sshSessionId, swapSession, replaceTabId]);
+      // 4. Update the tab store so AppShell passes the new session ID as prop.
+      //    This triggers a React key change → ExplorerView remounts cleanly.
+      replaceTabId(sessionId, newSftpSessionId);
+    } catch (err: unknown) {
+      // Surface the failure (e.g. host without passwordless sudo) instead of
+      // silently no-op'ing. The old session is untouched (close runs only
+      // after a successful open), so the view keeps working.
+      const msg =
+        err && typeof err === "object" && "message" in err
+          ? String((err as { message: string }).message)
+          : `Failed to ${newSudoMode ? "enable" : "disable"} sudo mode`;
+      setError(sessionId, msg);
+    } finally {
+      // On success the view remounts (tab id changes) and this is a no-op;
+      // on failure or a closed tab it re-enables the button.
+      setTogglingSudo(false);
+    }
+  }, [transport, togglingSudo, sudoMode, sessionId, sshSessionId, swapSession, replaceTabId, setError]);
 
-  // On mount: resolve home dir, then load it
+  // On mount: reload the preserved directory (e.g. after a sudo-toggle
+  // remount), otherwise resolve the home dir.
   useEffect(() => {
     (async () => {
+      const preserved = useSftpStore.getState().sessions.get(sessionId)?.currentPath;
+      if (preserved && preserved !== "/") {
+        try {
+          await loadDirectory(preserved);
+          return;
+        } catch { /* fall through to home/root */ }
+      }
       try {
         const homeDir = await explorerInvoke<string>(transport, "home_dir", sessionId);
         await loadDirectory(homeDir);
@@ -483,6 +511,7 @@ export function ExplorerView({ sessionId, transport = "sftp", isActive = true }:
         onUpload={() => void handleUpload()}
         busy={busy}
         sudoMode={sudoMode}
+        sudoBusy={togglingSudo}
         onToggleSudo={transport === "sftp" && !isRoot ? () => void handleToggleSudo() : undefined}
       />
 

--- a/src/components/sftp/ExplorerView.tsx
+++ b/src/components/sftp/ExplorerView.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from "react";
+import { invoke } from "@tauri-apps/api/core";
 import { AlertCircle } from "lucide-react";
 import { useSftpStore } from "../../stores/sftp-store";
+import { useTabStore } from "../../stores/tab-store";
 import type { SftpEntry } from "../../types";
 import type { ExplorerEntry, ExplorerClipboard } from "../../types/explorer";
 import { ExplorerToolbar, ExplorerFileTable, ExplorerDropZone } from "../explorer";
@@ -30,6 +32,11 @@ export function ExplorerView({ sessionId, transport = "sftp", isActive = true }:
   const setSort = useSftpStore((s) => s.setSort);
   const clipboard = useSftpStore((s) => s.clipboard);
   const setClipboard = useSftpStore((s) => s.setClipboard);
+  const sudoMode = useSftpStore((s) => s.sessions.get(sessionId)?.sudoMode ?? false);
+  const sshSessionId = useSftpStore((s) => s.sessions.get(sessionId)?.sshSessionId ?? "");
+  const swapSession = useSftpStore((s) => s.swapSession);
+  const replaceTabId = useTabStore((s) => s.replaceTabId);
+  const isRoot = useSftpStore((s) => s.sessions.get(sessionId)?.username === "root");
 
   const provider = useMemo(() => createSftpProvider(sessionId), [sessionId]);
 
@@ -158,6 +165,30 @@ export function ExplorerView({ sessionId, transport = "sftp", isActive = true }:
     },
     [sessionId, transport, setLoading, setEntries, setError],
   );
+
+  // ─── Sudo toggle (SFTP only) ──────────────────────────────────────────────
+
+  const handleToggleSudo = useCallback(async () => {
+    if (transport !== "sftp") return;
+    const newSudoMode = !sudoMode;
+
+    // 1. Open the new session BEFORE closing the old one.
+    const newSftpSessionId = await invoke<string>("sftp_open", {
+      sessionId: sshSessionId,
+      useSudo: newSudoMode,
+    });
+
+    // 2. Close old session on the server (best-effort).
+    try { await invoke("sftp_close", { sftpSessionId: sessionId }); } catch { /* ignore */ }
+
+    // 3. Atomically swap the store entry (keeps same key reference for a
+    //    split second, then the tab ID change causes a clean remount).
+    swapSession(sessionId, newSftpSessionId, newSudoMode);
+
+    // 4. Update the tab store so AppShell passes the new session ID as prop.
+    //    This triggers a React key change → ExplorerView remounts cleanly.
+    replaceTabId(sessionId, newSftpSessionId);
+  }, [transport, sudoMode, sessionId, sshSessionId, swapSession, replaceTabId]);
 
   // On mount: resolve home dir, then load it
   useEffect(() => {
@@ -451,6 +482,8 @@ export function ExplorerView({ sessionId, transport = "sftp", isActive = true }:
         onNewFolder={() => setCreatingFolder(true)}
         onUpload={() => void handleUpload()}
         busy={busy}
+        sudoMode={sudoMode}
+        onToggleSudo={transport === "sftp" && !isRoot ? () => void handleToggleSudo() : undefined}
       />
 
       {/* Error banner */}

--- a/src/components/sftp/SftpSessionPicker.tsx
+++ b/src/components/sftp/SftpSessionPicker.tsx
@@ -14,14 +14,14 @@ export function SftpSessionPicker() {
     (s) => s.status === "Connected",
   );
 
-  const handleOpenSftp = async (sshSessionId: string, label: string) => {
+  const handleOpenSftp = async (sshSessionId: string, label: string, username: string) => {
     setOpeningId(sshSessionId);
     setError(null);
 
     try {
       const { invoke } = await import("@tauri-apps/api/core");
       const sftpSessionId = await invoke<string>("sftp_open", { sessionId: sshSessionId });
-      openSession(sftpSessionId, sshSessionId, label);
+      openSession(sftpSessionId, sshSessionId, label, username);
     } catch (err: unknown) {
       const msg =
         err && typeof err === "object" && "message" in err
@@ -119,7 +119,7 @@ export function SftpSessionPicker() {
 
                     {/* Open SFTP button */}
                     <button
-                      onClick={() => void handleOpenSftp(session.id, session.label)}
+                      onClick={() => void handleOpenSftp(session.id, session.label, session.hostConfig.username)}
                       disabled={isOpening}
                       title={`Open SFTP for ${session.label}`}
                       aria-label={`Open file browser for ${session.label}`}

--- a/src/stores/sftp-store.ts
+++ b/src/stores/sftp-store.ts
@@ -83,9 +83,17 @@ export const useSftpStore = create<SftpState>((set) => ({
       if (!old) return state;
       const next = new Map(state.sessions);
       next.delete(oldId);
-      next.set(newId, { ...old, sftpSessionId: newId, sudoMode, currentPath: "/", entries: [], loading: false, error: null });
+      // Keep currentPath (via ...old) so the remounted view reloads the same
+      // directory; only the entries are cleared pending the fresh listing.
+      next.set(newId, { ...old, sftpSessionId: newId, sudoMode, entries: [], loading: false, error: null });
       const newActive = state.activeSftpSessionId === oldId ? newId : state.activeSftpSessionId;
-      return { sessions: next, activeSftpSessionId: newActive };
+      // Re-point an outstanding clipboard so a pending cut/copy still pastes
+      // after the session id changes.
+      const clipboard =
+        state.clipboard?.sourceSessionId === oldId
+          ? { ...state.clipboard, sourceSessionId: newId }
+          : state.clipboard;
+      return { sessions: next, activeSftpSessionId: newActive, clipboard };
     }),
 
   setActiveSftpSession: (id) =>

--- a/src/stores/sftp-store.ts
+++ b/src/stores/sftp-store.ts
@@ -7,6 +7,8 @@ export interface SftpSession {
   sftpSessionId: string;
   sshSessionId: string;
   label: string;
+  username: string;
+  sudoMode: boolean;
   currentPath: string;
   entries: SftpEntry[];
   loading: boolean;
@@ -22,8 +24,10 @@ interface SftpState {
   activeSftpSessionId: string | null;
   clipboard: SftpClipboard | null;
 
-  openSession: (sftpSessionId: string, sshSessionId: string, label: string) => void;
+  openSession: (sftpSessionId: string, sshSessionId: string, label: string, username?: string, sudoMode?: boolean) => void;
   closeSession: (sftpSessionId: string) => void;
+  /** Replace an existing session's ID in-place (used by sudo toggle). */
+  swapSession: (oldId: string, newId: string, sudoMode: boolean) => void;
   setActiveSftpSession: (id: string | null) => void;
   setEntries: (sftpSessionId: string, path: string, entries: SftpEntry[]) => void;
   setLoading: (sftpSessionId: string, loading: boolean) => void;
@@ -43,13 +47,15 @@ export const useSftpStore = create<SftpState>((set) => ({
   activeSftpSessionId: null,
   clipboard: null,
 
-  openSession: (sftpSessionId, sshSessionId, label) =>
+  openSession: (sftpSessionId, sshSessionId, label, username, sudoMode) =>
     set((state) => {
       const next = new Map(state.sessions);
       next.set(sftpSessionId, {
         sftpSessionId,
         sshSessionId,
         label,
+        username: username ?? "",
+        sudoMode: sudoMode ?? false,
         currentPath: "/",
         entries: [],
         loading: false,
@@ -68,6 +74,17 @@ export const useSftpStore = create<SftpState>((set) => ({
         state.activeSftpSessionId === sftpSessionId
           ? (next.keys().next().value ?? null)
           : state.activeSftpSessionId;
+      return { sessions: next, activeSftpSessionId: newActive };
+    }),
+
+  swapSession: (oldId, newId, sudoMode) =>
+    set((state) => {
+      const old = state.sessions.get(oldId);
+      if (!old) return state;
+      const next = new Map(state.sessions);
+      next.delete(oldId);
+      next.set(newId, { ...old, sftpSessionId: newId, sudoMode, currentPath: "/", entries: [], loading: false, error: null });
+      const newActive = state.activeSftpSessionId === oldId ? newId : state.activeSftpSessionId;
       return { sessions: next, activeSftpSessionId: newActive };
     }),
 

--- a/src/stores/tab-store.ts
+++ b/src/stores/tab-store.ts
@@ -28,6 +28,8 @@ interface TabState {
   removeTab: (id: string) => void;
   setActiveTab: (id: string) => void;
   updateTabLabel: (id: string, label: string) => void;
+  /** Swap a tab's ID in-place (used by SFTP sudo toggle when session reopens). */
+  replaceTabId: (oldId: string, newId: string) => void;
   /** Activate or create a singleton page tab. */
   openPageTab: (page: PageId, label: string) => void;
   /** Find the most recent tab of a given type and activate it. Returns false if none found. */
@@ -102,6 +104,18 @@ export const useTabStore = create<TabState>((set, get) => ({
       const tabs = new Map(state.tabs);
       tabs.set(id, { ...tab, label });
       return { tabs };
+    }),
+
+  replaceTabId: (oldId, newId) =>
+    set((state) => {
+      const tab = state.tabs.get(oldId);
+      if (!tab) return state;
+      const tabs = new Map(state.tabs);
+      tabs.delete(oldId);
+      tabs.set(newId, { ...tab, id: newId });
+      const tabOrder = state.tabOrder.map((t) => (t === oldId ? newId : t));
+      const activeTabId = state.activeTabId === oldId ? newId : state.activeTabId;
+      return { tabs, tabOrder, activeTabId };
     }),
 
   openPageTab: (page, label) => {

--- a/tests/e2e/docker-compose.yml
+++ b/tests/e2e/docker-compose.yml
@@ -16,6 +16,26 @@ services:
       SUDO_ACCESS: "true"
     networks: [e2e]
 
+  # Passwordless-sudo target (built from tests/sudo-server). Same base as
+  # sshd-pass but with a NOPASSWD sudoers rule, so the SFTP sudo-mode toggle
+  # (`sudo -n sftp-server`) succeeds here. sshd-pass, by contrast, keeps
+  # password-prompting sudo and exercises the toggle's failure path.
+  sshd-sudo:
+    build:
+      context: ../sudo-server
+      dockerfile: Dockerfile
+    image: anyscp-test-sudo:latest
+    container_name: anyscp-e2e-sshd-sudo
+    environment:
+      PUID: "1000"
+      PGID: "1000"
+      TZ: Etc/UTC
+      USER_NAME: testuser
+      USER_PASSWORD: testpass
+      PASSWORD_ACCESS: "true"
+      SUDO_ACCESS: "true"
+    networks: [e2e]
+
   sshd-key:
     image: lscr.io/linuxserver/openssh-server:latest
     container_name: anyscp-e2e-sshd-key
@@ -133,6 +153,8 @@ services:
     depends_on:
       sshd-pass:
         condition: service_started
+      sshd-sudo:
+        condition: service_started
       sshd-key:
         condition: service_started
       sshd-scp:
@@ -144,6 +166,8 @@ services:
     environment:
       SSHD_PASS_HOST: sshd-pass
       SSHD_PASS_PORT: "2222"
+      SSHD_SUDO_HOST: sshd-sudo
+      SSHD_SUDO_PORT: "2222"
       SSHD_KEY_HOST: sshd-key
       SSHD_KEY_PORT: "2222"
       SSHD_SCP_HOST: sshd-scp

--- a/tests/e2e/entrypoint.sh
+++ b/tests/e2e/entrypoint.sh
@@ -28,6 +28,7 @@ wait_for() {
 }
 
 wait_for "${SSHD_PASS_HOST:-sshd-pass}" "${SSHD_PASS_PORT:-2222}" sshd-pass
+wait_for "${SSHD_SUDO_HOST:-sshd-sudo}" "${SSHD_SUDO_PORT:-2222}" sshd-sudo
 wait_for "${SSHD_KEY_HOST:-sshd-key}"   "${SSHD_KEY_PORT:-2222}"   sshd-key
 wait_for "${SSHD_SCP_HOST:-sshd-scp}"   "${SSHD_SCP_PORT:-2222}"   sshd-scp
 wait_for "${SSHD_SCP_BUSYBOX_HOST:-sshd-scp-busybox}" "${SSHD_SCP_BUSYBOX_PORT:-2222}" sshd-scp-busybox

--- a/tests/e2e/helpers/sftp-ops.ts
+++ b/tests/e2e/helpers/sftp-ops.ts
@@ -45,6 +45,29 @@ export async function navigateExplorerHome(): Promise<void> {
     await btn.click();
 }
 
+/** Current pressed-state of the sudo toggle ("true"/"false"), or null if the
+ *  button isn't rendered (e.g. SCP transport or a root login). */
+export async function sudoToggleState(): Promise<string | null> {
+    const btn = await $("[data-testid='explorer-sudo-toggle']");
+    if (!(await btn.isExisting())) return null;
+    return await btn.getAttribute("aria-pressed");
+}
+
+/** Click the sudo toggle and wait until the (remounted) explorer reports the
+ *  expected pressed state. Toggling reopens the SFTP session over `sudo
+ *  sftp-server` and remounts the view, so the button element is replaced. */
+export async function toggleSudo(expectOn: boolean): Promise<void> {
+    const btn = await $("[data-testid='explorer-sudo-toggle']");
+    await btn.waitForClickable({ timeout: 10_000 });
+    await btn.click();
+    await browser.waitUntil(async () => (await sudoToggleState()) === String(expectOn), {
+        timeout: 30_000,
+        timeoutMsg: `sudo toggle never reached aria-pressed=${expectOn}`,
+    });
+    // The reopened session re-lists its directory; wait for the toolbar to settle.
+    await waitForExplorer();
+}
+
 /** Create a folder via the toolbar. Waits for the new entry to appear. */
 export async function createFolder(name: string): Promise<void> {
     await (await $("[data-testid='explorer-new-folder']")).click();

--- a/tests/e2e/specs/55-sftp-sudo-toggle.spec.ts
+++ b/tests/e2e/specs/55-sftp-sudo-toggle.spec.ts
@@ -1,11 +1,13 @@
 // SFTP sudo-mode toggle (PR #35): the shield toolbar button reopens the SFTP
 // session over `sudo sftp-server` so the user can browse as root, then back.
 //
-// Infra notes: every e2e sshd target runs `testuser` with SUDO_ACCESS=true
-// (passwordless sudo), and the linuxserver/openssh-server image is Alpine, so
-// sftp-server lives at /usr/lib/ssh/sftp-server — found via the backend's
-// command-v + per-distro probe list. Because testuser != root and the
-// transport is sftp, the shield button is rendered.
+// Two targets exercise both paths:
+//   - sshd-sudo: NOPASSWD sudoers (tests/sudo-server) → the toggle succeeds.
+//   - sshd-pass: password-prompting sudo → the backend preflight (`sudo -n
+//     true`) fails fast and the toggle surfaces an error banner instead of
+//     hanging or silently no-op'ing.
+// Both linuxserver images are Alpine, so sftp-server lives at
+// /usr/lib/ssh/sftp-server — found via the backend's command-v + probe list.
 
 import { expect } from "chai";
 import { resetApp } from "../helpers/reset.js";
@@ -27,20 +29,16 @@ import {
     waitForExplorer,
 } from "../helpers/sftp-ops.js";
 
+const SSHD_SUDO_HOST = process.env.SSHD_SUDO_HOST ?? "sshd-sudo";
+const SSHD_SUDO_PORT = Number(process.env.SSHD_SUDO_PORT ?? 2222);
 const SSHD_PASS_HOST = process.env.SSHD_PASS_HOST ?? "sshd-pass";
 const SSHD_PASS_PORT = Number(process.env.SSHD_PASS_PORT ?? 2222);
 const SSH_USER = process.env.SSH_USER ?? "testuser";
 const SSH_PASS = process.env.SSH_PASS ?? "testpass";
 
-async function openSftp(label: string): Promise<void> {
+async function openSftp(label: string, host: string, port: number): Promise<void> {
     await openNewHostModal();
-    await fillPasswordHostForm({
-        label,
-        host: SSHD_PASS_HOST,
-        port: SSHD_PASS_PORT,
-        username: SSH_USER,
-        password: SSH_PASS,
-    });
+    await fillPasswordHostForm({ label, host, port, username: SSH_USER, password: SSH_PASS });
     await clickSave();
     await waitForModalClosed();
     await findHostCardByLabel(label);
@@ -56,9 +54,8 @@ describe("SFTP sudo toggle", () => {
     });
 
     it("enables sudo mode then disables it, keeping the listing", async () => {
-        await openSftp("sudo-target");
+        await openSftp("sudo-on", SSHD_SUDO_HOST, SSHD_SUDO_PORT);
 
-        // The shield button is rendered (non-root sftp session) and starts off.
         const toggle = await $("[data-testid='explorer-sudo-toggle']");
         await toggle.waitForDisplayed({ timeout: 10_000 });
         expect(await sudoToggleState()).to.equal("false");
@@ -79,9 +76,6 @@ describe("SFTP sudo toggle", () => {
         // Disable sudo: back to the unprivileged session, symmetrically.
         await toggleSudo(false);
         expect(await sudoToggleState()).to.equal("false");
-        expect(
-            await (await $("[data-testid='explorer-sudo-toggle']")).getAttribute("aria-label"),
-        ).to.equal("Enable sudo mode");
         await browser.waitUntil(
             async () => (await $$("[data-entry-row='true']")).length > 0,
             { timeout: 15_000, timeoutMsg: "no entries rendered after disabling sudo" },
@@ -89,7 +83,7 @@ describe("SFTP sudo toggle", () => {
     });
 
     it("stays in the current directory after toggling sudo", async () => {
-        await openSftp("sudo-keepdir");
+        await openSftp("sudo-keepdir", SSHD_SUDO_HOST, SSHD_SUDO_PORT);
 
         // Navigate into a fresh subdir so currentPath is a non-home path.
         const dirName = "e2e-sudo-" + Date.now();
@@ -116,5 +110,28 @@ describe("SFTP sudo toggle", () => {
             buttons.at(-2)?.click();
         });
         await deleteEntry(dirName);
+    });
+
+    it("surfaces an error when passwordless sudo is unavailable", async () => {
+        // sshd-pass has sudo but PROMPTS for a password, so the backend
+        // preflight rejects it. The toggle must show an error banner and stay
+        // off — not hang or silently do nothing.
+        await openSftp("sudo-nopass", SSHD_PASS_HOST, SSHD_PASS_PORT);
+
+        const toggle = await $("[data-testid='explorer-sudo-toggle']");
+        await toggle.waitForClickable({ timeout: 10_000 });
+        await toggle.click();
+
+        // Error banner appears (fast, via the preflight — no 30s init hang).
+        const banner = await $("[data-testid='explorer-error']");
+        await banner.waitForDisplayed({ timeout: 15_000 });
+        const text = await browser.execute(
+            () => document.querySelector("[data-testid='explorer-error']")?.textContent ?? "",
+        );
+        expect(text.toLowerCase()).to.include("sudo");
+
+        // The toggle did not engage and is re-enabled for another try.
+        expect(await sudoToggleState()).to.equal("false");
+        await (await $("[data-testid='explorer-sudo-toggle']")).waitForClickable({ timeout: 5_000 });
     });
 });

--- a/tests/e2e/specs/55-sftp-sudo-toggle.spec.ts
+++ b/tests/e2e/specs/55-sftp-sudo-toggle.spec.ts
@@ -1,0 +1,120 @@
+// SFTP sudo-mode toggle (PR #35): the shield toolbar button reopens the SFTP
+// session over `sudo sftp-server` so the user can browse as root, then back.
+//
+// Infra notes: every e2e sshd target runs `testuser` with SUDO_ACCESS=true
+// (passwordless sudo), and the linuxserver/openssh-server image is Alpine, so
+// sftp-server lives at /usr/lib/ssh/sftp-server — found via the backend's
+// command-v + per-distro probe list. Because testuser != root and the
+// transport is sftp, the shield button is rendered.
+
+import { expect } from "chai";
+import { resetApp } from "../helpers/reset.js";
+import { waitForDashboard } from "../helpers/dashboard.js";
+import {
+    clickSave,
+    fillPasswordHostForm,
+    findHostCardByLabel,
+    getHostId,
+    openNewHostModal,
+    waitForModalClosed,
+} from "../helpers/host.js";
+import {
+    createFolder,
+    deleteEntry,
+    openEntry,
+    sudoToggleState,
+    toggleSudo,
+    waitForExplorer,
+} from "../helpers/sftp-ops.js";
+
+const SSHD_PASS_HOST = process.env.SSHD_PASS_HOST ?? "sshd-pass";
+const SSHD_PASS_PORT = Number(process.env.SSHD_PASS_PORT ?? 2222);
+const SSH_USER = process.env.SSH_USER ?? "testuser";
+const SSH_PASS = process.env.SSH_PASS ?? "testpass";
+
+async function openSftp(label: string): Promise<void> {
+    await openNewHostModal();
+    await fillPasswordHostForm({
+        label,
+        host: SSHD_PASS_HOST,
+        port: SSHD_PASS_PORT,
+        username: SSH_USER,
+        password: SSH_PASS,
+    });
+    await clickSave();
+    await waitForModalClosed();
+    await findHostCardByLabel(label);
+    const hostId = await getHostId(label);
+    await (await $(`[data-testid='host-card-${hostId}-explorer']`)).click();
+    await waitForExplorer();
+}
+
+describe("SFTP sudo toggle", () => {
+    beforeEach(async () => {
+        await resetApp();
+        await waitForDashboard();
+    });
+
+    it("enables sudo mode then disables it, keeping the listing", async () => {
+        await openSftp("sudo-target");
+
+        // The shield button is rendered (non-root sftp session) and starts off.
+        const toggle = await $("[data-testid='explorer-sudo-toggle']");
+        await toggle.waitForDisplayed({ timeout: 10_000 });
+        expect(await sudoToggleState()).to.equal("false");
+        expect(await toggle.getAttribute("aria-label")).to.equal("Enable sudo mode");
+
+        // Enable sudo: the session reopens over `sudo sftp-server` as root and
+        // the explorer remounts. aria-pressed flips and the listing re-renders.
+        await toggleSudo(true);
+        expect(await sudoToggleState()).to.equal("true");
+        expect(
+            await (await $("[data-testid='explorer-sudo-toggle']")).getAttribute("aria-label"),
+        ).to.equal("Disable sudo mode");
+        await browser.waitUntil(
+            async () => (await $$("[data-entry-row='true']")).length > 0,
+            { timeout: 15_000, timeoutMsg: "no entries rendered after enabling sudo" },
+        );
+
+        // Disable sudo: back to the unprivileged session, symmetrically.
+        await toggleSudo(false);
+        expect(await sudoToggleState()).to.equal("false");
+        expect(
+            await (await $("[data-testid='explorer-sudo-toggle']")).getAttribute("aria-label"),
+        ).to.equal("Enable sudo mode");
+        await browser.waitUntil(
+            async () => (await $$("[data-entry-row='true']")).length > 0,
+            { timeout: 15_000, timeoutMsg: "no entries rendered after disabling sudo" },
+        );
+    });
+
+    it("stays in the current directory after toggling sudo", async () => {
+        await openSftp("sudo-keepdir");
+
+        // Navigate into a fresh subdir so currentPath is a non-home path.
+        const dirName = "e2e-sudo-" + Date.now();
+        await createFolder(dirName);
+        await openEntry(dirName);
+        await browser.waitUntil(
+            async () => (await $(`button*=${dirName}`)).isExisting(),
+            { timeout: 5_000, timeoutMsg: "did not enter the subdir" },
+        );
+
+        // Toggling sudo must reload the SAME directory, not bounce to home/root.
+        await toggleSudo(true);
+        const crumb = await $(`button*=${dirName}`);
+        await crumb.waitForExist({ timeout: 5_000 });
+        expect(await crumb.isExisting()).to.equal(true);
+
+        // Cleanup: go up to the parent and delete the folder (as root).
+        await browser.execute(() => {
+            const buttons = Array.from(
+                document.querySelectorAll<HTMLButtonElement>(
+                    "[aria-label='Current path'] button",
+                ),
+            );
+            buttons.at(-2)?.click();
+        });
+        await deleteEntry(dirName);
+    });
+});

--- a/tests/sudo-server/Dockerfile
+++ b/tests/sudo-server/Dockerfile
@@ -1,0 +1,14 @@
+# Passwordless-sudo test SSH server.
+#
+# Extends the upstream linuxserver/openssh-server image. With SUDO_ACCESS=true
+# the base grants the user `sudo` but still PROMPTS FOR A PASSWORD (it appends
+# `<user> ALL=(ALL) ALL` to /etc/sudoers, after the @includedir line, so a
+# /etc/sudoers.d drop-in can't override it). This init script appends a
+# NOPASSWD rule as the final — and therefore winning — match, so the SFTP
+# sudo-mode toggle (`sudo -n sftp-server`) actually succeeds here.
+#
+# Built implicitly by docker compose for the `sshd-sudo` e2e service.
+FROM lscr.io/linuxserver/openssh-server:latest
+
+COPY enable-nopasswd-sudo.sh /custom-cont-init.d/enable-nopasswd-sudo.sh
+RUN chmod +x /custom-cont-init.d/enable-nopasswd-sudo.sh

--- a/tests/sudo-server/enable-nopasswd-sudo.sh
+++ b/tests/sudo-server/enable-nopasswd-sudo.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Runs from /custom-cont-init.d/ after the linuxserver base has applied
+# SUDO_ACCESS (which appends `<user> ALL=(ALL) ALL` to /etc/sudoers) and
+# before sshd starts. Appends a NOPASSWD rule as the LAST match for the user
+# so `sudo -n` works without a password — sudo evaluates rules last-match-wins.
+set -eu
+
+user="${USER_NAME:-testuser}"
+sudoers=/etc/sudoers
+
+if [ -f "$sudoers" ]; then
+    echo "$user ALL=(ALL) NOPASSWD: ALL" >> "$sudoers"
+    echo "[nopasswd-sudo] passwordless sudo enabled for $user"
+else
+    echo "[nopasswd-sudo] WARNING: $sudoers not found; passwordless sudo not enabled" >&2
+fi


### PR DESCRIPTION
 ## Problem

When connecting to servers (e.g. EC2, Ubuntu) as a non-root user, the SFTP 
browser can only access files owned by that user. Operations on system files 
(e.g. /etc/nginx/, /var/log/) fail with permission denied.

## Proposed Solution

Add a sudo toggle button (shield icon) to the SFTP explorer toolbar, similar 
to MobaXterm's "Use SUDO for SSH-browser" feature.

When clicked:
1. Close the current SFTP session
2. Reopen on the same SSH connection using `exec("sudo sftp-server")` instead 
   of `request_subsystem("sftp")`
3. Reload the current directory

The user stays in the same directory with the same UI — only the privilege 
level changes. Button turns yellow when active.

## Why This Approach

- No server configuration required
- Works on any Linux server where the user has NOPASSWD sudo (e.g. EC2 default)
- Full SFTP protocol is preserved — file listing, permissions, timestamps, 
  symlinks all work correctly (unlike SCP fallback)
- Only 4 files need to be changed, database untouched

## Files Changed

| File | Change |
|---|---|
| `src-tauri/src/sftp/commands.rs` | Add `use_sudo` param to `sftp_open`, switch between `request_subsystem` and `exec` |
| `src/stores/sftp-store.ts` | Add `sudoMode` field to `SftpSession` |
| `src/components/sftp/ExplorerView.tsx` | Add toggle handler, reopen session on switch |
| `src/components/explorer/ExplorerToolbar.tsx` | Add Shield icon button |