### PR TITLE
fix: resolve VS Code launch failure on macOS for edit-in-vscode

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,6 +10,7 @@ mod ssh;
 pub mod telemetry;
 mod types;
 mod vault;
+mod vscode;
 
 use db::HostDb;
 use portforward::manager::PortForwardManager;

--- a/src-tauri/src/s3/commands.rs
+++ b/src-tauri/src/s3/commands.rs
@@ -914,8 +914,7 @@ pub async fn s3_edit_in_vscode(
     }
 
     // 2. Open in VS Code (without --wait so it returns immediately).
-    crate::vscode::launch_vscode(&local_path)
-        .map_err(|e| {
+    crate::vscode::launch_vscode(&local_path).map_err(|e| {
             S3Error::IoError(format!(
                 "Failed to open VS Code: {e}. Is 'code' in your PATH?"
             ))

--- a/src-tauri/src/s3/commands.rs
+++ b/src-tauri/src/s3/commands.rs
@@ -914,9 +914,7 @@ pub async fn s3_edit_in_vscode(
     }
 
     // 2. Open in VS Code (without --wait so it returns immediately).
-    tokio::process::Command::new("code")
-        .arg(&local_path)
-        .spawn()
+    crate::vscode::launch_vscode(&local_path)
         .map_err(|e| {
             S3Error::IoError(format!(
                 "Failed to open VS Code: {e}. Is 'code' in your PATH?"

--- a/src-tauri/src/scp/commands.rs
+++ b/src-tauri/src/scp/commands.rs
@@ -443,9 +443,7 @@ pub async fn scp_edit_in_vscode(
     transfer::download_file(handle.clone(), &remote_path, &local_path, &token, |_| {}).await?;
 
     // 2. Open VS Code (non-blocking).
-    tokio::process::Command::new("code")
-        .arg(&local_path)
-        .spawn()
+    crate::vscode::launch_vscode(&local_path)
         .map_err(|e| {
             ScpError::LocalIoError(format!(
                 "Failed to open VS Code: {e}. Is 'code' in your PATH?"

--- a/src-tauri/src/scp/commands.rs
+++ b/src-tauri/src/scp/commands.rs
@@ -443,8 +443,7 @@ pub async fn scp_edit_in_vscode(
     transfer::download_file(handle.clone(), &remote_path, &local_path, &token, |_| {}).await?;
 
     // 2. Open VS Code (non-blocking).
-    crate::vscode::launch_vscode(&local_path)
-        .map_err(|e| {
+    crate::vscode::launch_vscode(&local_path).map_err(|e| {
             ScpError::LocalIoError(format!(
                 "Failed to open VS Code: {e}. Is 'code' in your PATH?"
             ))

--- a/src-tauri/src/sftp/commands.rs
+++ b/src-tauri/src/sftp/commands.rs
@@ -811,8 +811,7 @@ pub async fn sftp_edit_in_vscode(
     }
 
     // 2. Open in VS Code (without --wait so it returns immediately)
-    crate::vscode::launch_vscode(&local_path)
-        .map_err(|e| {
+    crate::vscode::launch_vscode(&local_path).map_err(|e| {
             SftpError::LocalIoError(format!(
                 "Failed to open VS Code: {e}. Is 'code' in your PATH?"
             ))

--- a/src-tauri/src/sftp/commands.rs
+++ b/src-tauri/src/sftp/commands.rs
@@ -811,9 +811,7 @@ pub async fn sftp_edit_in_vscode(
     }
 
     // 2. Open in VS Code (without --wait so it returns immediately)
-    tokio::process::Command::new("code")
-        .arg(&local_path)
-        .spawn()
+    crate::vscode::launch_vscode(&local_path)
         .map_err(|e| {
             SftpError::LocalIoError(format!(
                 "Failed to open VS Code: {e}. Is 'code' in your PATH?"

--- a/src-tauri/src/vscode.rs
+++ b/src-tauri/src/vscode.rs
@@ -1,0 +1,45 @@
+//! Cross-platform VS Code launcher for the edit-in-vscode workflow.
+//!
+//! On macOS, VS Code installed via the .app bundle doesn't automatically
+//! add `code` to PATH. This helper tries multiple discovery strategies.
+
+use std::path::Path;
+
+/// Attempt to launch VS Code with `path` as the file to open.
+///
+/// On macOS, falls back through:
+/// 1. `code` on PATH (if the user ran "Install 'code' command in PATH")
+/// 2. Bundled CLI inside the .app
+/// 3. `open -a "Visual Studio Code"` as a last resort
+///
+/// On other platforms, simply runs `code <path>`.
+pub fn launch_vscode(path: &Path) -> Result<tokio::process::Child, std::io::Error> {
+    #[cfg(target_os = "macos")]
+    {
+        // 1. Standard CLI (works when user ran "Install 'code' command in PATH")
+        match tokio::process::Command::new("code").arg(path).spawn() {
+            Ok(child) => return Ok(child),
+            Err(_) => {}
+        }
+
+        // 2. Full path to the bundled CLI inside the .app
+        let bundled =
+            "/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code";
+        match tokio::process::Command::new(bundled).arg(path).spawn() {
+            Ok(child) => return Ok(child),
+            Err(_) => {}
+        }
+
+        // 3. macOS `open` command — last resort (doesn't support --wait, but we
+        //    don't use --wait anyway)
+        tokio::process::Command::new("open")
+            .args(["-a", "Visual Studio Code"])
+            .arg(path)
+            .spawn()
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        tokio::process::Command::new("code").arg(path).spawn()
+    }
+}

--- a/src-tauri/src/vscode.rs
+++ b/src-tauri/src/vscode.rs
@@ -17,17 +17,14 @@ pub fn launch_vscode(path: &Path) -> Result<tokio::process::Child, std::io::Erro
     #[cfg(target_os = "macos")]
     {
         // 1. Standard CLI (works when user ran "Install 'code' command in PATH")
-        match tokio::process::Command::new("code").arg(path).spawn() {
-            Ok(child) => return Ok(child),
-            Err(_) => {}
+        if let Ok(child) = tokio::process::Command::new("code").arg(path).spawn() {
+            return Ok(child);
         }
 
         // 2. Full path to the bundled CLI inside the .app
-        let bundled =
-            "/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code";
-        match tokio::process::Command::new(bundled).arg(path).spawn() {
-            Ok(child) => return Ok(child),
-            Err(_) => {}
+        let bundled = "/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code";
+        if let Ok(child) = tokio::process::Command::new(bundled).arg(path).spawn() {
+            return Ok(child);
         }
 
         // 3. macOS `open` command — last resort (doesn't support --wait, but we


### PR DESCRIPTION
## Problem

On macOS, right-clicking a file and selecting "Edit in VS Code" does nothing. The `code` CLI is not automatically available when VS Code is installed via the .app bundle (the default installation method on macOS).

## Root Cause

All three `edit_in_vscode` commands (SFTP, SCP, S3) hard-code `tokio::process::Command::new("code")` which fails when `code` is not in PATH. The spawn error is silently swallowed because the function returns immediately after spawning.

## Fix

Created a cross-platform `vscode::launch_vscode()` helper that implements multi-level fallback on macOS:

1. Try `code` on PATH (works if user ran Install Shell Command in VS Code)
2. Try `/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code` (bundled CLI)
3. Try `open -a "Visual Studio Code"` (macOS last resort)

On other platforms, behavior is unchanged (uses `code` directly).

## Changes

- New file: `src-tauri/src/vscode.rs` — cross-platform VS Code launcher helper
- Updated: `src-tauri/src/lib.rs` — register `vscode` module
- Updated: `src-tauri/src/sftp/commands.rs` — use `crate::vscode::launch_vscode()`
- Updated: `src-tauri/src/scp/commands.rs` — use `crate::vscode::launch_vscode()`
- Updated: `src-tauri/src/s3/commands.rs` — use `crate::vscode::launch_vscode()`

Closes #12