### PR TITLE
ci(release): create one draft release for the whole build matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,46 @@ permissions:
   contents: write
 
 jobs:
+  # Create the draft release ONCE so the parallel build matrix all upload to
+  # the same release. GitHub does not de-duplicate *draft* releases by tag, so
+  # previously each matrix job raced to create its own draft → multiple v*
+  # drafts with split assets. Reuse an existing draft if present (e.g. on a
+  # workflow re-run) to stay idempotent.
+  create-release:
+    runs-on: ubuntu-latest
+    outputs:
+      release_id: ${{ steps.create-release.outputs.result }}
+    steps:
+      - name: Create or reuse the draft release
+        id: create-release
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const tag = process.env.GITHUB_REF_NAME;
+            const releases = await github.paginate(github.rest.repos.listReleases, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              per_page: 100,
+            });
+            const existing = releases.find((r) => r.tag_name === tag && r.draft);
+            if (existing) {
+              core.info(`Reusing existing draft release ${existing.id} for ${tag}`);
+              return existing.id;
+            }
+            const { data } = await github.rest.repos.createRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: tag,
+              name: `anySCP ${tag}`,
+              body: "",
+              draft: true,
+              prerelease: false,
+            });
+            core.info(`Created draft release ${data.id} for ${tag}`);
+            return data.id;
+
   build:
+    needs: create-release
     strategy:
       fail-fast: false
       matrix:
@@ -93,11 +132,8 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
         with:
-          tagName: ${{ github.ref_name }}
-          releaseName: "anySCP ${{ github.ref_name }}"
-          releaseBody: ""
-          releaseDraft: true
-          prerelease: false
+          # Upload to the single release created up front (no per-job drafts).
+          releaseId: ${{ needs.create-release.outputs.release_id }}
           args: ${{ matrix.args }}
           updaterJsonKeepUniversal: true
 


### PR DESCRIPTION
## Problem

Every `v*` tag push runs the Release workflow's **4-way build matrix** (macOS-arm64, macOS-x64, Linux, Windows), and each matrix job ran `tauri-action` with `releaseDraft: true` and the same `tagName`. GitHub does **not** de-duplicate *draft* releases by tag, so the parallel jobs race and each create their own draft.

`v0.9.0` came out as **two draft releases** with assets split across them:
- one with **Windows + macOS-x64** (`.exe/.msi/.dmg`)
- one with **Linux + macOS-arm64** (`.deb/.AppImage/.rpm/.dmg`)

Neither draft is a complete release on its own. This recurs on most releases.

## Fix

Add a `create-release` job that creates (or reuses) **one** draft release up front and exposes its `release_id`. The `build` matrix now `needs: create-release` and passes `releaseId: ${{ needs.create-release.outputs.release_id }}` to `tauri-action`, so **all platforms upload to the same release**. Reusing an existing draft for the tag keeps workflow re-runs idempotent.

This is the standard `tauri-action` + matrix pattern. No app code changes.

## Note on v0.9.0

The two duplicate `v0.9.0` drafts and the `v0.9.0` tag have been deleted. After this merges, re-push the `v0.9.0` tag **at `main`'s HEAD (which must include this fix)** to build a single clean release — tag-triggered workflows run the workflow file as it exists at the tagged commit, so the tag must point at a commit that contains this change.
