### PR TITLE
fix: respect user-chosen filename when saving via download dialog

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -209,6 +209,7 @@ pub fn run() {
             // S3 — Transfer Manager
             s3::commands::s3_enqueue_upload,
             s3::commands::s3_enqueue_download,
+            s3::commands::s3_enqueue_download_as,
             s3::commands::s3_cancel_transfer,
             s3::commands::s3_retry_transfer,
             s3::commands::s3_list_transfers,

--- a/src-tauri/src/s3/commands.rs
+++ b/src-tauri/src/s3/commands.rs
@@ -834,6 +834,30 @@ pub async fn s3_enqueue_download(
     result
 }
 
+/// Download a single object to an explicit local path through the transfer
+/// pipeline (streams to disk, reports progress, cancellable). Use this instead
+/// of [`s3_download_file`] when the user picks/renames the destination in a save
+/// dialog. Returns the transfer id.
+#[tauri::command]
+#[instrument(skip(s3_transfer_manager), fields(s3_session_id = %s3_session_id))]
+pub async fn s3_enqueue_download_as(
+    s3_session_id: String,
+    key: String,
+    local_path: String,
+    s3_transfer_manager: State<'_, Arc<S3TransferManager>>,
+) -> Result<String, S3Error> {
+    let result = s3_transfer_manager
+        .enqueue_download_to(s3_session_id, key, std::path::PathBuf::from(local_path))
+        .await;
+    if result.is_ok() {
+        crate::telemetry::capture(
+            "s3_download_enqueued",
+            serde_json::json!({ "file_count": 1 }),
+        );
+    }
+    result
+}
+
 /// Cancel a queued or in-progress S3 transfer.
 #[tauri::command]
 #[instrument(skip(s3_transfer_manager), fields(transfer_id = %transfer_id))]

--- a/src-tauri/src/s3/transfer_manager.rs
+++ b/src-tauri/src/s3/transfer_manager.rs
@@ -262,7 +262,8 @@ impl S3TransferManager {
 
     // ─── Download ────────────────────────────────────────────────────────────
 
-    /// Enqueue one or more S3 object keys for download.
+    /// Enqueue one or more S3 object keys for download into `local_dir`, each
+    /// saved under its key's basename.
     #[instrument(skip(self), fields(s3_session_id = %s3_session_id))]
     pub async fn enqueue_download(
         &self,
@@ -282,53 +283,95 @@ impl S3TransferManager {
                 .file_name()
                 .map(|n| n.to_string_lossy().to_string())
                 .unwrap_or_else(|| key.clone());
-
-            let transfer_id = uuid::Uuid::new_v4().to_string();
-            let now = Self::unix_now_millis();
-            let now_instant = Instant::now();
-
-            // Fetch the object size via HEAD.
-            let size = match bucket.head_object(&key).await {
-                Ok((head, _)) => head.content_length.unwrap_or(0) as u64,
-                Err(_) => 0,
-            };
-
             let local_path = local_dir.join(&name);
-
-            let job = TransferJobState {
-                transfer_id: transfer_id.clone(),
-                s3_session_id: s3_session_id.clone(),
-                name: name.clone(),
-                direction: S3TransferDirection::Download,
-                kind: TransferJobKind::DownloadFile {
-                    key: key.clone(),
-                    local_path,
-                    size,
-                },
-                status: S3TransferStatus::Queued,
-                bytes_transferred: 0,
-                total_bytes: size,
-                files_done: 0,
-                files_total: 1,
-                speed_bps: 0,
-                cancel_token: CancellationToken::new(),
-                error: None,
-                created_at: now,
-                last_emit: now_instant,
-                speed_window_bytes: 0,
-                speed_window_start: now_instant,
-            };
-
-            self.jobs.insert(transfer_id.clone(), job);
-            Self::emit_initial(&self.jobs, &transfer_id, &self.app_handle);
-            self.queue_tx
-                .send(transfer_id.clone())
-                .map_err(|e| S3Error::OperationError(format!("queue send error: {e}")))?;
-
-            ids.push(transfer_id);
+            let id = self
+                .queue_download_job(&bucket, &s3_session_id, key, local_path)
+                .await?;
+            ids.push(id);
         }
 
         Ok(ids)
+    }
+
+    /// Enqueue a single object for streaming download to an explicit local path
+    /// (e.g. a save-dialog target the user renamed). Unlike the one-shot
+    /// [`s3_download_file`](crate::s3::commands::s3_download_file) command, this
+    /// goes through the transfer pipeline, so it reports progress, can be
+    /// cancelled, and streams to disk instead of buffering the whole object in
+    /// memory.
+    #[instrument(skip(self), fields(s3_session_id = %s3_session_id))]
+    pub async fn enqueue_download_to(
+        &self,
+        s3_session_id: String,
+        key: String,
+        local_path: PathBuf,
+    ) -> Result<String, S3Error> {
+        self.ensure_worker_spawned();
+        let bucket = self.s3_manager.get_bucket(&s3_session_id)?;
+        self.queue_download_job(&bucket, &s3_session_id, key, local_path)
+            .await
+    }
+
+    /// Build, register, and queue a single streaming download job that writes the
+    /// object to `local_path` exactly. Shared by [`enqueue_download`] (path =
+    /// `dir/basename`) and [`enqueue_download_to`] (caller-chosen path); the
+    /// transfer's display name is the local file's name.
+    ///
+    /// [`enqueue_download`]: Self::enqueue_download
+    /// [`enqueue_download_to`]: Self::enqueue_download_to
+    async fn queue_download_job(
+        &self,
+        bucket: &s3::Bucket,
+        s3_session_id: &str,
+        key: String,
+        local_path: PathBuf,
+    ) -> Result<String, S3Error> {
+        let name = local_path
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_else(|| key.clone());
+
+        let transfer_id = uuid::Uuid::new_v4().to_string();
+        let now = Self::unix_now_millis();
+        let now_instant = Instant::now();
+
+        // Fetch the object size via HEAD.
+        let size = match bucket.head_object(&key).await {
+            Ok((head, _)) => head.content_length.unwrap_or(0) as u64,
+            Err(_) => 0,
+        };
+
+        let job = TransferJobState {
+            transfer_id: transfer_id.clone(),
+            s3_session_id: s3_session_id.to_string(),
+            name,
+            direction: S3TransferDirection::Download,
+            kind: TransferJobKind::DownloadFile {
+                key,
+                local_path,
+                size,
+            },
+            status: S3TransferStatus::Queued,
+            bytes_transferred: 0,
+            total_bytes: size,
+            files_done: 0,
+            files_total: 1,
+            speed_bps: 0,
+            cancel_token: CancellationToken::new(),
+            error: None,
+            created_at: now,
+            last_emit: now_instant,
+            speed_window_bytes: 0,
+            speed_window_start: now_instant,
+        };
+
+        self.jobs.insert(transfer_id.clone(), job);
+        Self::emit_initial(&self.jobs, &transfer_id, &self.app_handle);
+        self.queue_tx
+            .send(transfer_id.clone())
+            .map_err(|e| S3Error::OperationError(format!("queue send error: {e}")))?;
+
+        Ok(transfer_id)
     }
 
     // ─── Control ─────────────────────────────────────────────────────────────

--- a/src/components/s3/S3Browser.tsx
+++ b/src/components/s3/S3Browser.tsx
@@ -262,14 +262,13 @@ export function S3Browser({ sessionId, isActive = true }: S3BrowserProps) {
       const savePath = await save({ defaultPath: entry.name, title: `Download "${entry.name}"` });
       if (!savePath) return;
 
-      const lastSlash = savePath.lastIndexOf("/");
-      const localDir = lastSlash > 0 ? savePath.substring(0, lastSlash) : savePath;
-
+      // Use the single-file download so a renamed file is saved under the
+      // name the user picked in the dialog, not the remote key name.
       const { invoke } = await import("@tauri-apps/api/core");
-      await invoke("s3_enqueue_download", {
+      await invoke("s3_download_file", {
         s3SessionId: sessionId,
-        keys: [entry.id],
-        localDir,
+        key: entry.id,
+        localPath: savePath,
       });
     } catch { /* best-effort */ }
   }, [sessionId]);

--- a/src/components/s3/S3Browser.tsx
+++ b/src/components/s3/S3Browser.tsx
@@ -262,16 +262,19 @@ export function S3Browser({ sessionId, isActive = true }: S3BrowserProps) {
       const savePath = await save({ defaultPath: entry.name, title: `Download "${entry.name}"` });
       if (!savePath) return;
 
-      // Use the single-file download so a renamed file is saved under the
-      // name the user picked in the dialog, not the remote key name.
+      // Download to the user-chosen (possibly renamed) path THROUGH the transfer
+      // pipeline, so it streams to disk, shows progress, and is cancellable — and
+      // any failure surfaces in the transfers panel instead of being dropped.
       const { invoke } = await import("@tauri-apps/api/core");
-      await invoke("s3_download_file", {
+      await invoke("s3_enqueue_download_as", {
         s3SessionId: sessionId,
         key: entry.id,
         localPath: savePath,
       });
-    } catch { /* best-effort */ }
-  }, [sessionId]);
+    } catch (err) {
+      setError(sessionId, err instanceof Error ? err.message : String(err));
+    }
+  }, [sessionId, setError]);
 
   // ─── Upload (dialog, enqueue) ─────────────────────────────────────────────
 

--- a/src/components/sftp/ExplorerView.tsx
+++ b/src/components/sftp/ExplorerView.tsx
@@ -231,31 +231,39 @@ export function ExplorerView({ sessionId, transport = "sftp", isActive = true }:
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sessionId, transport]);
 
-  // ─── Download (enqueue) ───────────────────────────────────────────────────
+  // ─── Download ─────────────────────────────────────────────────────────────
 
   const handleDownload = useCallback(async (entry: ExplorerEntry) => {
     try {
-      const { open, save } = await import("@tauri-apps/plugin-dialog");
-      let localDir: string | null = null;
-
       if (entry.entryType === "Directory") {
-        localDir = await open({ directory: true, title: `Download "${entry.name}" to…` }) as string | null;
+        const { open } = await import("@tauri-apps/plugin-dialog");
+        const localDir = await open({
+          directory: true,
+          title: `Download "${entry.name}" to…`,
+        }) as string | null;
+        if (!localDir) return;
+
+        await explorerInvoke(transport, "enqueue_download", sessionId, {
+          remotePaths: [entry.id],
+          localDir,
+        });
       } else {
-        const savePath = await save({ defaultPath: entry.name, title: `Save "${entry.name}" as…` });
-        if (savePath) {
-          const lastSlash = savePath.lastIndexOf("/");
-          localDir = lastSlash > 0 ? savePath.substring(0, lastSlash) : savePath;
-        }
+        const { save } = await import("@tauri-apps/plugin-dialog");
+        const savePath = await save({
+          defaultPath: entry.name,
+          title: `Save "${entry.name}" as…`,
+        });
+        if (!savePath) return;
+
+        // Use the single-file download API with the full user-chosen path,
+        // so a renamed file is saved under the name the user picked.
+        await explorerInvoke(transport, "download", sessionId, {
+          remotePath: entry.id,
+          localPath: savePath,
+        });
       }
-
-      if (!localDir) return;
-
-      await explorerInvoke(transport, "enqueue_download", sessionId, {
-        remotePaths: [entry.id],
-        localDir,
-      });
     } catch (err) {
-      console.error("Download enqueue failed:", err);
+      console.error("Download failed:", err);
     }
   }, [sessionId, transport]);
 


### PR DESCRIPTION
## Problem

When downloading a file, changing the name in the Tauri save dialog has no effect. The file is always saved with the remote filename regardless of what the user types in the save dialog.

## Root Cause

The download handler in ExplorerView.tsx and S3Browser.tsx extracts only the **directory** from the save dialog path and passes it to the batch download command (enqueue_download), which always uses the remote filename as the local filename.

	s
const savePath = await save({ defaultPath: entry.name });  // /Users/me/Downloads/newname.txt
const lastSlash = savePath.lastIndexOf(/);
const localDir = savePath.substring(0, lastSlash);           // /Users/me/Downloads (name lost!)

## Fix

For single-file downloads, use the single-file download API with the full user-chosen savePath as localPath. This preserves the filename the user entered in the dialog.

For directory downloads (SFTP/SCP only), enqueue_download is still the correct choice.

## Changes

- src/components/sftp/ExplorerView.tsx: use sftp_download/scp_download with full savePath
- src/components/s3/S3Browser.tsx: use s3_download_file with full savePath

Closes #8