### PR TITLE
Feature/ssh tunnel proxyjump implemented 

### DIFF
--- a/src-tauri/src/db/commands.rs
+++ b/src-tauri/src/db/commands.rs
@@ -11,9 +11,43 @@ use super::{ConnectionHistoryEntry, DbError, HostDb, HostGroup, RecentConnection
 #[instrument(skip(state), fields(id = %host.id))]
 pub async fn save_host(host: SavedHost, state: State<'_, Arc<HostDb>>) -> Result<(), DbError> {
     let db = Arc::clone(&state);
-    task::spawn_blocking(move || db.save_host(&host))
-        .await
-        .map_err(|e| DbError::InitError(format!("task panicked: {e}")))?
+    task::spawn_blocking(move || {
+        validate_no_proxy_jump_cycle(&db, &host)?;
+        db.save_host(&host)
+    })
+    .await
+    .map_err(|e| DbError::InitError(format!("task panicked: {e}")))?
+}
+
+/// Reject ProxyJump configurations that would form a cycle (e.g. A → B → A) or
+/// a self-reference (A → A). Walks the existing jump chain starting at the
+/// host's proposed `proxy_jump_host_id`; if it ever points back at the host
+/// being saved, the configuration is circular.
+fn validate_no_proxy_jump_cycle(db: &HostDb, host: &SavedHost) -> Result<(), DbError> {
+    let Some(first) = host.proxy_jump_host_id.as_deref().filter(|s| !s.is_empty()) else {
+        return Ok(());
+    };
+    if first == host.id {
+        return Err(DbError::Validation(
+            "A host cannot tunnel through itself".to_string(),
+        ));
+    }
+
+    let mut current = Some(first.to_string());
+    // Bound the walk to avoid runaway loops on pre-existing corrupt chains.
+    for _ in 0..64 {
+        let Some(cid) = current else { return Ok(()) };
+        if cid == host.id {
+            return Err(DbError::Validation(
+                "Circular tunnel configuration detected".to_string(),
+            ));
+        }
+        current = db
+            .get_host(&cid)?
+            .and_then(|h| h.proxy_jump_host_id)
+            .filter(|s| !s.is_empty());
+    }
+    Ok(())
 }
 
 /// Return all saved hosts, ordered by label.

--- a/src-tauri/src/db/commands.rs
+++ b/src-tauri/src/db/commands.rs
@@ -7,47 +7,16 @@ use tracing::instrument;
 use super::{ConnectionHistoryEntry, DbError, HostDb, HostGroup, RecentConnection, SavedHost};
 
 /// Persist (insert or update) a host entry.
+///
+/// ProxyJump cycles, self-references, and dangling tunnel-host targets are
+/// rejected atomically with the write inside [`HostDb::save_host_validated`].
 #[tauri::command]
 #[instrument(skip(state), fields(id = %host.id))]
 pub async fn save_host(host: SavedHost, state: State<'_, Arc<HostDb>>) -> Result<(), DbError> {
     let db = Arc::clone(&state);
-    task::spawn_blocking(move || {
-        validate_no_proxy_jump_cycle(&db, &host)?;
-        db.save_host(&host)
-    })
-    .await
-    .map_err(|e| DbError::InitError(format!("task panicked: {e}")))?
-}
-
-/// Reject ProxyJump configurations that would form a cycle (e.g. A → B → A) or
-/// a self-reference (A → A). Walks the existing jump chain starting at the
-/// host's proposed `proxy_jump_host_id`; if it ever points back at the host
-/// being saved, the configuration is circular.
-fn validate_no_proxy_jump_cycle(db: &HostDb, host: &SavedHost) -> Result<(), DbError> {
-    let Some(first) = host.proxy_jump_host_id.as_deref().filter(|s| !s.is_empty()) else {
-        return Ok(());
-    };
-    if first == host.id {
-        return Err(DbError::Validation(
-            "A host cannot tunnel through itself".to_string(),
-        ));
-    }
-
-    let mut current = Some(first.to_string());
-    // Bound the walk to avoid runaway loops on pre-existing corrupt chains.
-    for _ in 0..64 {
-        let Some(cid) = current else { return Ok(()) };
-        if cid == host.id {
-            return Err(DbError::Validation(
-                "Circular tunnel configuration detected".to_string(),
-            ));
-        }
-        current = db
-            .get_host(&cid)?
-            .and_then(|h| h.proxy_jump_host_id)
-            .filter(|s| !s.is_empty());
-    }
-    Ok(())
+    task::spawn_blocking(move || db.save_host_validated(&host))
+        .await
+        .map_err(|e| DbError::InitError(format!("task panicked: {e}")))?
 }
 
 /// Return all saved hosts, ordered by label.

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -488,12 +488,100 @@ impl HostDb {
 
     /// Upsert a host record.  If a row with the same `id` already exists it
     /// is fully replaced; `created_at` is preserved by the caller-supplied value.
+    ///
+    /// This is the raw write with no ProxyJump validation — use
+    /// [`save_host_validated`](Self::save_host_validated) for the user-facing save
+    /// path that must reject cycles. This variant is retained for callers that
+    /// either don't set `proxy_jump_host_id` (e.g. the first pass of an import) or
+    /// validate separately.
     #[instrument(skip(self), fields(id = %host.id))]
     pub fn save_host(&self, host: &SavedHost) -> Result<(), DbError> {
         let conn = self
             .conn
             .lock()
             .map_err(|e| DbError::InitError(format!("db lock poisoned: {e}")))?;
+        Self::upsert_host(&conn, host)?;
+        Ok(())
+    }
+
+    /// Upsert a host, atomically rejecting ProxyJump configurations that would
+    /// form a cycle (`A → B → A`), a self-reference (`A → A`), or point at a
+    /// non-existent tunnel host. The chain walk and the write share a single
+    /// `IMMEDIATE` transaction so a concurrent writer cannot slip a cycle in
+    /// between the check and the write (closing the TOCTOU window).
+    #[instrument(skip(self), fields(id = %host.id))]
+    pub fn save_host_validated(&self, host: &SavedHost) -> Result<(), DbError> {
+        let mut conn = self
+            .conn
+            .lock()
+            .map_err(|e| DbError::InitError(format!("db lock poisoned: {e}")))?;
+        let tx = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
+        Self::check_proxy_jump_chain(&tx, &host.id, host.proxy_jump_host_id.as_deref())?;
+        Self::upsert_host(&tx, host)?;
+        tx.commit()?;
+        Ok(())
+    }
+
+    /// Walk the ProxyJump chain starting at `proxy` (the proposed
+    /// `proxy_jump_host_id` for `host_id`) and reject self-references, cycles, and
+    /// dangling immediate targets. Operates on a single connection/transaction so
+    /// it can be composed atomically with a write. The walk is bounded so a
+    /// pre-existing corrupt chain can never loop forever.
+    fn check_proxy_jump_chain(
+        conn: &Connection,
+        host_id: &str,
+        proxy: Option<&str>,
+    ) -> Result<(), DbError> {
+        let Some(first) = proxy.filter(|s| !s.is_empty()) else {
+            return Ok(());
+        };
+        if first == host_id {
+            return Err(DbError::Validation(
+                "A host cannot tunnel through itself".to_string(),
+            ));
+        }
+
+        // The immediate target must exist — otherwise the FK would reject the
+        // write with an opaque error. Surface a friendly message instead.
+        let exists: bool = conn
+            .query_row(
+                "SELECT 1 FROM saved_hosts WHERE id = ?1",
+                params![first],
+                |_| Ok(()),
+            )
+            .optional()?
+            .is_some();
+        if !exists {
+            return Err(DbError::Validation(
+                "The selected tunnel host no longer exists".to_string(),
+            ));
+        }
+
+        let mut current = Some(first.to_string());
+        // Bound the walk to avoid runaway loops on pre-existing corrupt chains.
+        for _ in 0..64 {
+            let Some(cid) = current else { return Ok(()) };
+            if cid == host_id {
+                return Err(DbError::Validation(
+                    "Circular tunnel configuration detected".to_string(),
+                ));
+            }
+            current = conn
+                .query_row(
+                    "SELECT proxy_jump_host_id FROM saved_hosts WHERE id = ?1",
+                    params![cid],
+                    |row| row.get::<_, Option<String>>(0),
+                )
+                .optional()?
+                .flatten()
+                .filter(|s| !s.is_empty());
+        }
+        Ok(())
+    }
+
+    /// Shared upsert used by both the raw and validated save paths. Takes a bare
+    /// connection so it can run inside a transaction.
+    fn upsert_host(conn: &Connection, host: &SavedHost) -> Result<(), DbError> {
         conn.execute(
             "INSERT INTO saved_hosts (
                  id, label, host, port, username, auth_type, group_id, created_at, updated_at,
@@ -668,25 +756,28 @@ impl HostDb {
         }
     }
 
-    /// Set (or clear) the ProxyJump target host id for a saved host.
-    /// Returns `DbError::NotFound` if the host id does not exist.
+    /// Link `id` to tunnel through `jump_id`, atomically rejecting links that
+    /// would form a cycle or self-reference (the same guard the UI save path
+    /// enforces). Used by the SSH-config import so a config with mutually
+    /// referencing `ProxyJump` directives cannot persist a connect-breaking cycle.
+    /// Returns `DbError::Validation` on a cycle/self-reference and
+    /// `DbError::NotFound` if `id` does not exist.
     #[instrument(skip(self), fields(id = %id))]
-    pub fn set_proxy_jump_host(
-        &self,
-        id: &str,
-        proxy_jump_host_id: Option<&str>,
-    ) -> Result<(), DbError> {
-        let conn = self
+    pub fn set_proxy_jump_host_validated(&self, id: &str, jump_id: &str) -> Result<(), DbError> {
+        let mut conn = self
             .conn
             .lock()
             .map_err(|e| DbError::InitError(format!("db lock poisoned: {e}")))?;
-        let affected = conn.execute(
+        let tx = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
+        Self::check_proxy_jump_chain(&tx, id, Some(jump_id))?;
+        let affected = tx.execute(
             "UPDATE saved_hosts SET proxy_jump_host_id = ?2, updated_at = datetime('now') WHERE id = ?1",
-            params![id, proxy_jump_host_id],
+            params![id, jump_id],
         )?;
         if affected == 0 {
             return Err(DbError::NotFound(id.to_string()));
         }
+        tx.commit()?;
         Ok(())
     }
 
@@ -1575,17 +1666,22 @@ mod tests {
         assert_eq!(fetched.label, "Renamed");
     }
 
+    /// Helper: build a host that tunnels through `jump_id`.
+    fn host_with_jump(id: &str, jump_id: &str) -> SavedHost {
+        SavedHost {
+            proxy_jump_host_id: Some(jump_id.to_string()),
+            ..sample_host(id)
+        }
+    }
+
     #[test]
     fn proxy_jump_host_id_round_trips() {
         let (db, _dir) = test_db();
 
         // Jump host first, then the target that tunnels through it.
         db.save_host(&sample_host("jump-1")).expect("save jump");
-        let target = SavedHost {
-            proxy_jump_host_id: Some("jump-1".to_string()),
-            ..sample_host("target-1")
-        };
-        db.save_host(&target).expect("save target");
+        db.save_host_validated(&host_with_jump("target-1", "jump-1"))
+            .expect("save target");
 
         let fetched = db.get_host("target-1").expect("get").expect("Some");
         assert_eq!(fetched.proxy_jump_host_id.as_deref(), Some("jump-1"));
@@ -1595,10 +1691,114 @@ mod tests {
         let t = listed.iter().find(|h| h.id == "target-1").expect("present");
         assert_eq!(t.proxy_jump_host_id.as_deref(), Some("jump-1"));
 
-        // Clearing it via the dedicated setter works.
-        db.set_proxy_jump_host("target-1", None).expect("clear");
+        // Re-point the target at a different jump host: exercises the UPSERT
+        // `DO UPDATE SET proxy_jump_host_id` branch the UI save path uses.
+        db.save_host(&sample_host("jump-2")).expect("save jump-2");
+        db.save_host_validated(&host_with_jump("target-1", "jump-2"))
+            .expect("re-point");
+        let repointed = db.get_host("target-1").expect("get").expect("Some");
+        assert_eq!(repointed.proxy_jump_host_id.as_deref(), Some("jump-2"));
+
+        // Clearing it via the real upsert path (proxy_jump_host_id: None) works.
+        db.save_host_validated(&sample_host("target-1"))
+            .expect("clear");
         let cleared = db.get_host("target-1").expect("get").expect("Some");
         assert!(cleared.proxy_jump_host_id.is_none());
+    }
+
+    #[test]
+    fn save_rejects_self_referential_proxy_jump() {
+        let (db, _dir) = test_db();
+        db.save_host(&sample_host("a")).expect("save a");
+        let err = db
+            .save_host_validated(&host_with_jump("a", "a"))
+            .expect_err("self-reference must be rejected");
+        assert!(matches!(err, DbError::Validation(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn save_rejects_two_hop_cycle() {
+        let (db, _dir) = test_db();
+        // a (no jump), b → a.
+        db.save_host(&sample_host("a")).expect("save a");
+        db.save_host_validated(&host_with_jump("b", "a"))
+            .expect("save b→a");
+        // Now a → b would close the loop a → b → a.
+        let err = db
+            .save_host_validated(&host_with_jump("a", "b"))
+            .expect_err("cycle must be rejected");
+        assert!(matches!(err, DbError::Validation(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn save_accepts_valid_linear_chain() {
+        let (db, _dir) = test_db();
+        db.save_host(&sample_host("a")).expect("save a");
+        db.save_host_validated(&host_with_jump("b", "a"))
+            .expect("b→a");
+        db.save_host_validated(&host_with_jump("c", "b"))
+            .expect("c→b (linear chain a←b←c is valid)");
+        let c = db.get_host("c").expect("get").expect("Some");
+        assert_eq!(c.proxy_jump_host_id.as_deref(), Some("b"));
+    }
+
+    #[test]
+    fn save_rejects_dangling_jump_target() {
+        let (db, _dir) = test_db();
+        // No host "ghost" exists; the FK would reject this, but we want a friendly
+        // Validation error rather than a raw sqlite constraint failure.
+        let err = db
+            .save_host_validated(&host_with_jump("a", "ghost"))
+            .expect_err("dangling target must be rejected");
+        assert!(matches!(err, DbError::Validation(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn deleting_jump_host_nulls_dependent() {
+        let (db, _dir) = test_db();
+        db.save_host(&sample_host("jump")).expect("save jump");
+        db.save_host_validated(&host_with_jump("target", "jump"))
+            .expect("save target→jump");
+
+        // ON DELETE SET NULL (with foreign_keys=ON) must clear the dependent link.
+        db.delete_host("jump").expect("delete jump");
+        let target = db.get_host("target").expect("get").expect("Some");
+        assert!(
+            target.proxy_jump_host_id.is_none(),
+            "deleting the jump host should NULL the dependent proxy_jump_host_id",
+        );
+    }
+
+    #[test]
+    fn validated_setter_rejects_cycle() {
+        let (db, _dir) = test_db();
+        db.save_host(&sample_host("a")).expect("save a");
+        db.save_host(&sample_host("b")).expect("save b");
+        db.set_proxy_jump_host_validated("a", "b").expect("a→b");
+        // b → a would form a cycle; the import path must reject it.
+        let err = db
+            .set_proxy_jump_host_validated("b", "a")
+            .expect_err("cycle via setter must be rejected");
+        assert!(matches!(err, DbError::Validation(_)), "got {err:?}");
+        // Self-reference too.
+        let err = db
+            .set_proxy_jump_host_validated("a", "a")
+            .expect_err("self-reference via setter must be rejected");
+        assert!(matches!(err, DbError::Validation(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn migrations_are_idempotent_across_reopen() {
+        let dir = std::env::temp_dir().join(format!("anyscp_test_{}", uuid::Uuid::new_v4()));
+        {
+            let db = HostDb::new(&dir).expect("first open");
+            db.save_host(&sample_host("persisted")).expect("save");
+        }
+        // Re-opening the same directory re-runs migrations against an already
+        // up-to-date schema; it must not error and must preserve data.
+        let db2 = HostDb::new(&dir).expect("second open re-runs migrations cleanly");
+        let h = db2.get_host("persisted").expect("get").expect("Some");
+        assert_eq!(h.id, "persisted");
     }
 
     #[test]

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -21,6 +21,9 @@ pub enum DbError {
 
     #[error("Failed to initialize database: {0}")]
     InitError(String),
+
+    #[error("{0}")]
+    Validation(String),
 }
 
 /// Serialize DbError as `{ kind, message }` so the frontend can pattern-match
@@ -36,6 +39,7 @@ impl Serialize for DbError {
             DbError::Sqlite(_) => "sqlite",
             DbError::NotFound(_) => "not_found",
             DbError::InitError(_) => "init_error",
+            DbError::Validation(_) => "validation",
         };
         state.serialize_field("kind", kind)?;
         state.serialize_field("message", &self.to_string())?;
@@ -105,6 +109,11 @@ pub struct SavedHost {
     pub startup_command: Option<String>,
     /// ProxyJump / bastion host in `user@host:port` form.
     pub proxy_jump: Option<String>,
+    /// Id of another saved host to tunnel through (ProxyJump). When set, the
+    /// connection is established by first opening an SSH session to this jump
+    /// host and tunnelling a `direct-tcpip` channel to the target. Takes
+    /// precedence over the free-text `proxy_jump` field above.
+    pub proxy_jump_host_id: Option<String>,
     /// Seconds between SSH keepalive pings (0 = disabled).
     pub keep_alive_interval: Option<u32>,
     /// Default login shell, e.g. "/bin/zsh".
@@ -452,6 +461,24 @@ impl HostDb {
             );
         }
 
+        if version < 12 {
+            // Idempotent: only add the column if it doesn't already exist.
+            let has_proxy_jump_host_id: bool = conn
+                .prepare("SELECT proxy_jump_host_id FROM saved_hosts LIMIT 0")
+                .is_ok();
+            if !has_proxy_jump_host_id {
+                conn.execute(
+                    "ALTER TABLE saved_hosts ADD COLUMN proxy_jump_host_id TEXT REFERENCES saved_hosts(id) ON DELETE SET NULL",
+                    [],
+                )?;
+            }
+            conn.execute(
+                "INSERT OR REPLACE INTO _meta (key, value) VALUES ('schema_version', '12')",
+                [],
+            )?;
+            tracing::info!("migration 11→12 applied: added saved_hosts.proxy_jump_host_id");
+        }
+
         Ok(())
     }
 
@@ -472,13 +499,13 @@ impl HostDb {
                  id, label, host, port, username, auth_type, group_id, created_at, updated_at,
                  key_path, color, notes, environment, os_type,
                  startup_command, proxy_jump, keep_alive_interval, default_shell,
-                 font_size, last_connected_at, connection_count
+                 font_size, last_connected_at, connection_count, proxy_jump_host_id
              )
              VALUES (
                  ?1,  ?2,  ?3,  ?4,  ?5,  ?6,  ?7,  ?8,  ?9,
                  ?10, ?11, ?12, ?13, ?14,
                  ?15, ?16, ?17, ?18,
-                 ?19, ?20, ?21
+                 ?19, ?20, ?21, ?22
              )
              ON CONFLICT(id) DO UPDATE SET
                  label                = excluded.label,
@@ -499,7 +526,8 @@ impl HostDb {
                  default_shell        = excluded.default_shell,
                  font_size            = excluded.font_size,
                  last_connected_at    = excluded.last_connected_at,
-                 connection_count     = excluded.connection_count",
+                 connection_count     = excluded.connection_count,
+                 proxy_jump_host_id   = excluded.proxy_jump_host_id",
             params![
                 host.id,
                 host.label,
@@ -522,6 +550,7 @@ impl HostDb {
                 host.font_size,
                 host.last_connected_at,
                 host.connection_count,
+                host.proxy_jump_host_id,
             ],
         )?;
         Ok(())
@@ -538,7 +567,7 @@ impl HostDb {
             "SELECT id, label, host, port, username, auth_type, group_id, created_at, updated_at,
                     key_path, color, notes, environment, os_type,
                     startup_command, proxy_jump, keep_alive_interval, default_shell,
-                    font_size, last_connected_at, connection_count
+                    font_size, last_connected_at, connection_count, proxy_jump_host_id
              FROM saved_hosts
              ORDER BY label ASC",
         )?;
@@ -566,6 +595,7 @@ impl HostDb {
                 font_size: row.get(18)?,
                 last_connected_at: row.get(19)?,
                 connection_count: row.get(20)?,
+                proxy_jump_host_id: row.get(21)?,
             })
         })?;
 
@@ -599,7 +629,7 @@ impl HostDb {
             "SELECT id, label, host, port, username, auth_type, group_id, created_at, updated_at,
                     key_path, color, notes, environment, os_type,
                     startup_command, proxy_jump, keep_alive_interval, default_shell,
-                    font_size, last_connected_at, connection_count
+                    font_size, last_connected_at, connection_count, proxy_jump_host_id
              FROM saved_hosts
              WHERE id = ?1",
         )?;
@@ -627,6 +657,7 @@ impl HostDb {
                 font_size: row.get(18)?,
                 last_connected_at: row.get(19)?,
                 connection_count: row.get(20)?,
+                proxy_jump_host_id: row.get(21)?,
             })
         })?;
 
@@ -635,6 +666,28 @@ impl HostDb {
             Some(Err(e)) => Err(DbError::from(e)),
             None => Ok(None),
         }
+    }
+
+    /// Set (or clear) the ProxyJump target host id for a saved host.
+    /// Returns `DbError::NotFound` if the host id does not exist.
+    #[instrument(skip(self), fields(id = %id))]
+    pub fn set_proxy_jump_host(
+        &self,
+        id: &str,
+        proxy_jump_host_id: Option<&str>,
+    ) -> Result<(), DbError> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| DbError::InitError(format!("db lock poisoned: {e}")))?;
+        let affected = conn.execute(
+            "UPDATE saved_hosts SET proxy_jump_host_id = ?2, updated_at = datetime('now') WHERE id = ?1",
+            params![id, proxy_jump_host_id],
+        )?;
+        if affected == 0 {
+            return Err(DbError::NotFound(id.to_string()));
+        }
+        Ok(())
     }
 
     // -----------------------------------------------------------------------
@@ -1470,6 +1523,7 @@ mod tests {
             os_type: None,
             startup_command: None,
             proxy_jump: None,
+            proxy_jump_host_id: None,
             keep_alive_interval: None,
             default_shell: None,
             font_size: None,
@@ -1519,6 +1573,32 @@ mod tests {
 
         let fetched = db.get_host("host-2").expect("get").expect("Some");
         assert_eq!(fetched.label, "Renamed");
+    }
+
+    #[test]
+    fn proxy_jump_host_id_round_trips() {
+        let (db, _dir) = test_db();
+
+        // Jump host first, then the target that tunnels through it.
+        db.save_host(&sample_host("jump-1")).expect("save jump");
+        let target = SavedHost {
+            proxy_jump_host_id: Some("jump-1".to_string()),
+            ..sample_host("target-1")
+        };
+        db.save_host(&target).expect("save target");
+
+        let fetched = db.get_host("target-1").expect("get").expect("Some");
+        assert_eq!(fetched.proxy_jump_host_id.as_deref(), Some("jump-1"));
+
+        // list_hosts must surface the column too.
+        let listed = db.list_hosts().expect("list");
+        let t = listed.iter().find(|h| h.id == "target-1").expect("present");
+        assert_eq!(t.proxy_jump_host_id.as_deref(), Some("jump-1"));
+
+        // Clearing it via the dedicated setter works.
+        db.set_proxy_jump_host("target-1", None).expect("clear");
+        let cleared = db.get_host("target-1").expect("get").expect("Some");
+        assert!(cleared.proxy_jump_host_id.is_none());
     }
 
     #[test]

--- a/src-tauri/src/import/commands.rs
+++ b/src-tauri/src/import/commands.rs
@@ -48,12 +48,18 @@ pub async fn import_save_ssh_hosts(
         let mut skipped = 0u32;
         let mut errors = Vec::new();
 
+        // alias (Host block name) → generated host id, for ProxyJump resolution.
+        let mut alias_to_id: std::collections::HashMap<String, String> =
+            std::collections::HashMap::new();
+        // (host id, raw ProxyJump value) pairs that still need resolving.
+        let mut pending_jumps: Vec<(String, String)> = Vec::new();
+
         for entry in &entries {
             let now = timestamp_now();
             let id = uuid::Uuid::new_v4().to_string();
 
             let host = SavedHost {
-                id,
+                id: id.clone(),
                 label: entry.host_alias.clone(),
                 host: entry.hostname.clone(),
                 port: entry.port as _,
@@ -71,6 +77,7 @@ pub async fn import_save_ssh_hosts(
                 os_type: None,
                 startup_command: None,
                 proxy_jump: entry.proxy_jump.clone(),
+                proxy_jump_host_id: None,
                 keep_alive_interval: entry.keep_alive_interval,
                 default_shell: None,
                 font_size: None,
@@ -81,10 +88,30 @@ pub async fn import_save_ssh_hosts(
             };
 
             match db.save_host(&host) {
-                Ok(()) => imported += 1,
+                Ok(()) => {
+                    imported += 1;
+                    alias_to_id.insert(entry.host_alias.clone(), id.clone());
+                    if let Some(pj) = entry.proxy_jump.as_ref().filter(|s| !s.trim().is_empty()) {
+                        pending_jumps.push((id, pj.clone()));
+                    }
+                }
                 Err(e) => {
                     errors.push(format!("{}: {e}", entry.host_alias));
                     skipped += 1;
+                }
+            }
+        }
+
+        // Second pass: resolve each parsed ProxyJump value against the imported
+        // (and pre-existing) hosts, then link via proxy_jump_host_id. Matching is
+        // best-effort — an unresolved jump simply leaves the free-text
+        // proxy_jump field in place without breaking the import.
+        let existing_hosts = db.list_hosts().unwrap_or_default();
+        for (host_id, jump_value) in pending_jumps {
+            if let Some(jump_id) = resolve_jump_target(&jump_value, &alias_to_id, &existing_hosts) {
+                // Don't let a host point at itself.
+                if jump_id != host_id {
+                    let _ = db.set_proxy_jump_host(&host_id, Some(jump_id.as_str()));
                 }
             }
         }
@@ -108,4 +135,47 @@ pub async fn import_save_ssh_hosts(
 fn timestamp_now() -> String {
     // SQLite-compatible datetime string
     "datetime('now')".to_string()
+}
+
+/// Resolve a raw `ProxyJump` directive value to a saved-host id.
+///
+/// SSH config ProxyJump values come in several shapes: a bare `Host` alias
+/// (`database`), `user@host`, or `user@host:port`. We try, in order:
+///   1. an exact alias match among the just-imported hosts,
+///   2. a label match among all saved hosts,
+///   3. a hostname match (after stripping any `user@` and `:port`).
+/// Returns `None` when nothing matches — the import then leaves the free-text
+/// `proxy_jump` field untouched.
+fn resolve_jump_target(
+    jump_value: &str,
+    alias_to_id: &std::collections::HashMap<String, String>,
+    existing_hosts: &[SavedHost],
+) -> Option<String> {
+    let value = jump_value.trim();
+
+    // 1. Exact alias (Host block name) match among freshly imported hosts.
+    if let Some(id) = alias_to_id.get(value) {
+        return Some(id.clone());
+    }
+
+    // 2. Label match across all saved hosts.
+    if let Some(h) = existing_hosts.iter().find(|h| h.label == value) {
+        return Some(h.id.clone());
+    }
+
+    // 3. Strip `user@` and `:port`, then match on alias or hostname.
+    let without_user = value.rsplit('@').next().unwrap_or(value);
+    let host_part = without_user.split(':').next().unwrap_or(without_user);
+
+    if let Some(id) = alias_to_id.get(host_part) {
+        return Some(id.clone());
+    }
+    if let Some(h) = existing_hosts
+        .iter()
+        .find(|h| h.host == host_part || h.label == host_part)
+    {
+        return Some(h.id.clone());
+    }
+
+    None
 }

--- a/src-tauri/src/import/commands.rs
+++ b/src-tauri/src/import/commands.rs
@@ -141,9 +141,11 @@ fn timestamp_now() -> String {
 ///
 /// SSH config ProxyJump values come in several shapes: a bare `Host` alias
 /// (`database`), `user@host`, or `user@host:port`. We try, in order:
+///
 ///   1. an exact alias match among the just-imported hosts,
 ///   2. a label match among all saved hosts,
 ///   3. a hostname match (after stripping any `user@` and `:port`).
+///
 /// Returns `None` when nothing matches — the import then leaves the free-text
 /// `proxy_jump` field untouched.
 fn resolve_jump_target(

--- a/src-tauri/src/import/commands.rs
+++ b/src-tauri/src/import/commands.rs
@@ -51,8 +51,8 @@ pub async fn import_save_ssh_hosts(
         // alias (Host block name) → generated host id, for ProxyJump resolution.
         let mut alias_to_id: std::collections::HashMap<String, String> =
             std::collections::HashMap::new();
-        // (host id, raw ProxyJump value) pairs that still need resolving.
-        let mut pending_jumps: Vec<(String, String)> = Vec::new();
+        // (host id, alias, raw ProxyJump value) tuples that still need resolving.
+        let mut pending_jumps: Vec<(String, String, String)> = Vec::new();
 
         for entry in &entries {
             let now = timestamp_now();
@@ -92,7 +92,7 @@ pub async fn import_save_ssh_hosts(
                     imported += 1;
                     alias_to_id.insert(entry.host_alias.clone(), id.clone());
                     if let Some(pj) = entry.proxy_jump.as_ref().filter(|s| !s.trim().is_empty()) {
-                        pending_jumps.push((id, pj.clone()));
+                        pending_jumps.push((id, entry.host_alias.clone(), pj.clone()));
                     }
                 }
                 Err(e) => {
@@ -104,15 +104,28 @@ pub async fn import_save_ssh_hosts(
 
         // Second pass: resolve each parsed ProxyJump value against the imported
         // (and pre-existing) hosts, then link via proxy_jump_host_id. Matching is
-        // best-effort — an unresolved jump simply leaves the free-text
-        // proxy_jump field in place without breaking the import.
+        // best-effort — an unresolved jump simply leaves the free-text proxy_jump
+        // field in place without breaking the import. Linking goes through the
+        // *validated* setter so a config with mutually-referencing ProxyJump
+        // directives (A→B, B→A) can never persist a connect-breaking cycle.
         let existing_hosts = db.list_hosts().unwrap_or_default();
-        for (host_id, jump_value) in pending_jumps {
-            if let Some(jump_id) = resolve_jump_target(&jump_value, &alias_to_id, &existing_hosts) {
-                // Don't let a host point at itself.
-                if jump_id != host_id {
-                    let _ = db.set_proxy_jump_host(&host_id, Some(jump_id.as_str()));
-                }
+        for (host_id, alias, jump_value) in pending_jumps {
+            // Multi-hop chains (`jump1,jump2`) are retained as free-text but not
+            // auto-linked: a single proxy_jump_host_id can't express the chain,
+            // and guessing which hop is adjacent to the target risks a wrong link.
+            if jump_value.contains(',') {
+                continue;
+            }
+            let Some(jump_id) = resolve_jump_target(&jump_value, &alias_to_id, &existing_hosts)
+            else {
+                continue;
+            };
+            match db.set_proxy_jump_host_validated(&host_id, &jump_id) {
+                Ok(()) => {}
+                // A self-reference / cycle is an expected best-effort skip; only
+                // surface genuine write failures so they aren't silently lost.
+                Err(DbError::Validation(_)) => {}
+                Err(e) => errors.push(format!("{alias}: tunnel link not created: {e}")),
             }
         }
 
@@ -137,17 +150,20 @@ fn timestamp_now() -> String {
     "datetime('now')".to_string()
 }
 
-/// Resolve a raw `ProxyJump` directive value to a saved-host id.
+/// Resolve a single-hop `ProxyJump` directive value to a saved-host id.
 ///
 /// SSH config ProxyJump values come in several shapes: a bare `Host` alias
-/// (`database`), `user@host`, or `user@host:port`. We try, in order:
+/// (`database`), `user@host`, or `user@host:port`. Resolution order:
 ///
-///   1. an exact alias match among the just-imported hosts,
-///   2. a label match among all saved hosts,
-///   3. a hostname match (after stripping any `user@` and `:port`).
+///   1. an exact alias match among the just-imported hosts (this run) — first on
+///      the raw value, then on the normalised token (with any `user@`/`:port`
+///      stripped). Aliases are unique within a run, so these are unambiguous.
+///   2. a *unique* label/hostname match among all saved hosts, comparing both the
+///      raw value and the normalised token. If more than one distinct host
+///      matches, the value is ambiguous and we return `None` rather than guess.
 ///
-/// Returns `None` when nothing matches — the import then leaves the free-text
-/// `proxy_jump` field untouched.
+/// Returns `None` when nothing matches (or the match is ambiguous) — the import
+/// then leaves the free-text `proxy_jump` field untouched.
 fn resolve_jump_target(
     jump_value: &str,
     alias_to_id: &std::collections::HashMap<String, String>,
@@ -155,29 +171,143 @@ fn resolve_jump_target(
 ) -> Option<String> {
     let value = jump_value.trim();
 
-    // 1. Exact alias (Host block name) match among freshly imported hosts.
-    if let Some(id) = alias_to_id.get(value) {
-        return Some(id.clone());
-    }
-
-    // 2. Label match across all saved hosts.
-    if let Some(h) = existing_hosts.iter().find(|h| h.label == value) {
-        return Some(h.id.clone());
-    }
-
-    // 3. Strip `user@` and `:port`, then match on alias or hostname.
+    // Normalised token: strip `user@` and `:port` (e.g. `admin@bastion:2222` → `bastion`).
     let without_user = value.rsplit('@').next().unwrap_or(value);
     let host_part = without_user.split(':').next().unwrap_or(without_user);
 
-    if let Some(id) = alias_to_id.get(host_part) {
+    // 1. Exact alias match among freshly imported hosts (unique within a run).
+    if let Some(id) = alias_to_id.get(value) {
         return Some(id.clone());
     }
-    if let Some(h) = existing_hosts
-        .iter()
-        .find(|h| h.host == host_part || h.label == host_part)
-    {
-        return Some(h.id.clone());
+    if host_part != value {
+        if let Some(id) = alias_to_id.get(host_part) {
+            return Some(id.clone());
+        }
     }
 
-    None
+    // 2. Unique label/hostname match among all saved hosts. Collect distinct host
+    //    ids so a collision (e.g. two accounts on one bastion sharing a hostname,
+    //    or duplicate labels) is detected and skipped rather than silently
+    //    linking the alphabetically-first host.
+    let mut matched: Option<&str> = None;
+    for h in existing_hosts {
+        let is_match =
+            h.label == value || h.label == host_part || h.host == host_part || h.host == value;
+        if !is_match {
+            continue;
+        }
+        match matched {
+            None => matched = Some(&h.id),
+            Some(existing) if existing == h.id => {}
+            Some(_) => return None, // ambiguous — more than one distinct host matches
+        }
+    }
+
+    matched.map(|id| id.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    /// Minimal SavedHost for resolution tests (only id/label/host are consulted).
+    fn host(id: &str, label: &str, hostname: &str) -> SavedHost {
+        SavedHost {
+            id: id.to_string(),
+            label: label.to_string(),
+            host: hostname.to_string(),
+            port: 22,
+            username: "u".to_string(),
+            auth_type: "password".to_string(),
+            group_id: None,
+            key_path: None,
+            color: None,
+            notes: None,
+            environment: None,
+            os_type: None,
+            startup_command: None,
+            proxy_jump: None,
+            proxy_jump_host_id: None,
+            keep_alive_interval: None,
+            default_shell: None,
+            font_size: None,
+            last_connected_at: None,
+            connection_count: None,
+            created_at: "t".to_string(),
+            updated_at: "t".to_string(),
+        }
+    }
+
+    fn aliases(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(a, id)| (a.to_string(), id.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn resolves_bare_alias_from_this_run() {
+        let a = aliases(&[("bastion", "id-b")]);
+        assert_eq!(
+            resolve_jump_target("bastion", &a, &[]).as_deref(),
+            Some("id-b")
+        );
+    }
+
+    #[test]
+    fn resolves_user_at_host_and_port_via_alias() {
+        let a = aliases(&[("bastion", "id-b")]);
+        assert_eq!(
+            resolve_jump_target("admin@bastion", &a, &[]).as_deref(),
+            Some("id-b")
+        );
+        assert_eq!(
+            resolve_jump_target("admin@bastion:2222", &a, &[]).as_deref(),
+            Some("id-b")
+        );
+    }
+
+    #[test]
+    fn resolves_label_and_hostname_among_existing() {
+        let hosts = vec![host("id-1", "DB Box", "10.0.0.5")];
+        // Label match (raw value).
+        assert_eq!(
+            resolve_jump_target("DB Box", &HashMap::new(), &hosts).as_deref(),
+            Some("id-1")
+        );
+        // Hostname match after stripping user@ and :port.
+        assert_eq!(
+            resolve_jump_target("ops@10.0.0.5:22", &HashMap::new(), &hosts).as_deref(),
+            Some("id-1")
+        );
+    }
+
+    #[test]
+    fn ambiguous_hostname_collision_returns_none() {
+        // Two distinct hosts share a hostname — linking either would be a guess.
+        let hosts = vec![
+            host("id-1", "prod-a", "10.0.0.5"),
+            host("id-2", "prod-b", "10.0.0.5"),
+        ];
+        assert_eq!(
+            resolve_jump_target("10.0.0.5", &HashMap::new(), &hosts),
+            None
+        );
+    }
+
+    #[test]
+    fn this_run_alias_wins_over_existing_label_collision() {
+        let a = aliases(&[("x", "fresh")]);
+        let hosts = vec![host("old", "x", "1.2.3.4")];
+        assert_eq!(
+            resolve_jump_target("x", &a, &hosts).as_deref(),
+            Some("fresh")
+        );
+    }
+
+    #[test]
+    fn unmatched_value_returns_none() {
+        assert_eq!(resolve_jump_target("nope", &HashMap::new(), &[]), None);
+    }
 }

--- a/src-tauri/src/import/mod.rs
+++ b/src-tauri/src/import/mod.rs
@@ -105,11 +105,15 @@ pub fn parse_ssh_config(
             .and_then(|files| files.first())
             .map(|p| resolve_key_path(p, &home));
 
+        // Preserve the FULL ProxyJump directive (OpenSSH allows a comma-separated
+        // multi-hop list `jump1,jump2`). Keeping every hop avoids silently losing
+        // the chain; the importer auto-links only the single-hop case (see
+        // `resolve_jump_target`), so multi-hop values survive here as provenance.
         let proxy_jump = params
             .proxy_jump
             .as_ref()
-            .and_then(|jumps| jumps.first())
-            .map(|j| j.to_string());
+            .filter(|jumps| !jumps.is_empty())
+            .map(|jumps| jumps.join(","));
 
         let keep_alive_interval = params.server_alive_interval.map(|d| d.as_secs() as u32);
 

--- a/src-tauri/src/portforward/commands.rs
+++ b/src-tauri/src/portforward/commands.rs
@@ -207,6 +207,9 @@ pub async fn pf_start_tunnel(
         keep_alive_interval: None,
         default_shell: None,
         startup_command: None,
+        // Port-forwarding connects directly; ProxyJump tunnelling is handled by
+        // the terminal/SFTP connect paths.
+        jump_host: None,
     };
 
     let session_id = ssh_manager.connect_no_pty(config).await?;

--- a/src-tauri/src/ssh/commands.rs
+++ b/src-tauri/src/ssh/commands.rs
@@ -289,60 +289,108 @@ pub async fn connect_saved_host(
     app_handle: AppHandle,
 ) -> Result<SessionId, SshError> {
     // -----------------------------------------------------------------
-    // 1. Load the SavedHost record from SQLite.
+    // Resolve the full HostConfig (credentials + ProxyJump chain) entirely
+    // inside one blocking task — DB and keychain access are synchronous.
     // -----------------------------------------------------------------
     let db_clone = Arc::clone(&db);
     let id_for_db = host_id.clone();
+    let config = tokio::task::spawn_blocking(move || {
+        build_host_config_blocking(&id_for_db, &db_clone, &mut Vec::new())
+    })
+    .await
+    .map_err(|e| SshError::IoError(format!("task panicked: {e}")))??;
 
-    let saved_host = tokio::task::spawn_blocking(move || db_clone.get_host(&id_for_db))
-        .await
-        .map_err(|e| SshError::IoError(format!("task panicked: {e}")))?
+    let auth_type = auth_method_label(&config.auth_method).to_string();
+    let session_id = state.connect(config, app_handle).await?;
+
+    crate::telemetry::capture(
+        "ssh_connected",
+        serde_json::json!({
+            "auth_type": auth_type,
+        }),
+    );
+
+    Ok(session_id)
+}
+
+/// Short label for an AuthMethod variant, used for telemetry only.
+fn auth_method_label(auth: &AuthMethod) -> &'static str {
+    match auth {
+        AuthMethod::Password { .. } => "password",
+        AuthMethod::PrivateKey { .. } => "privateKey",
+        AuthMethod::PrivateKeyData { .. } => "privateKeyData",
+    }
+}
+
+/// Resolve the AuthMethod for a saved host, pulling secrets from the keychain.
+/// An empty password / absent passphrase means the keychain entry is missing;
+/// the SSH handshake then fails with AuthenticationFailed rather than a vault
+/// error.
+fn resolve_auth_method(host_id: &str, auth_type: &str, key_path: Option<String>) -> AuthMethod {
+    match auth_type {
+        "privateKey" => {
+            let path = key_path.unwrap_or_default();
+            let passphrase = match vault::get_credential(host_id) {
+                Ok(vault::StoredCredential::KeyPassphrase { passphrase }) => Some(passphrase),
+                _ => None,
+            };
+            AuthMethod::PrivateKey {
+                key_path: path,
+                passphrase,
+            }
+        }
+        _ => {
+            let password = match vault::get_credential(host_id) {
+                Ok(vault::StoredCredential::Password { password }) => password,
+                _ => String::new(),
+            };
+            AuthMethod::Password { password }
+        }
+    }
+}
+
+/// Recursively build a [`HostConfig`] for a saved host, including its
+/// credentials and its full ProxyJump chain (`jump_host`). Runs entirely
+/// synchronously (DB + keychain only) so it can be called inside a single
+/// `spawn_blocking`. `visited` guards against cyclic ProxyJump references.
+///
+/// A missing jump host surfaces as a clear `"tunnel host ... not found"` error
+/// rather than the generic not-found message used for the top-level host.
+fn build_host_config_blocking(
+    host_id: &str,
+    db: &HostDb,
+    visited: &mut Vec<String>,
+) -> Result<HostConfig, SshError> {
+    if visited.iter().any(|v| v == host_id) {
+        return Err(SshError::ConnectionFailed(
+            "circular ProxyJump configuration detected".to_string(),
+        ));
+    }
+    visited.push(host_id.to_string());
+
+    let saved_host = db
+        .get_host(host_id)
         .map_err(|e| SshError::IoError(e.to_string()))?
         .ok_or_else(|| SshError::SessionNotFound(format!("host not found: {host_id}")))?;
 
-    // -----------------------------------------------------------------
-    // 2. Resolve the AuthMethod, pulling the secret from the keychain.
-    //
-    //    We move the fields we need into the blocking task so that neither
-    //    the SavedHost nor the vault reference cross an await point.
-    // -----------------------------------------------------------------
-    let id_for_vault = host_id.clone();
-    let auth_type = saved_host.auth_type.clone();
-    let key_path = saved_host.key_path.clone();
+    let auth_method = resolve_auth_method(host_id, &saved_host.auth_type, saved_host.key_path);
 
-    let auth_method = tokio::task::spawn_blocking(move || -> AuthMethod {
-        match auth_type.as_str() {
-            "privateKey" => {
-                let path = key_path.unwrap_or_default();
-                // A passphrase is optional — a key without encryption is valid.
-                let passphrase = match vault::get_credential(&id_for_vault) {
-                    Ok(vault::StoredCredential::KeyPassphrase { passphrase }) => Some(passphrase),
-                    _ => None,
-                };
-                AuthMethod::PrivateKey {
-                    key_path: path,
-                    passphrase,
-                }
-            }
-            _ => {
-                // Default: password auth.  An empty password means the
-                // keychain entry is missing; the SSH handshake will fail
-                // with AuthenticationFailed rather than a vault error.
-                let password = match vault::get_credential(&id_for_vault) {
-                    Ok(vault::StoredCredential::Password { password }) => password,
-                    _ => String::new(),
-                };
-                AuthMethod::Password { password }
-            }
+    // Resolve the ProxyJump target (if any) into a nested HostConfig.
+    let jump_host = match saved_host.proxy_jump_host_id.as_deref() {
+        Some(jump_id) if !jump_id.is_empty() => {
+            let jump_cfg =
+                build_host_config_blocking(jump_id, db, visited).map_err(|e| match e {
+                    SshError::SessionNotFound(_) => SshError::ConnectionFailed(format!(
+                        "tunnel host not found in saved hosts (id {jump_id})"
+                    )),
+                    other => other,
+                })?;
+            Some(Box::new(jump_cfg))
         }
-    })
-    .await
-    .map_err(|e| SshError::IoError(format!("task panicked: {e}")))?;
+        _ => None,
+    };
 
-    // -----------------------------------------------------------------
-    // 3. Build HostConfig and open the SSH connection.
-    // -----------------------------------------------------------------
-    let config = HostConfig {
+    Ok(HostConfig {
         host: saved_host.host,
         port: saved_host.port,
         username: saved_host.username,
@@ -355,18 +403,8 @@ pub async fn connect_saved_host(
         keep_alive_interval: saved_host.keep_alive_interval,
         default_shell: saved_host.default_shell,
         startup_command: saved_host.startup_command,
-    };
-
-    let session_id = state.connect(config, app_handle).await?;
-
-    crate::telemetry::capture(
-        "ssh_connected",
-        serde_json::json!({
-            "auth_type": saved_host.auth_type,
-        }),
-    );
-
-    Ok(session_id)
+        jump_host,
+    })
 }
 
 /// Connect to a saved host without opening a PTY.
@@ -380,56 +418,11 @@ pub async fn connect_saved_host_no_pty(
 ) -> Result<SessionId, SshError> {
     let db_clone = Arc::clone(&db);
     let id_for_db = host_id.clone();
-
-    let saved_host = tokio::task::spawn_blocking(move || db_clone.get_host(&id_for_db))
-        .await
-        .map_err(|e| SshError::IoError(format!("task panicked: {e}")))?
-        .map_err(|e| SshError::IoError(e.to_string()))?
-        .ok_or_else(|| SshError::SessionNotFound(format!("host not found: {host_id}")))?;
-
-    let id_for_vault = host_id.clone();
-    let auth_type = saved_host.auth_type.clone();
-    let key_path = saved_host.key_path.clone();
-
-    let auth_method = tokio::task::spawn_blocking(move || -> AuthMethod {
-        match auth_type.as_str() {
-            "privateKey" => {
-                let path = key_path.unwrap_or_default();
-                let passphrase = match vault::get_credential(&id_for_vault) {
-                    Ok(vault::StoredCredential::KeyPassphrase { passphrase }) => Some(passphrase),
-                    _ => None,
-                };
-                AuthMethod::PrivateKey {
-                    key_path: path,
-                    passphrase,
-                }
-            }
-            _ => {
-                let password = match vault::get_credential(&id_for_vault) {
-                    Ok(vault::StoredCredential::Password { password }) => password,
-                    _ => String::new(),
-                };
-                AuthMethod::Password { password }
-            }
-        }
+    let config = tokio::task::spawn_blocking(move || {
+        build_host_config_blocking(&id_for_db, &db_clone, &mut Vec::new())
     })
     .await
-    .map_err(|e| SshError::IoError(format!("task panicked: {e}")))?;
-
-    let config = HostConfig {
-        host: saved_host.host,
-        port: saved_host.port,
-        username: saved_host.username,
-        auth_method,
-        label: if saved_host.label.is_empty() {
-            None
-        } else {
-            Some(saved_host.label)
-        },
-        keep_alive_interval: None,
-        default_shell: None,
-        startup_command: None,
-    };
+    .map_err(|e| SshError::IoError(format!("task panicked: {e}")))??;
 
     state.connect_no_pty(config).await
 }

--- a/src-tauri/src/ssh/commands.rs
+++ b/src-tauri/src/ssh/commands.rs
@@ -193,65 +193,57 @@ async fn probe_direct(host: &str, port: u16) -> HostHealthCheckResult {
 }
 
 /// Probe a host that is only reachable through a ProxyJump/bastion host. Mirrors
-/// the real connection path in `SshManager::establish`: reach + authenticate the
-/// jump host, open a `direct-tcpip` channel to the target, then run an
-/// (unauthenticated) SSH handshake on the target over that tunnel.
+/// the real connection path by reusing [`SshManager::establish`] to bring up the
+/// *entire* jump chain (so a multi-hop `a → b → target` is traversed in full,
+/// not just the first hop), then opens a `direct-tcpip` channel to the target and
+/// runs an (unauthenticated) SSH handshake on it over that tunnel.
+///
+/// Authenticating the jump chain is unavoidable — a bastion cannot open a tunnel
+/// without a login — so unlike the direct probe this performs a real auth against
+/// every jump hop using stored credentials. Each phase is bounded by a timeout so
+/// a stalled auth on any hop cannot hang the probe (the jump-chain bring-up gets a
+/// larger budget because it may legitimately span several sequential handshakes).
 ///
 /// Failure stages are attributed so the result is actionable: problems reaching
-/// or authenticating the jump host say so explicitly, while a refused tunnel to
-/// the target maps to `PortClosed`.
+/// or authenticating a jump hop are prefixed `tunnel host …`, while a refused
+/// tunnel to the target maps to `PortClosed`.
 async fn probe_via_jump(target: &HostConfig, jump: &HostConfig) -> HostHealthCheckResult {
     let started = Instant::now();
     let elapsed_ms = || started.elapsed().as_millis() as u64;
+    // Throwaway config: no keepalive/inactivity timeout needed for a one-shot probe.
     let russh_config = Arc::new(client::Config::default());
 
-    // ── 1. DNS + TCP to the jump host ────────────────────────────────────
-    let jump_stream = match resolve_and_connect_tcp(&jump.host, jump.port, started).await {
-        Ok(stream) => stream,
-        // Re-label so it's clear the *tunnel host* is the unreachable hop.
-        Err(mut result) => {
-            result.message = format!("tunnel host {}: {}", jump.host, result.message);
-            return result;
-        }
-    };
-
-    // ── 2. SSH handshake + authentication to the jump host ───────────────
-    let mut jump_handle = match timeout(
-        HEALTH_CHECK_TIMEOUT,
-        client::connect_stream(
-            russh_config.clone(),
-            jump_stream,
-            super::handler::SshClientHandler,
-        ),
+    // ── 1. Bring up the full jump chain (connect + auth every hop) ─────────
+    // Bounded so a tarpit/stalled auth on any hop can't hang the probe. The
+    // budget is a small multiple of HEALTH_CHECK_TIMEOUT to accommodate the
+    // sequential handshakes a multi-hop chain requires.
+    let jump_bringup_budget = HEALTH_CHECK_TIMEOUT.saturating_mul(3);
+    let (jump_handle, _chain) = match timeout(
+        jump_bringup_budget,
+        SshManager::establish(jump, russh_config.clone()),
     )
     .await
     {
-        Ok(Ok(handle)) => handle,
+        Ok(Ok(established)) => established,
+        // establish() already prefixes nested hops with "tunnel host …"; add the
+        // immediate hop's identity and surface the underlying reason.
         Ok(Err(e)) => {
             return HostHealthCheckResult {
                 status: HostHealthStatus::SshFailed,
-                message: format!("tunnel host {} SSH handshake failed: {e}", jump.host),
+                message: format!("tunnel host {}: {e}", jump.host),
                 latency_ms: Some(elapsed_ms()),
             };
         }
         Err(_) => {
             return HostHealthCheckResult {
                 status: HostHealthStatus::SshFailed,
-                message: format!("tunnel host {} SSH handshake timed out", jump.host),
+                message: format!("tunnel host {} timed out", jump.host),
                 latency_ms: Some(elapsed_ms()),
             };
         }
     };
 
-    if let Err(e) = SshManager::authenticate_handle(&mut jump_handle, jump).await {
-        return HostHealthCheckResult {
-            status: HostHealthStatus::SshFailed,
-            message: format!("tunnel host {} authentication failed: {e}", jump.host),
-            latency_ms: Some(elapsed_ms()),
-        };
-    }
-
-    // ── 3. Open a direct-tcpip channel through the jump host to the target ─
+    // ── 2. Open a direct-tcpip channel through the jump host to the target ─
     let channel = match timeout(
         HEALTH_CHECK_TIMEOUT,
         jump_handle.channel_open_direct_tcpip(
@@ -268,7 +260,7 @@ async fn probe_via_jump(target: &HostConfig, jump: &HostConfig) -> HostHealthChe
             return HostHealthCheckResult {
                 status: HostHealthStatus::PortClosed,
                 message: format!(
-                    "{}:{} is not reachable through the tunnel: {e}",
+                    "{}:{} could not be reached through the tunnel: {e}",
                     target.host, target.port
                 ),
                 latency_ms: Some(elapsed_ms()),
@@ -286,8 +278,8 @@ async fn probe_via_jump(target: &HostConfig, jump: &HostConfig) -> HostHealthChe
         }
     };
 
-    // ── 4. SSH transport handshake on the target (no auth) over the tunnel ─
-    match timeout(
+    // ── 3. SSH transport handshake on the target (no auth) over the tunnel ─
+    let result = match timeout(
         HEALTH_CHECK_TIMEOUT,
         client::connect_stream(
             russh_config,
@@ -317,7 +309,16 @@ async fn probe_via_jump(target: &HostConfig, jump: &HostConfig) -> HostHealthChe
             message: "SSH handshake timed out".to_string(),
             latency_ms: Some(elapsed_ms()),
         },
-    }
+    };
+
+    // Cleanly tear the jump chain down rather than dropping the sockets, so the
+    // bastion logs a graceful disconnect. Holding `_chain` until here keeps the
+    // tunnel alive for the duration of the probe.
+    let _ = jump_handle
+        .disconnect(russh::Disconnect::ByApplication, "", "en")
+        .await;
+    drop(_chain);
+    result
 }
 
 /// Resolve `host:port` and open a TCP connection, returning the connected stream.
@@ -423,6 +424,86 @@ mod tests {
             result.message,
         );
         assert!(result.latency_ms.is_some());
+    }
+
+    /// Build a minimal direct HostConfig for probe tests.
+    fn cfg(host: &str, port: u16) -> HostConfig {
+        HostConfig {
+            host: host.to_string(),
+            port,
+            username: "u".to_string(),
+            auth_method: AuthMethod::Password {
+                password: String::new(),
+            },
+            label: None,
+            keep_alive_interval: None,
+            default_shell: None,
+            startup_command: None,
+            jump_host: None,
+        }
+    }
+
+    /// When the jump host itself is unreachable, the tunnelled probe must blame
+    /// the *tunnel host* explicitly (prefix `tunnel host …`) rather than the
+    /// target, so the user knows which hop failed.
+    #[tokio::test]
+    async fn probe_via_jump_blames_unreachable_tunnel_host() {
+        // A closed ephemeral port stands in for an unreachable bastion.
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind ephemeral port");
+        let jump_port = listener.local_addr().expect("local addr").port();
+        drop(listener);
+
+        let target = cfg("198.51.100.1", 22); // never reached
+        let jump = cfg("127.0.0.1", jump_port);
+
+        let result = probe_via_jump(&target, &jump).await;
+        assert!(
+            matches!(result.status, HostHealthStatus::SshFailed),
+            "expected SshFailed, got {:?} ({})",
+            result.status,
+            result.message,
+        );
+        assert!(
+            result.message.contains("tunnel host"),
+            "message should blame the tunnel host, got: {}",
+            result.message,
+        );
+    }
+
+    /// Multi-hop: a chain `target → mid → deep` must recurse all the way to the
+    /// DEEPEST hop. We make `deep` an unresolvable host; the failure must name
+    /// it, proving `establish` descended through the whole chain rather than
+    /// stopping at the first jump (the bug the recursive rewrite fixed — the old
+    /// code would only ever touch `mid`).
+    #[tokio::test]
+    async fn probe_via_jump_recurses_through_multi_hop_chain() {
+        // deep (unresolvable, reserved .invalid TLD) ← mid ← target.
+        let deep = cfg("anyscp-deep-hop.invalid", 22);
+        let mid = HostConfig {
+            jump_host: Some(Box::new(deep)),
+            ..cfg("anyscp-mid-hop.invalid", 22)
+        };
+        let target = HostConfig {
+            jump_host: Some(Box::new(mid.clone())),
+            ..cfg("anyscp-target.invalid", 22)
+        };
+
+        let result = probe_via_jump(&target, &mid).await;
+        assert!(
+            matches!(result.status, HostHealthStatus::SshFailed),
+            "expected SshFailed, got {:?} ({})",
+            result.status,
+            result.message,
+        );
+        // The deepest hop's identity in the message proves the recursion reached
+        // it; the old single-hop code never would have.
+        assert!(
+            result.message.contains("anyscp-deep-hop.invalid"),
+            "message should name the deepest hop, got: {}",
+            result.message,
+        );
     }
 }
 

--- a/src-tauri/src/ssh/commands.rs
+++ b/src-tauri/src/ssh/commands.rs
@@ -102,11 +102,16 @@ pub async fn inspect_ssh_key(path: String) -> Result<SshKeyInfo, SshError> {
         .map_err(|e| SshError::IoError(format!("task panicked: {e}")))?
 }
 
-/// Check whether a saved host is reachable without opening a terminal or using
-/// stored credentials. Loads the host from the DB and delegates to
-/// [`probe_host_health`]. Authentication is intentionally skipped, so a
-/// `Reachable` result only means the endpoint speaks SSH — not that the host
-/// identity is verified or that the stored credentials would be accepted.
+/// Check whether a saved host is reachable without opening a terminal.
+///
+/// The full [`HostConfig`] is resolved first (including any ProxyJump chain and
+/// the credentials needed to authenticate the jump host), then delegated to
+/// [`probe_host_health`]. For a direct host, target authentication is
+/// intentionally skipped, so a `Reachable` result only means the endpoint speaks
+/// SSH — not that the host identity is verified or that the stored credentials
+/// would be accepted. For a tunnelled host, the jump host *is* authenticated
+/// (there is no other way to open the tunnel), but the target handshake is still
+/// unauthenticated.
 #[tauri::command]
 pub async fn ssh_health_check_saved_host(
     host_id: String,
@@ -114,84 +119,42 @@ pub async fn ssh_health_check_saved_host(
 ) -> Result<HostHealthCheckResult, SshError> {
     let db_clone = Arc::clone(&db);
     let id_for_db = host_id.clone();
-    let saved_host = tokio::task::spawn_blocking(move || db_clone.get_host(&id_for_db))
-        .await
-        .map_err(|e| SshError::IoError(format!("task panicked: {e}")))?
-        .map_err(|e| SshError::IoError(e.to_string()))?
-        .ok_or_else(|| SshError::SessionNotFound(format!("host not found: {host_id}")))?;
+    let config = tokio::task::spawn_blocking(move || {
+        build_host_config_blocking(&id_for_db, &db_clone, &mut Vec::new())
+    })
+    .await
+    .map_err(|e| SshError::IoError(format!("task panicked: {e}")))??;
 
-    Ok(probe_host_health(&saved_host.host, saved_host.port).await)
+    Ok(probe_host_health(&config).await)
 }
 
-/// Probe a host's SSH reachability: DNS resolution → TCP connect → SSH transport
-/// handshake (no authentication). Each stage is bounded by `HEALTH_CHECK_TIMEOUT`;
-/// crucially the TCP stage shares a *single* budget across all resolved addresses
-/// so a host that resolves to many (or black-holed) addresses cannot stall the
-/// probe for `N * HEALTH_CHECK_TIMEOUT`. The connected TCP stream is reused for the
-/// handshake, so a reachable host is connected to only once. Never returns an
-/// error — every failure mode maps to a structured `HostHealthCheckResult`.
-async fn probe_host_health(host: &str, port: u16) -> HostHealthCheckResult {
+/// Probe a saved host's reachability, routing through its ProxyJump host when one
+/// is configured. A direct host is probed straight against `host:port`; a
+/// tunnelled host is reached by connecting + authenticating to the jump host and
+/// opening a `direct-tcpip` channel to the target (mirroring how a real
+/// connection is established). Never returns an error — every failure mode maps
+/// to a structured [`HostHealthCheckResult`].
+async fn probe_host_health(config: &HostConfig) -> HostHealthCheckResult {
+    match &config.jump_host {
+        Some(jump) => probe_via_jump(config, jump).await,
+        None => probe_direct(&config.host, config.port).await,
+    }
+}
+
+/// Probe a host directly: DNS resolution → TCP connect → SSH transport handshake
+/// (no authentication). Each stage is bounded by `HEALTH_CHECK_TIMEOUT`; crucially
+/// the TCP stage shares a *single* budget across all resolved addresses so a host
+/// that resolves to many (or black-holed) addresses cannot stall the probe for
+/// `N * HEALTH_CHECK_TIMEOUT`. The connected TCP stream is reused for the
+/// handshake, so a reachable host is connected to only once.
+async fn probe_direct(host: &str, port: u16) -> HostHealthCheckResult {
     let started = Instant::now();
     let elapsed_ms = || started.elapsed().as_millis() as u64;
-    let addr = format!("{host}:{port}");
 
-    // ── DNS ────────────────────────────────────────────────────────────────
-    let resolved = match timeout(HEALTH_CHECK_TIMEOUT, lookup_host(&addr)).await {
-        Ok(Ok(addrs)) => addrs.collect::<Vec<_>>(),
-        Ok(Err(e)) => {
-            return HostHealthCheckResult {
-                status: HostHealthStatus::DnsFailed,
-                message: format!("DNS lookup failed: {e}"),
-                latency_ms: None,
-            };
-        }
-        Err(_) => {
-            return HostHealthCheckResult {
-                status: HostHealthStatus::DnsFailed,
-                message: "DNS lookup timed out".to_string(),
-                latency_ms: None,
-            };
-        }
-    };
-
-    if resolved.is_empty() {
-        return HostHealthCheckResult {
-            status: HostHealthStatus::DnsFailed,
-            message: "DNS lookup returned no addresses".to_string(),
-            latency_ms: None,
-        };
-    }
-
-    // ── TCP ──────────────────────────────────────────────────────────────
-    // Try each resolved address in turn, but bound the whole loop to a single
-    // HEALTH_CHECK_TIMEOUT budget so address count can't multiply the wait.
-    let tcp_deadline = started + HEALTH_CHECK_TIMEOUT;
-    let mut tcp_error = None;
-    let mut reachable_stream = None;
-    for socket_addr in resolved {
-        let remaining = tcp_deadline.saturating_duration_since(Instant::now());
-        if remaining.is_zero() {
-            tcp_error = Some("TCP connection timed out".to_string());
-            break;
-        }
-        match timeout(remaining, TcpStream::connect(socket_addr)).await {
-            Ok(Ok(stream)) => {
-                reachable_stream = Some(stream);
-                break;
-            }
-            Ok(Err(e)) => tcp_error = Some(e.to_string()),
-            Err(_) => tcp_error = Some("TCP connection timed out".to_string()),
-        }
-    }
-
-    let Some(stream) = reachable_stream else {
-        return HostHealthCheckResult {
-            status: HostHealthStatus::PortClosed,
-            message: tcp_error
-                .map(|e| format!("TCP port is not reachable: {e}"))
-                .unwrap_or_else(|| "TCP port is not reachable".to_string()),
-            latency_ms: Some(elapsed_ms()),
-        };
+    // ── DNS + TCP ────────────────────────────────────────────────────────
+    let stream = match resolve_and_connect_tcp(host, port, started).await {
+        Ok(stream) => stream,
+        Err(result) => return result,
     };
 
     // ── SSH transport handshake (no auth) ────────────────────────────────
@@ -229,6 +192,200 @@ async fn probe_host_health(host: &str, port: u16) -> HostHealthCheckResult {
     }
 }
 
+/// Probe a host that is only reachable through a ProxyJump/bastion host. Mirrors
+/// the real connection path in `SshManager::establish`: reach + authenticate the
+/// jump host, open a `direct-tcpip` channel to the target, then run an
+/// (unauthenticated) SSH handshake on the target over that tunnel.
+///
+/// Failure stages are attributed so the result is actionable: problems reaching
+/// or authenticating the jump host say so explicitly, while a refused tunnel to
+/// the target maps to `PortClosed`.
+async fn probe_via_jump(target: &HostConfig, jump: &HostConfig) -> HostHealthCheckResult {
+    let started = Instant::now();
+    let elapsed_ms = || started.elapsed().as_millis() as u64;
+    let russh_config = Arc::new(client::Config::default());
+
+    // ── 1. DNS + TCP to the jump host ────────────────────────────────────
+    let jump_stream = match resolve_and_connect_tcp(&jump.host, jump.port, started).await {
+        Ok(stream) => stream,
+        // Re-label so it's clear the *tunnel host* is the unreachable hop.
+        Err(mut result) => {
+            result.message = format!("tunnel host {}: {}", jump.host, result.message);
+            return result;
+        }
+    };
+
+    // ── 2. SSH handshake + authentication to the jump host ───────────────
+    let mut jump_handle = match timeout(
+        HEALTH_CHECK_TIMEOUT,
+        client::connect_stream(
+            russh_config.clone(),
+            jump_stream,
+            super::handler::SshClientHandler,
+        ),
+    )
+    .await
+    {
+        Ok(Ok(handle)) => handle,
+        Ok(Err(e)) => {
+            return HostHealthCheckResult {
+                status: HostHealthStatus::SshFailed,
+                message: format!("tunnel host {} SSH handshake failed: {e}", jump.host),
+                latency_ms: Some(elapsed_ms()),
+            };
+        }
+        Err(_) => {
+            return HostHealthCheckResult {
+                status: HostHealthStatus::SshFailed,
+                message: format!("tunnel host {} SSH handshake timed out", jump.host),
+                latency_ms: Some(elapsed_ms()),
+            };
+        }
+    };
+
+    if let Err(e) = SshManager::authenticate_handle(&mut jump_handle, jump).await {
+        return HostHealthCheckResult {
+            status: HostHealthStatus::SshFailed,
+            message: format!("tunnel host {} authentication failed: {e}", jump.host),
+            latency_ms: Some(elapsed_ms()),
+        };
+    }
+
+    // ── 3. Open a direct-tcpip channel through the jump host to the target ─
+    let channel = match timeout(
+        HEALTH_CHECK_TIMEOUT,
+        jump_handle.channel_open_direct_tcpip(
+            target.host.clone(),
+            target.port as u32,
+            "127.0.0.1".to_string(),
+            0,
+        ),
+    )
+    .await
+    {
+        Ok(Ok(channel)) => channel,
+        Ok(Err(e)) => {
+            return HostHealthCheckResult {
+                status: HostHealthStatus::PortClosed,
+                message: format!(
+                    "{}:{} is not reachable through the tunnel: {e}",
+                    target.host, target.port
+                ),
+                latency_ms: Some(elapsed_ms()),
+            };
+        }
+        Err(_) => {
+            return HostHealthCheckResult {
+                status: HostHealthStatus::PortClosed,
+                message: format!(
+                    "opening tunnel to {}:{} timed out",
+                    target.host, target.port
+                ),
+                latency_ms: Some(elapsed_ms()),
+            };
+        }
+    };
+
+    // ── 4. SSH transport handshake on the target (no auth) over the tunnel ─
+    match timeout(
+        HEALTH_CHECK_TIMEOUT,
+        client::connect_stream(
+            russh_config,
+            channel.into_stream(),
+            super::handler::SshClientHandler,
+        ),
+    )
+    .await
+    {
+        Ok(Ok(handle)) => {
+            let _ = handle
+                .disconnect(russh::Disconnect::ByApplication, "", "en")
+                .await;
+            HostHealthCheckResult {
+                status: HostHealthStatus::Reachable,
+                message: "Ping (via tunnel)".to_string(),
+                latency_ms: Some(elapsed_ms()),
+            }
+        }
+        Ok(Err(e)) => HostHealthCheckResult {
+            status: HostHealthStatus::SshFailed,
+            message: format!("SSH handshake failed: {e}"),
+            latency_ms: Some(elapsed_ms()),
+        },
+        Err(_) => HostHealthCheckResult {
+            status: HostHealthStatus::SshFailed,
+            message: "SSH handshake timed out".to_string(),
+            latency_ms: Some(elapsed_ms()),
+        },
+    }
+}
+
+/// Resolve `host:port` and open a TCP connection, returning the connected stream.
+/// On failure returns a ready-made [`HostHealthCheckResult`] (DnsFailed or
+/// PortClosed). The TCP stage shares a single `HEALTH_CHECK_TIMEOUT` budget
+/// (measured from `started`) across all resolved addresses.
+async fn resolve_and_connect_tcp(
+    host: &str,
+    port: u16,
+    started: Instant,
+) -> Result<TcpStream, HostHealthCheckResult> {
+    let elapsed_ms = || started.elapsed().as_millis() as u64;
+    let addr = format!("{host}:{port}");
+
+    // ── DNS ────────────────────────────────────────────────────────────────
+    let resolved = match timeout(HEALTH_CHECK_TIMEOUT, lookup_host(&addr)).await {
+        Ok(Ok(addrs)) => addrs.collect::<Vec<_>>(),
+        Ok(Err(e)) => {
+            return Err(HostHealthCheckResult {
+                status: HostHealthStatus::DnsFailed,
+                message: format!("DNS lookup failed: {e}"),
+                latency_ms: None,
+            });
+        }
+        Err(_) => {
+            return Err(HostHealthCheckResult {
+                status: HostHealthStatus::DnsFailed,
+                message: "DNS lookup timed out".to_string(),
+                latency_ms: None,
+            });
+        }
+    };
+
+    if resolved.is_empty() {
+        return Err(HostHealthCheckResult {
+            status: HostHealthStatus::DnsFailed,
+            message: "DNS lookup returned no addresses".to_string(),
+            latency_ms: None,
+        });
+    }
+
+    // ── TCP ──────────────────────────────────────────────────────────────
+    // Try each resolved address in turn, but bound the whole loop to a single
+    // HEALTH_CHECK_TIMEOUT budget so address count can't multiply the wait.
+    let tcp_deadline = started + HEALTH_CHECK_TIMEOUT;
+    let mut tcp_error = None;
+    for socket_addr in resolved {
+        let remaining = tcp_deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            tcp_error = Some("TCP connection timed out".to_string());
+            break;
+        }
+        match timeout(remaining, TcpStream::connect(socket_addr)).await {
+            Ok(Ok(stream)) => return Ok(stream),
+            Ok(Err(e)) => tcp_error = Some(e.to_string()),
+            Err(_) => tcp_error = Some("TCP connection timed out".to_string()),
+        }
+    }
+
+    Err(HostHealthCheckResult {
+        status: HostHealthStatus::PortClosed,
+        message: tcp_error
+            .map(|e| format!("TCP port is not reachable: {e}"))
+            .unwrap_or_else(|| "TCP port is not reachable".to_string()),
+        latency_ms: Some(elapsed_ms()),
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -238,7 +395,7 @@ mod tests {
     /// so the probe must short-circuit at the DNS stage with no latency reading.
     #[tokio::test]
     async fn probe_reports_dns_failed_for_unresolvable_host() {
-        let result = probe_host_health("anyscp-nonexistent.invalid", 22).await;
+        let result = probe_direct("anyscp-nonexistent.invalid", 22).await;
         assert!(
             matches!(result.status, HostHealthStatus::DnsFailed),
             "expected DnsFailed, got {:?} ({})",
@@ -258,7 +415,7 @@ mod tests {
         let port = listener.local_addr().expect("local addr").port();
         drop(listener);
 
-        let result = probe_host_health("127.0.0.1", port).await;
+        let result = probe_direct("127.0.0.1", port).await;
         assert!(
             matches!(result.status, HostHealthStatus::PortClosed),
             "expected PortClosed, got {:?} ({})",

--- a/src-tauri/src/ssh/manager.rs
+++ b/src-tauri/src/ssh/manager.rs
@@ -10,12 +10,21 @@ use tracing::info;
 use super::handler::SshClientHandler;
 use super::session::SshSession;
 
+/// A bare (PTY-less) SSH connection used by the SFTP layer.
+struct BareConn {
+    /// The authenticated target handle, shared with the SFTP layer.
+    handle: Arc<tokio::sync::Mutex<client::Handle<SshClientHandler>>>,
+    /// When the target is reached through a ProxyJump, the jump-host handle is
+    /// stored here so the tunnel underneath stays open. It is never locked —
+    /// merely keeping it alive prevents russh from tearing down the tunnel.
+    _jump_handle: Option<client::Handle<SshClientHandler>>,
+}
+
 /// Manages all active SSH sessions. Stored as Tauri managed state.
 pub struct SshManager {
     sessions: DashMap<String, SshSession>,
     /// Bare SSH handles for SFTP-only connections (no PTY).
-    bare_handles:
-        DashMap<String, Arc<tokio::sync::Mutex<client::Handle<super::handler::SshClientHandler>>>>,
+    bare_handles: DashMap<String, BareConn>,
 }
 
 impl SshManager {
@@ -53,70 +62,16 @@ impl SshManager {
             ..Default::default()
         });
 
-        let addr = format!("{}:{}", config.host, config.port);
-        let handler = SshClientHandler;
-        let mut handle = client::connect(russh_config, &addr, handler)
-            .await
-            .map_err(|e| SshError::ConnectionFailed(e.to_string()))?;
-
-        let authenticated = match &config.auth_method {
-            AuthMethod::Password { password } => handle
-                .authenticate_password(&config.username, password)
-                .await
-                .map_err(|e| SshError::AuthenticationFailed(e.to_string()))?,
-            AuthMethod::PrivateKey {
-                key_path,
-                passphrase,
-            } => {
-                let key_data = tokio::fs::read_to_string(key_path)
-                    .await
-                    .map_err(|e| SshError::IoError(e.to_string()))?;
-
-                // Auto-convert PPK to OpenSSH if detected
-                let key_data = if super::keys::is_ppk_format(&key_data) {
-                    let kp = key_path.clone();
-                    let pp = passphrase.clone();
-                    tokio::task::spawn_blocking(move || {
-                        super::keys::convert_ppk_to_openssh(&kp, pp.as_deref())
-                    })
-                    .await
-                    .map_err(|e| SshError::IoError(format!("task panicked: {e}")))??
-                } else {
-                    key_data
-                };
-
-                Self::auth_with_key_data(
-                    &mut handle,
-                    &config.username,
-                    &key_data,
-                    passphrase.as_deref(),
-                )
-                .await?
-            }
-            AuthMethod::PrivateKeyData {
-                key_data,
-                passphrase,
-            } => {
-                Self::auth_with_key_data(
-                    &mut handle,
-                    &config.username,
-                    key_data,
-                    passphrase.as_deref(),
-                )
-                .await?
-            }
-        };
-
-        if !authenticated {
-            return Err(SshError::AuthenticationFailed(
-                "server rejected credentials".to_string(),
-            ));
-        }
+        // Establish the connection — directly or tunnelled through a ProxyJump
+        // host. `jump_handle` (when present) must outlive the target session,
+        // so it is handed to the SshSession to keep alive.
+        let (handle, jump_handle) = Self::establish(&config, russh_config).await?;
 
         info!(session_id = %sid, host = %config.host, "SSH authenticated");
 
         let session = SshSession::open_pty(
             handle,
+            jump_handle,
             sid.clone(),
             80,
             24,
@@ -143,12 +98,98 @@ impl SshManager {
             ..Default::default()
         });
 
-        let addr = format!("{}:{}", config.host, config.port);
-        let handler = SshClientHandler;
-        let mut handle = client::connect(russh_config, &addr, handler)
-            .await
-            .map_err(|e| SshError::ConnectionFailed(e.to_string()))?;
+        // Establish the connection — directly or tunnelled through a ProxyJump.
+        let (handle, jump_handle) = Self::establish(&config, russh_config).await?;
 
+        info!(session_id = %sid, host = %config.host, "SSH authenticated (no PTY, for SFTP)");
+
+        self.bare_handles.insert(
+            sid.clone(),
+            BareConn {
+                handle: Arc::new(tokio::sync::Mutex::new(handle)),
+                _jump_handle: jump_handle,
+            },
+        );
+
+        Ok(session_id)
+    }
+
+    /// Establish a connected + authenticated russh handle for `config`.
+    ///
+    /// When `config.jump_host` is set, the connection is tunnelled: an SSH
+    /// session to the jump host is opened first, a `direct-tcpip` channel to the
+    /// target is opened over it, and the target SSH session runs over that
+    /// channel (`ssh -J jump target`). The returned jump handle MUST be kept
+    /// alive for as long as the target session is in use — dropping it tears
+    /// down the tunnel. For direct connections the second element is `None`.
+    async fn establish(
+        config: &HostConfig,
+        russh_config: Arc<client::Config>,
+    ) -> Result<
+        (
+            client::Handle<SshClientHandler>,
+            Option<client::Handle<SshClientHandler>>,
+        ),
+        SshError,
+    > {
+        if let Some(jump) = &config.jump_host {
+            // 1. Connect + authenticate to the jump host.
+            let jump_addr = format!("{}:{}", jump.host, jump.port);
+            let mut jump_handle =
+                client::connect(russh_config.clone(), &jump_addr, SshClientHandler)
+                    .await
+                    .map_err(|e| {
+                        SshError::ConnectionFailed(format!("tunnel host {}: {e}", jump.host))
+                    })?;
+            Self::authenticate_handle(&mut jump_handle, jump)
+                .await
+                .map_err(|e| match e {
+                    SshError::AuthenticationFailed(m) => {
+                        SshError::AuthenticationFailed(format!("tunnel host: {m}"))
+                    }
+                    other => other,
+                })?;
+
+            // 2. Open a direct-tcpip channel through the jump host to the target.
+            let channel = jump_handle
+                .channel_open_direct_tcpip(
+                    config.host.clone(),
+                    config.port as u32,
+                    "127.0.0.1".to_string(),
+                    0,
+                )
+                .await
+                .map_err(|e| {
+                    SshError::ConnectionFailed(format!(
+                        "failed to open tunnel to {}:{}: {e}",
+                        config.host, config.port
+                    ))
+                })?;
+
+            // 3. Run the target SSH session over the tunnelled channel.
+            let mut handle =
+                client::connect_stream(russh_config, channel.into_stream(), SshClientHandler)
+                    .await
+                    .map_err(|e| SshError::ConnectionFailed(e.to_string()))?;
+            Self::authenticate_handle(&mut handle, config).await?;
+
+            Ok((handle, Some(jump_handle)))
+        } else {
+            let addr = format!("{}:{}", config.host, config.port);
+            let mut handle = client::connect(russh_config, &addr, SshClientHandler)
+                .await
+                .map_err(|e| SshError::ConnectionFailed(e.to_string()))?;
+            Self::authenticate_handle(&mut handle, config).await?;
+            Ok((handle, None))
+        }
+    }
+
+    /// Authenticate an already-connected handle using the config's auth method.
+    /// Shared by direct and tunnelled connection paths.
+    async fn authenticate_handle(
+        handle: &mut client::Handle<SshClientHandler>,
+        config: &HostConfig,
+    ) -> Result<(), SshError> {
         let authenticated = match &config.auth_method {
             AuthMethod::Password { password } => handle
                 .authenticate_password(&config.username, password)
@@ -176,7 +217,7 @@ impl SshManager {
                 };
 
                 Self::auth_with_key_data(
-                    &mut handle,
+                    handle,
                     &config.username,
                     &key_data,
                     passphrase.as_deref(),
@@ -187,13 +228,8 @@ impl SshManager {
                 key_data,
                 passphrase,
             } => {
-                Self::auth_with_key_data(
-                    &mut handle,
-                    &config.username,
-                    key_data,
-                    passphrase.as_deref(),
-                )
-                .await?
+                Self::auth_with_key_data(handle, &config.username, key_data, passphrase.as_deref())
+                    .await?
             }
         };
 
@@ -202,13 +238,7 @@ impl SshManager {
                 "server rejected credentials".to_string(),
             ));
         }
-
-        info!(session_id = %sid, host = %config.host, "SSH authenticated (no PTY, for SFTP)");
-
-        self.bare_handles
-            .insert(sid.clone(), Arc::new(tokio::sync::Mutex::new(handle)));
-
-        Ok(session_id)
+        Ok(())
     }
 
     async fn auth_with_key_data(
@@ -241,7 +271,7 @@ impl SshManager {
             return Ok(entry.value().ssh_handle());
         }
         if let Some(entry) = self.bare_handles.get(session_id) {
-            return Ok(entry.value().clone());
+            return Ok(entry.value().handle.clone());
         }
         Err(SshError::SessionNotFound(session_id.to_string()))
     }

--- a/src-tauri/src/ssh/manager.rs
+++ b/src-tauri/src/ssh/manager.rs
@@ -217,13 +217,8 @@ impl SshManager {
                     key_data
                 };
 
-                Self::auth_with_key_data(
-                    handle,
-                    &config.username,
-                    &key_data,
-                    passphrase.as_deref(),
-                )
-                .await?
+                Self::auth_with_key_data(handle, &config.username, &key_data, passphrase.as_deref())
+                    .await?
             }
             AuthMethod::PrivateKeyData {
                 key_data,

--- a/src-tauri/src/ssh/manager.rs
+++ b/src-tauri/src/ssh/manager.rs
@@ -185,8 +185,9 @@ impl SshManager {
     }
 
     /// Authenticate an already-connected handle using the config's auth method.
-    /// Shared by direct and tunnelled connection paths.
-    async fn authenticate_handle(
+    /// Shared by direct and tunnelled connection paths (and the health-check
+    /// probe, which authenticates the jump host before tunnelling to the target).
+    pub(crate) async fn authenticate_handle(
         handle: &mut client::Handle<SshClientHandler>,
         config: &HostConfig,
     ) -> Result<(), SshError> {

--- a/src-tauri/src/ssh/manager.rs
+++ b/src-tauri/src/ssh/manager.rs
@@ -3,6 +3,8 @@ use crate::types::{
 };
 use dashmap::DashMap;
 use russh::client;
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::Arc;
 use tauri::{AppHandle, Emitter};
 use tracing::info;
@@ -10,14 +12,27 @@ use tracing::info;
 use super::handler::SshClientHandler;
 use super::session::SshSession;
 
+/// The target handle plus the chain of jump-host handles that must outlive it
+/// (deepest hop first, empty for a direct connection).
+type EstablishedConn = (
+    client::Handle<SshClientHandler>,
+    Vec<client::Handle<SshClientHandler>>,
+);
+
+/// Boxed, `Send` future for the recursive [`SshManager::establish`]. Boxing is
+/// required because the recursion makes the future type self-referential.
+type EstablishFuture<'a> =
+    Pin<Box<dyn Future<Output = Result<EstablishedConn, SshError>> + Send + 'a>>;
+
 /// A bare (PTY-less) SSH connection used by the SFTP layer.
 struct BareConn {
     /// The authenticated target handle, shared with the SFTP layer.
     handle: Arc<tokio::sync::Mutex<client::Handle<SshClientHandler>>>,
-    /// When the target is reached through a ProxyJump, the jump-host handle is
-    /// stored here so the tunnel underneath stays open. It is never locked —
-    /// merely keeping it alive prevents russh from tearing down the tunnel.
-    _jump_handle: Option<client::Handle<SshClientHandler>>,
+    /// When the target is reached through a ProxyJump chain, the jump-host
+    /// handles (one per hop) are stored here so the tunnel underneath stays
+    /// open. They are never locked — merely keeping them alive prevents russh
+    /// from tearing down the tunnel.
+    _jump_handles: Vec<client::Handle<SshClientHandler>>,
 }
 
 /// Manages all active SSH sessions. Stored as Tauri managed state.
@@ -54,24 +69,32 @@ impl SshManager {
 
         let keepalive_secs = config.keep_alive_interval.unwrap_or(0) as u64;
         let russh_config = Arc::new(client::Config {
-            inactivity_timeout: if keepalive_secs > 0 {
+            // Send SSH keepalive probes rather than arming an inactivity GC timer.
+            // `inactivity_timeout` only tears the session down after a quiet
+            // window (and sends nothing to prevent it), which would also collapse
+            // any ProxyJump tunnel beneath an idle session. `keepalive_interval`
+            // proactively keeps the connection — and the tunnel — alive, while
+            // `keepalive_max` unanswered probes still detect a genuinely dead peer.
+            keepalive_interval: if keepalive_secs > 0 {
                 Some(std::time::Duration::from_secs(keepalive_secs))
             } else {
-                None // No timeout — connection stays alive until explicitly closed
+                None // No keepalive — connection stays alive until explicitly closed
             },
+            keepalive_max: 3,
             ..Default::default()
         });
 
         // Establish the connection — directly or tunnelled through a ProxyJump
-        // host. `jump_handle` (when present) must outlive the target session,
-        // so it is handed to the SshSession to keep alive.
-        let (handle, jump_handle) = Self::establish(&config, russh_config).await?;
+        // chain. The jump handles must outlive the target session, so they are
+        // handed (shared) to the SshSession to keep alive; sharing via Arc lets
+        // split panes on the same connection hold the tunnel open too.
+        let (handle, jump_handles) = Self::establish(&config, russh_config).await?;
 
         info!(session_id = %sid, host = %config.host, "SSH authenticated");
 
         let session = SshSession::open_pty(
             handle,
-            jump_handle,
+            Arc::new(jump_handles),
             sid.clone(),
             80,
             24,
@@ -99,7 +122,7 @@ impl SshManager {
         });
 
         // Establish the connection — directly or tunnelled through a ProxyJump.
-        let (handle, jump_handle) = Self::establish(&config, russh_config).await?;
+        let (handle, jump_handles) = Self::establish(&config, russh_config).await?;
 
         info!(session_id = %sid, host = %config.host, "SSH authenticated (no PTY, for SFTP)");
 
@@ -107,45 +130,54 @@ impl SshManager {
             sid.clone(),
             BareConn {
                 handle: Arc::new(tokio::sync::Mutex::new(handle)),
-                _jump_handle: jump_handle,
+                _jump_handles: jump_handles,
             },
         );
 
         Ok(session_id)
     }
 
-    /// Establish a connected + authenticated russh handle for `config`.
+    /// Establish a connected + authenticated russh handle for `config`, returning
+    /// the target handle plus the chain of jump-host handles that must be kept
+    /// alive beneath it (empty for a direct connection).
     ///
-    /// When `config.jump_host` is set, the connection is tunnelled: an SSH
-    /// session to the jump host is opened first, a `direct-tcpip` channel to the
-    /// target is opened over it, and the target SSH session runs over that
-    /// channel (`ssh -J jump target`). The returned jump handle MUST be kept
-    /// alive for as long as the target session is in use — dropping it tears
-    /// down the tunnel. For direct connections the second element is `None`.
-    async fn establish(
+    /// When `config.jump_host` is set the connection is tunnelled, and because a
+    /// jump host may itself be reached through its own ProxyJump this recurses to
+    /// build the *entire* chain (`ssh -J a,b,c target`): each hop opens a
+    /// `direct-tcpip` channel to the next over the already-authenticated handle
+    /// below it. Every returned jump handle MUST outlive the target session —
+    /// dropping one tears down the tunnel above it. Recursion depth is bounded by
+    /// the cyclic-reference guard in `build_host_config_blocking`, which resolves
+    /// the chain before this runs.
+    ///
+    /// Returns a boxed future because the recursion makes the future type
+    /// self-referential (an `async fn` calling itself cannot size its own future).
+    pub(crate) fn establish(
         config: &HostConfig,
         russh_config: Arc<client::Config>,
-    ) -> Result<
-        (
-            client::Handle<SshClientHandler>,
-            Option<client::Handle<SshClientHandler>>,
-        ),
-        SshError,
-    > {
-        if let Some(jump) = &config.jump_host {
-            // 1. Connect + authenticate to the jump host.
-            let jump_addr = format!("{}:{}", jump.host, jump.port);
-            let mut jump_handle =
-                client::connect(russh_config.clone(), &jump_addr, SshClientHandler)
+    ) -> EstablishFuture<'_> {
+        Box::pin(async move {
+            let Some(jump) = config.jump_host.as_deref() else {
+                // Direct connection — no tunnel.
+                let addr = format!("{}:{}", config.host, config.port);
+                let mut handle = client::connect(russh_config, &addr, SshClientHandler)
                     .await
-                    .map_err(|e| {
-                        SshError::ConnectionFailed(format!("tunnel host {}: {e}", jump.host))
-                    })?;
-            Self::authenticate_handle(&mut jump_handle, jump)
+                    .map_err(|e| SshError::ConnectionFailed(e.to_string()))?;
+                Self::authenticate_handle(&mut handle, config).await?;
+                return Ok((handle, Vec::new()));
+            };
+
+            // 1. Recursively establish the jump connection (it may itself be
+            //    tunnelled through its own ProxyJump). Reaching/auth errors are
+            //    re-labelled so the failing hop is identifiable.
+            let (jump_handle, mut chain) = Self::establish(jump, russh_config.clone())
                 .await
                 .map_err(|e| match e {
+                    SshError::ConnectionFailed(m) => {
+                        SshError::ConnectionFailed(format!("tunnel host {}: {m}", jump.host))
+                    }
                     SshError::AuthenticationFailed(m) => {
-                        SshError::AuthenticationFailed(format!("tunnel host: {m}"))
+                        SshError::AuthenticationFailed(format!("tunnel host {}: {m}", jump.host))
                     }
                     other => other,
                 })?;
@@ -173,15 +205,11 @@ impl SshManager {
                     .map_err(|e| SshError::ConnectionFailed(e.to_string()))?;
             Self::authenticate_handle(&mut handle, config).await?;
 
-            Ok((handle, Some(jump_handle)))
-        } else {
-            let addr = format!("{}:{}", config.host, config.port);
-            let mut handle = client::connect(russh_config, &addr, SshClientHandler)
-                .await
-                .map_err(|e| SshError::ConnectionFailed(e.to_string()))?;
-            Self::authenticate_handle(&mut handle, config).await?;
-            Ok((handle, None))
-        }
+            // Keep this hop's handle and everything beneath it alive under the
+            // target session.
+            chain.push(jump_handle);
+            Ok((handle, chain))
+        })
     }
 
     /// Authenticate an already-connected handle using the config's auth method.
@@ -279,13 +307,20 @@ impl SshManager {
         source_session_id: &str,
         app_handle: AppHandle,
     ) -> Result<SessionId, SshError> {
-        // Get the shared handle and host config from the source session
-        let (handle, host_config) = {
+        // Get the shared handle, host config, and the ProxyJump tunnel chain from
+        // the source session. The jump handles are shared (Arc) so the tunnel
+        // stays open as long as the parent OR any split pane is alive — closing
+        // the parent tab no longer tears the tunnel out from under its children.
+        let (handle, host_config, jump_handles) = {
             let entry = self
                 .sessions
                 .get(source_session_id)
                 .ok_or_else(|| SshError::SessionNotFound(source_session_id.to_string()))?;
-            (entry.value().ssh_handle(), entry.value().host_config())
+            (
+                entry.value().ssh_handle(),
+                entry.value().host_config(),
+                entry.value().jump_handles(),
+            )
         };
 
         let new_id = SessionId::new();
@@ -293,6 +328,7 @@ impl SshManager {
 
         let session = SshSession::open_split_pty(
             handle,
+            jump_handles,
             sid.clone(),
             80,
             24,

--- a/src-tauri/src/ssh/session.rs
+++ b/src-tauri/src/ssh/session.rs
@@ -35,22 +35,24 @@ pub struct SshSession {
     #[allow(dead_code)]
     session_id: String,
     split_config: SplitConfig,
-    /// When this session is reached through a ProxyJump, the jump-host handle is
-    /// held here so the tunnel underneath stays open for the session's lifetime.
-    /// Never accessed — merely keeping it alive prevents russh from tearing down
-    /// the tunnel.
+    /// When this session is reached through a ProxyJump chain, the jump-host
+    /// handles (one per hop) are held here so the tunnel underneath stays open
+    /// for the session's lifetime. Shared via `Arc` so split panes on the same
+    /// connection keep the tunnel alive even after the parent session is closed.
+    /// Never locked/accessed for I/O — merely held to prevent russh from tearing
+    /// the tunnel down. Empty for a direct (non-tunnelled) connection.
     #[allow(dead_code)]
-    jump_handle: Option<Handle<SshClientHandler>>,
+    jump_handles: Arc<Vec<Handle<SshClientHandler>>>,
 }
 
 impl SshSession {
     /// Open a PTY channel on an authenticated connection, start the output
     /// reader loop, and return the session wrapper.
-    // ProxyJump support added `jump_handle`, pushing this one over the 7-arg lint.
+    // ProxyJump support added `jump_handles`, pushing this one over the 7-arg lint.
     #[allow(clippy::too_many_arguments)]
     pub async fn open_pty(
         handle: Handle<SshClientHandler>,
-        jump_handle: Option<Handle<SshClientHandler>>,
+        jump_handles: Arc<Vec<Handle<SshClientHandler>>>,
         session_id: String,
         cols: u32,
         rows: u32,
@@ -171,14 +173,16 @@ impl SshSession {
             reader_task,
             session_id,
             split_config: SplitConfig { default_shell },
-            jump_handle,
+            jump_handles,
         })
     }
 
     /// Open a new PTY channel on the same authenticated connection.
     /// Used for split panes — avoids re-authentication.
+    #[allow(clippy::too_many_arguments)]
     pub async fn open_split_pty(
         handle: Arc<Mutex<Handle<SshClientHandler>>>,
+        jump_handles: Arc<Vec<Handle<SshClientHandler>>>,
         session_id: String,
         cols: u32,
         rows: u32,
@@ -278,9 +282,9 @@ impl SshSession {
             reader_task,
             session_id,
             split_config: SplitConfig { default_shell },
-            // Split panes reuse the parent connection, which already keeps any
-            // ProxyJump tunnel alive — no separate jump handle needed here.
-            jump_handle: None,
+            // Share the parent's ProxyJump tunnel chain so it stays alive for as
+            // long as this split pane lives, independent of the parent session.
+            jump_handles,
         })
     }
 
@@ -288,6 +292,12 @@ impl SshSession {
     /// its own channel on the same authenticated connection.
     pub fn ssh_handle(&self) -> Arc<Mutex<Handle<SshClientHandler>>> {
         self.handle.clone()
+    }
+
+    /// Return the shared ProxyJump tunnel chain so a split pane can keep the same
+    /// tunnel alive for its own lifetime. Empty for a direct connection.
+    pub fn jump_handles(&self) -> Arc<Vec<Handle<SshClientHandler>>> {
+        self.jump_handles.clone()
     }
 
     /// Return the config needed to open additional split channels.

--- a/src-tauri/src/ssh/session.rs
+++ b/src-tauri/src/ssh/session.rs
@@ -35,6 +35,12 @@ pub struct SshSession {
     #[allow(dead_code)]
     session_id: String,
     split_config: SplitConfig,
+    /// When this session is reached through a ProxyJump, the jump-host handle is
+    /// held here so the tunnel underneath stays open for the session's lifetime.
+    /// Never accessed — merely keeping it alive prevents russh from tearing down
+    /// the tunnel.
+    #[allow(dead_code)]
+    jump_handle: Option<Handle<SshClientHandler>>,
 }
 
 impl SshSession {
@@ -42,6 +48,7 @@ impl SshSession {
     /// reader loop, and return the session wrapper.
     pub async fn open_pty(
         handle: Handle<SshClientHandler>,
+        jump_handle: Option<Handle<SshClientHandler>>,
         session_id: String,
         cols: u32,
         rows: u32,
@@ -162,6 +169,7 @@ impl SshSession {
             reader_task,
             session_id,
             split_config: SplitConfig { default_shell },
+            jump_handle,
         })
     }
 
@@ -268,6 +276,9 @@ impl SshSession {
             reader_task,
             session_id,
             split_config: SplitConfig { default_shell },
+            // Split panes reuse the parent connection, which already keeps any
+            // ProxyJump tunnel alive — no separate jump handle needed here.
+            jump_handle: None,
         })
     }
 

--- a/src-tauri/src/ssh/session.rs
+++ b/src-tauri/src/ssh/session.rs
@@ -46,6 +46,8 @@ pub struct SshSession {
 impl SshSession {
     /// Open a PTY channel on an authenticated connection, start the output
     /// reader loop, and return the session wrapper.
+    // ProxyJump support added `jump_handle`, pushing this one over the 7-arg lint.
+    #[allow(clippy::too_many_arguments)]
     pub async fn open_pty(
         handle: Handle<SshClientHandler>,
         jump_handle: Option<Handle<SshClientHandler>>,

--- a/src-tauri/src/types/session.rs
+++ b/src-tauri/src/types/session.rs
@@ -53,6 +53,15 @@ pub struct HostConfig {
     pub default_shell: Option<String>,
     /// Command to execute after the shell is ready.
     pub startup_command: Option<String>,
+    /// Resolved ProxyJump / bastion host to tunnel this connection through.
+    ///
+    /// When present, the connection is established by first opening an SSH
+    /// session to this jump host and then tunnelling a `direct-tcpip` channel
+    /// to the target. Boxed to break the otherwise-infinite recursive type
+    /// size. `#[serde(default)]` keeps direct `ssh_connect` payloads (which omit
+    /// the field) backwards-compatible.
+    #[serde(default)]
+    pub jump_host: Option<Box<HostConfig>>,
 }
 
 /// Lifecycle state of a single SSH session.

--- a/src/components/dashboard/HostCard.tsx
+++ b/src/components/dashboard/HostCard.tsx
@@ -1,9 +1,10 @@
 import { useState } from "react";
-import { Activity, Pencil, TerminalSquare, Copy, Trash2, FolderOpen } from "lucide-react";
+import { Activity, Pencil, TerminalSquare, Copy, Trash2, FolderOpen, Waypoints } from "lucide-react";
 import type { SavedHost } from "../../types";
 import { relativeTime } from "../../utils/time";
 import { ContextMenu } from "../shared/ContextMenu";
 import { useHealthStore, IDLE_HEALTH, type HealthStatus } from "../../stores/health-store";
+import { useHostsStore } from "../../stores/hosts-store";
 
 // Single source of truth for status → colour, shared by the button and the label.
 function statusColor(status: HealthStatus): string {
@@ -75,6 +76,14 @@ export function HostCard({ host, onConnect, onExplore, onEdit, onDelete, onDupli
   // survives the dashboard unmounting when a terminal/other tab becomes active.
   const health = useHealthStore((s) => s.byHostId[host.id] ?? IDLE_HEALTH);
   const checkHealth = useHealthStore((s) => s.checkHealth);
+
+  // Resolve the ProxyJump / tunnel host (if any) for the "via …" badge.
+  const jumpHost = useHostsStore((s) =>
+    host.proxy_jump_host_id
+      ? s.hosts.find((h) => h.id === host.proxy_jump_host_id) ?? null
+      : null,
+  );
+  const jumpLabel = jumpHost ? jumpHost.label || jumpHost.host : null;
 
   // Build subtitle segments
   const subtitleParts: string[] = [`SSH, ${host.username}`];
@@ -305,6 +314,16 @@ export function HostCard({ host, onConnect, onExplore, onEdit, onDelete, onDupli
               </span>
             )}
           </div>
+          {jumpLabel && (
+            <div
+              data-testid={`host-card-${host.id}-tunnel`}
+              className="flex items-center gap-1 mt-0.5 text-[length:var(--text-xs)] text-text-muted truncate"
+              title={`Tunnels through ${jumpLabel}`}
+            >
+              <Waypoints size={11} strokeWidth={2} aria-hidden="true" className="shrink-0" />
+              <span className="truncate">via {jumpLabel}</span>
+            </div>
+          )}
           {/* Always-mounted live region: announces the result to screen
               readers and reserves a line so checking a host doesn't shift the
               card height (and its row neighbours in the stretch grid). */}

--- a/src/components/dashboard/HostEditModal.tsx
+++ b/src/components/dashboard/HostEditModal.tsx
@@ -26,6 +26,7 @@ interface FormState {
   groupId: string;
   keyPath: string;
   proxyJump: string;
+  proxyJumpHostId: string;
   keepAliveInterval: string;
   defaultShell: string;
   startupCommand: string;
@@ -49,6 +50,7 @@ const EMPTY_FORM: FormState = {
   groupId: "",
   keyPath: "",
   proxyJump: "",
+  proxyJumpHostId: "",
   keepAliveInterval: "",
   defaultShell: "",
   startupCommand: "",
@@ -81,6 +83,7 @@ function savedHostToForm(host: SavedHost): FormState {
     groupId: host.group_id ?? "",
     keyPath: host.key_path ?? "",
     proxyJump: host.proxy_jump ?? "",
+    proxyJumpHostId: host.proxy_jump_host_id ?? "",
     keepAliveInterval: host.keep_alive_interval != null ? String(host.keep_alive_interval) : "",
     defaultShell: host.default_shell ?? "",
     startupCommand: host.startup_command ?? "",
@@ -114,9 +117,14 @@ export function HostEditModal() {
 
   const saveHost = useHostsStore((s) => s.saveHost);
   const deleteHost = useHostsStore((s) => s.deleteHost);
+  const hosts = useHostsStore((s) => s.hosts);
+  const loadHosts = useHostsStore((s) => s.loadHosts);
   const groups = useGroupsStore((s) => s.groups);
   const loadGroups = useGroupsStore((s) => s.loadGroups);
   const addSession = useSessionStore((s) => s.addSession);
+
+  // Whether "Connect through SSH tunnel" is enabled for this host.
+  const [tunnelEnabled, setTunnelEnabled] = useState(false);
 
   // Animation gate — separate from editingHostId to allow exit animation
   const [visible, setVisible] = useState(false);
@@ -184,9 +192,11 @@ export function HostEditModal() {
     setForm(EMPTY_FORM);
     setHasSavedCred(false);
     setCredCleared(false);
+    setTunnelEnabled(false);
 
-    // Load groups in parallel
+    // Load groups + hosts (for the tunnel dropdown) in parallel
     loadGroups().catch(() => {/* non-fatal */});
+    loadHosts().catch(() => {/* non-fatal */});
 
     if (isNewHost) {
       // New host — no fetch needed
@@ -207,6 +217,7 @@ export function HostEditModal() {
         setOriginalHost(host);
         setForm(savedHostToForm(host));
         setHasSavedCred(hasCred);
+        setTunnelEnabled(!!host.proxy_jump_host_id);
       } catch (err) {
         setError(extractError(err, "Failed to load host data"));
       } finally {
@@ -214,7 +225,7 @@ export function HostEditModal() {
         requestAnimationFrame(() => setVisible(true));
       }
     })();
-  }, [isOpen, editingHostId, isNewHost, loadGroups]);
+  }, [isOpen, editingHostId, isNewHost, loadGroups, loadHosts]);
 
   // Scroll to top and focus Host field when modal opens
   useEffect(() => {
@@ -265,6 +276,9 @@ export function HostEditModal() {
       const kai = parseInt(form.keepAliveInterval, 10);
       if (isNaN(kai) || kai < 0) return "Keep Alive must be a positive number";
     }
+    if (tunnelEnabled && !form.proxyJumpHostId) {
+      return "Select a tunnel host or disable the SSH tunnel";
+    }
     return null;
   };
 
@@ -288,6 +302,7 @@ export function HostEditModal() {
       os_type: null,
       startup_command: null,
       proxy_jump: null,
+      proxy_jump_host_id: null,
       keep_alive_interval: null,
       default_shell: null,
       font_size: null,
@@ -307,6 +322,8 @@ export function HostEditModal() {
         ? form.keyPath.trim()
         : null,
       proxy_jump: form.proxyJump.trim() || null,
+      proxy_jump_host_id:
+        tunnelEnabled && form.proxyJumpHostId ? form.proxyJumpHostId : null,
       keep_alive_interval: form.keepAliveInterval.trim()
         ? parseInt(form.keepAliveInterval, 10)
         : null,
@@ -735,7 +752,23 @@ export function HostEditModal() {
                 </>
               )}
 
-              {/* TODO: Proxy / Jump Host — hidden until backend support is implemented */}
+              {/* ════════════════ TUNNEL ════════════════ */}
+              <SectionHeader>Tunnel</SectionHeader>
+
+              <TunnelSection
+                enabled={tunnelEnabled}
+                onToggle={(on) => {
+                  setError(null);
+                  setTunnelEnabled(on);
+                  if (!on) setField("proxyJumpHostId", "");
+                }}
+                value={form.proxyJumpHostId}
+                onChange={(v) => setField("proxyJumpHostId", v)}
+                hosts={hosts}
+                currentHostId={originalHost?.id ?? null}
+                disabled={isBusy}
+                labelClass={labelClass}
+              />
 
               {/* Keep Alive + Default Shell row */}
               <div className="flex gap-3">
@@ -1017,6 +1050,97 @@ function GroupSelect({ id, value, onChange, groups, disabled }: GroupSelectProps
         })),
       ]}
     />
+  );
+}
+
+// ─── TunnelSection ────────────────────────────────────────────────────────────
+
+interface TunnelSectionProps {
+  enabled: boolean;
+  onToggle: (on: boolean) => void;
+  value: string;
+  onChange: (val: string) => void;
+  hosts: SavedHost[];
+  /** Id of the host being edited — excluded from the dropdown. Null for new. */
+  currentHostId: string | null;
+  disabled: boolean;
+  labelClass: string;
+}
+
+/**
+ * "Connect through SSH tunnel" toggle plus a dropdown of saved hosts to use as
+ * the ProxyJump / bastion host. The currently-edited host is excluded so a host
+ * can't tunnel through itself.
+ */
+function TunnelSection({
+  enabled,
+  onToggle,
+  value,
+  onChange,
+  hosts,
+  currentHostId,
+  disabled,
+  labelClass,
+}: TunnelSectionProps) {
+  const candidates = hosts.filter((h) => h.id !== currentHostId);
+
+  const options = candidates.map((h) => ({
+    value: h.id,
+    label: h.label
+      ? `${h.label} (${h.host}:${h.port})`
+      : `${h.host}:${h.port}`,
+  }));
+
+  return (
+    <div className="flex flex-col gap-2.5">
+      {/* Checkbox row */}
+      <label className="flex items-center gap-2.5 cursor-pointer select-none">
+        <input
+          type="checkbox"
+          data-testid="host-modal-tunnel-enabled"
+          checked={enabled}
+          disabled={disabled}
+          onChange={(e) => onToggle(e.target.checked)}
+          className="h-4 w-4 rounded border-border bg-bg-base text-accent accent-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50 cursor-pointer"
+        />
+        <span className="text-[length:var(--text-sm)] text-text-primary">
+          Connect through SSH tunnel
+        </span>
+      </label>
+
+      {/* Tunnel host dropdown — only when enabled */}
+      {enabled && (
+        <div>
+          <label htmlFor="hem-tunnel-host" className={labelClass}>
+            Tunnel Host <span className="ml-0.5 text-status-error" aria-hidden="true">*</span>
+          </label>
+          {candidates.length > 0 ? (
+            <CustomSelect
+              id="hem-tunnel-host"
+              data-testid="host-modal-tunnel-host"
+              value={value}
+              onChange={onChange}
+              disabled={disabled}
+              placeholder="Select a host…"
+              options={options}
+            />
+          ) : (
+            <p className="text-[length:var(--text-xs)] text-text-muted px-3 py-2 rounded-lg bg-bg-base border border-border">
+              No other saved hosts available to tunnel through. Create another
+              host first.
+            </p>
+          )}
+        </div>
+      )}
+
+      {/* Divider separating tunnel config from the fields below */}
+      <div className="flex items-center gap-3 my-1">
+        <span className="text-[length:var(--text-xs)] font-semibold uppercase tracking-widest text-text-muted whitespace-nowrap">
+          Advanced
+        </span>
+        <div className="flex-1 h-px bg-border" aria-hidden="true" />
+      </div>
+    </div>
   );
 }
 

--- a/src/components/dashboard/HostEditModal.tsx
+++ b/src/components/dashboard/HostEditModal.tsx
@@ -276,8 +276,16 @@ export function HostEditModal() {
       const kai = parseInt(form.keepAliveInterval, 10);
       if (isNaN(kai) || kai < 0) return "Keep Alive must be a positive number";
     }
-    if (tunnelEnabled && !form.proxyJumpHostId) {
-      return "Select a tunnel host or disable the SSH tunnel";
+    if (tunnelEnabled) {
+      const candidates = hosts.filter((h) => h.id !== originalHost?.id);
+      if (candidates.length === 0) {
+        return "No other saved hosts are available to tunnel through";
+      }
+      // Rejects both an empty selection and a stale one whose host no longer
+      // exists in the dropdown (e.g. it was deleted while the modal was open).
+      if (!candidates.some((h) => h.id === form.proxyJumpHostId)) {
+        return "Select a tunnel host or disable the SSH tunnel";
+      }
     }
     return null;
   };
@@ -1083,6 +1091,10 @@ function TunnelSection({
   labelClass,
 }: TunnelSectionProps) {
   const candidates = hosts.filter((h) => h.id !== currentHostId);
+  const hasCandidates = candidates.length > 0;
+  // A selected value that isn't among the candidates is stale (its host was
+  // deleted, or it's a corrupt self-reference that got excluded).
+  const selectedIsStale = !!value && !candidates.some((h) => h.id === value);
 
   const options = candidates.map((h) => ({
     value: h.id,
@@ -1093,13 +1105,18 @@ function TunnelSection({
 
   return (
     <div className="flex flex-col gap-2.5">
-      {/* Checkbox row */}
-      <label className="flex items-center gap-2.5 cursor-pointer select-none">
+      {/* Checkbox row. Disabled when there's nothing to tunnel through (and not
+          already enabled) so the user can't enter a dead-end required-field state. */}
+      <label
+        className={`flex items-center gap-2.5 select-none ${
+          disabled || (!enabled && !hasCandidates) ? "cursor-not-allowed" : "cursor-pointer"
+        }`}
+      >
         <input
           type="checkbox"
           data-testid="host-modal-tunnel-enabled"
           checked={enabled}
-          disabled={disabled}
+          disabled={disabled || (!enabled && !hasCandidates)}
           onChange={(e) => onToggle(e.target.checked)}
           className="h-4 w-4 rounded border-border bg-bg-base text-accent accent-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50 cursor-pointer"
         />
@@ -1108,22 +1125,37 @@ function TunnelSection({
         </span>
       </label>
 
+      {/* Hint when the toggle is unavailable because no other hosts exist yet. */}
+      {!enabled && !hasCandidates && (
+        <p className="text-[length:var(--text-xs)] text-text-muted">
+          Create another saved host first to tunnel through it.
+        </p>
+      )}
+
       {/* Tunnel host dropdown — only when enabled */}
       {enabled && (
         <div>
           <label htmlFor="hem-tunnel-host" className={labelClass}>
             Tunnel Host <span className="ml-0.5 text-status-error" aria-hidden="true">*</span>
           </label>
-          {candidates.length > 0 ? (
-            <CustomSelect
-              id="hem-tunnel-host"
-              data-testid="host-modal-tunnel-host"
-              value={value}
-              onChange={onChange}
-              disabled={disabled}
-              placeholder="Select a host…"
-              options={options}
-            />
+          {hasCandidates ? (
+            <>
+              <CustomSelect
+                id="hem-tunnel-host"
+                data-testid="host-modal-tunnel-host"
+                value={selectedIsStale ? "" : value}
+                onChange={onChange}
+                disabled={disabled}
+                placeholder="Select a host…"
+                options={options}
+              />
+              {selectedIsStale && (
+                <p className="mt-1 text-[length:var(--text-xs)] text-status-error">
+                  The previously selected tunnel host is no longer available.
+                  Pick another or disable the tunnel.
+                </p>
+              )}
+            </>
           ) : (
             <p className="text-[length:var(--text-xs)] text-text-muted px-3 py-2 rounded-lg bg-bg-base border border-border">
               No other saved hosts available to tunnel through. Create another

--- a/src/types/ssh.ts
+++ b/src/types/ssh.ts
@@ -70,6 +70,8 @@ export interface SavedHost {
   os_type: string | null;              // "linux" | "macos" | "windows" | "freebsd"
   startup_command: string | null;
   proxy_jump: string | null;
+  /** Id of another saved host to tunnel through (ProxyJump). */
+  proxy_jump_host_id: string | null;
   keep_alive_interval: number | null;
   default_shell: string | null;
   font_size: number | null;

--- a/tests/bastion-server/Dockerfile
+++ b/tests/bastion-server/Dockerfile
@@ -1,0 +1,13 @@
+# Bastion (jump host) test SSH server for ProxyJump tunnelling.
+#
+# Extends upstream linuxserver/openssh-server, which ships `AllowTcpForwarding
+# no` in its sshd_config and therefore REJECTS the `direct-tcpip` channels a
+# ProxyJump jump host must open. This init script flips it to `yes` before sshd
+# starts, so the bastion can actually tunnel to the next hop.
+#
+# Built implicitly by docker compose for the `sshd-bastion` and `sshd-bastion2`
+# e2e services.
+FROM lscr.io/linuxserver/openssh-server:latest
+
+COPY enable-tcp-forwarding.sh /custom-cont-init.d/enable-tcp-forwarding.sh
+RUN chmod +x /custom-cont-init.d/enable-tcp-forwarding.sh

--- a/tests/bastion-server/enable-tcp-forwarding.sh
+++ b/tests/bastion-server/enable-tcp-forwarding.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Runs from /custom-cont-init.d/ after the linuxserver base has written its
+# sshd_config (the running sshd reads /config/sshd/sshd_config via `-f`) and
+# before sshd starts. The image ships `AllowTcpForwarding no`, which blocks the
+# direct-tcpip channels a ProxyJump bastion opens to reach the next hop. Flip it
+# to `yes` in whichever config file is present so the tunnel can be established.
+set -eu
+
+for cfg in /config/sshd/sshd_config /etc/ssh/sshd_config; do
+    [ -f "$cfg" ] || continue
+    if grep -qE '^[[:space:]]*AllowTcpForwarding[[:space:]]' "$cfg"; then
+        sed -i -E 's/^[[:space:]]*AllowTcpForwarding[[:space:]].*/AllowTcpForwarding yes/' "$cfg"
+    else
+        printf '\nAllowTcpForwarding yes\n' >> "$cfg"
+    fi
+    echo "[tcp-forwarding] enabled in $cfg"
+done

--- a/tests/e2e/docker-compose.yml
+++ b/tests/e2e/docker-compose.yml
@@ -54,10 +54,13 @@ services:
       keygen:
         condition: service_completed_successfully
     healthcheck:
-      test: ["CMD-SHELL", "ss -ltn | grep -q :2222"]
+      # `ss` (iproute2) may not be in the image; fall back to busybox netstat so
+      # the check reflects "sshd is listening on 2222" regardless of tooling.
+      test: ["CMD-SHELL", "ss -ltn 2>/dev/null | grep -q :2222 || netstat -lnt 2>/dev/null | grep -q :2222"]
       interval: 2s
-      timeout: 2s
-      retries: 30
+      timeout: 3s
+      retries: 40
+      start_period: 5s
 
   # SCP-only target — SFTP subsystem stripped (see tests/scp-server). Exercises
   # the transparent SFTP→SCP fallback: sftp_open fails here, the app retries
@@ -88,6 +91,114 @@ services:
     image: anyscp-test-scp-busybox:latest
     container_name: anyscp-e2e-sshd-scp-busybox
     networks: [e2e]
+
+  # ─── ProxyJump / tunnel pair ────────────────────────────────────────────────
+  # Proves a connection is genuinely tunnelled. `sshd-bastion` bridges the
+  # runner-reachable `e2e` network and an isolated `e2e-internal` network.
+  # `sshd-tunnel-target` lives ONLY on `e2e-internal`, so the runner shares no
+  # network with it and cannot resolve or reach it directly — a working shell on
+  # it can only mean the connection was tunnelled through the bastion. Distinct
+  # hostnames let the test assert which host the shell actually landed on.
+  # NB: the tunnel opens a `direct-tcpip` channel on the bastion, which needs
+  # `AllowTcpForwarding yes`. The stock linuxserver image ships it as `no`, so the
+  # bastions are built from tests/bastion-server (which flips it on). Targets are
+  # endpoints (they don't forward), so they keep the stock image.
+  sshd-bastion:
+    build:
+      context: ../bastion-server
+      dockerfile: Dockerfile
+    image: anyscp-test-bastion:latest
+    container_name: anyscp-e2e-sshd-bastion
+    hostname: anyscp-bastion
+    environment:
+      PUID: "1000"
+      PGID: "1000"
+      TZ: Etc/UTC
+      USER_NAME: testuser
+      USER_PASSWORD: testpass
+      PASSWORD_ACCESS: "true"
+      SUDO_ACCESS: "true"
+    networks: [e2e, e2e-internal]
+
+  sshd-tunnel-target:
+    image: lscr.io/linuxserver/openssh-server:latest
+    container_name: anyscp-e2e-sshd-tunnel-target
+    hostname: anyscp-tunnel-target
+    environment:
+      PUID: "1000"
+      PGID: "1000"
+      TZ: Etc/UTC
+      USER_NAME: testuser
+      USER_PASSWORD: testpass
+      PASSWORD_ACCESS: "true"
+      SUDO_ACCESS: "true"
+    # Intentionally NOT on `e2e` → unreachable from the runner except via the
+    # bastion tunnel. The runner can't TCP-probe it, so readiness is gated by a
+    # healthcheck + `service_healthy` rather than the entrypoint's wait_for.
+    networks: [e2e-internal]
+    healthcheck:
+      # `ss` (iproute2) may not be in the image; fall back to busybox netstat so
+      # the check reflects "sshd is listening on 2222" regardless of tooling.
+      test: ["CMD-SHELL", "ss -ltn 2>/dev/null | grep -q :2222 || netstat -lnt 2>/dev/null | grep -q :2222"]
+      interval: 2s
+      timeout: 3s
+      retries: 40
+      start_period: 5s
+
+  # ─── Multi-hop (chained bastion) pair ───────────────────────────────────────
+  # Proves a connection traverses MORE THAN ONE jump. A second bastion bridges
+  # `e2e-internal` (shared with bastion1) and a third network `e2e-internal2`;
+  # `sshd-deep-target` lives only on `e2e-internal2`. So the only path is
+  #   runner → sshd-bastion (e2e) → sshd-bastion2 (e2e-internal) → sshd-deep-target (e2e-internal2).
+  # Neither bastion2 nor the deep target is on `e2e`, so the runner can't reach
+  # either directly — this would FAIL on the old single-hop code, which tried to
+  # connect to the immediate jump (bastion2) directly.
+  sshd-bastion2:
+    build:
+      context: ../bastion-server
+      dockerfile: Dockerfile
+    image: anyscp-test-bastion:latest
+    container_name: anyscp-e2e-sshd-bastion2
+    hostname: anyscp-bastion2
+    environment:
+      PUID: "1000"
+      PGID: "1000"
+      TZ: Etc/UTC
+      USER_NAME: testuser
+      USER_PASSWORD: testpass
+      PASSWORD_ACCESS: "true"
+      SUDO_ACCESS: "true"
+    networks: [e2e-internal, e2e-internal2]
+    healthcheck:
+      # `ss` (iproute2) may not be in the image; fall back to busybox netstat so
+      # the check reflects "sshd is listening on 2222" regardless of tooling.
+      test: ["CMD-SHELL", "ss -ltn 2>/dev/null | grep -q :2222 || netstat -lnt 2>/dev/null | grep -q :2222"]
+      interval: 2s
+      timeout: 3s
+      retries: 40
+      start_period: 5s
+
+  sshd-deep-target:
+    image: lscr.io/linuxserver/openssh-server:latest
+    container_name: anyscp-e2e-sshd-deep-target
+    hostname: anyscp-deep-target
+    environment:
+      PUID: "1000"
+      PGID: "1000"
+      TZ: Etc/UTC
+      USER_NAME: testuser
+      USER_PASSWORD: testpass
+      PASSWORD_ACCESS: "true"
+      SUDO_ACCESS: "true"
+    networks: [e2e-internal2]
+    healthcheck:
+      # `ss` (iproute2) may not be in the image; fall back to busybox netstat so
+      # the check reflects "sshd is listening on 2222" regardless of tooling.
+      test: ["CMD-SHELL", "ss -ltn 2>/dev/null | grep -q :2222 || netstat -lnt 2>/dev/null | grep -q :2222"]
+      interval: 2s
+      timeout: 3s
+      retries: 40
+      start_period: 5s
 
   # ─── S3-compatible storage (MinIO) ──────────────────────────────────────────
   minio:
@@ -161,6 +272,14 @@ services:
         condition: service_started
       sshd-scp-busybox:
         condition: service_started
+      sshd-bastion:
+        condition: service_started
+      sshd-tunnel-target:
+        condition: service_healthy
+      sshd-bastion2:
+        condition: service_healthy
+      sshd-deep-target:
+        condition: service_healthy
       minio-seed:
         condition: service_completed_successfully
     environment:
@@ -174,6 +293,16 @@ services:
       SSHD_SCP_PORT: "2222"
       SSHD_SCP_BUSYBOX_HOST: sshd-scp-busybox
       SSHD_SCP_BUSYBOX_PORT: "2222"
+      # ProxyJump pair: bastion is runner-reachable; the tunnel target is not.
+      SSHD_BASTION_HOST: sshd-bastion
+      SSHD_BASTION_PORT: "2222"
+      SSHD_TUNNEL_TARGET_HOST: sshd-tunnel-target
+      SSHD_TUNNEL_TARGET_PORT: "2222"
+      # Multi-hop chain: target behind bastion2 behind bastion1.
+      SSHD_BASTION2_HOST: sshd-bastion2
+      SSHD_BASTION2_PORT: "2222"
+      SSHD_DEEP_TARGET_HOST: sshd-deep-target
+      SSHD_DEEP_TARGET_PORT: "2222"
       SSH_USER: testuser
       SSH_PASS: testpass
       SSH_KEY_PATH: /keys/id_ed25519
@@ -214,6 +343,17 @@ services:
 
 networks:
   e2e:
+  # Isolated tier for the ProxyJump target. Isolation comes from the runner NOT
+  # being attached (Docker doesn't route between separate bridge networks, and
+  # its embedded DNS only resolves names within shared networks) — NOT from
+  # `internal: true`. We deliberately avoid `internal: true` because it blocks
+  # the linuxserver image's first-boot init (which needs internet), leaving sshd
+  # unhealthy. The target still can't be reached from the runner.
+  e2e-internal:
+  # Second tier for the multi-hop chain. Only bastion2 and the deep target sit
+  # here, so reaching the deep target requires hopping bastion1 → bastion2
+  # (neither bastion1 nor the runner is attached).
+  e2e-internal2:
 
 volumes:
   cargo-cache:

--- a/tests/e2e/entrypoint.sh
+++ b/tests/e2e/entrypoint.sh
@@ -32,6 +32,10 @@ wait_for "${SSHD_SUDO_HOST:-sshd-sudo}" "${SSHD_SUDO_PORT:-2222}" sshd-sudo
 wait_for "${SSHD_KEY_HOST:-sshd-key}"   "${SSHD_KEY_PORT:-2222}"   sshd-key
 wait_for "${SSHD_SCP_HOST:-sshd-scp}"   "${SSHD_SCP_PORT:-2222}"   sshd-scp
 wait_for "${SSHD_SCP_BUSYBOX_HOST:-sshd-scp-busybox}" "${SSHD_SCP_BUSYBOX_PORT:-2222}" sshd-scp-busybox
+wait_for "${SSHD_BASTION_HOST:-sshd-bastion}" "${SSHD_BASTION_PORT:-2222}" sshd-bastion
+# NB: sshd-tunnel-target is intentionally unreachable from the runner (isolated
+# network) — its readiness is gated by `service_healthy` in docker-compose, so
+# there is deliberately no wait_for here (a TCP probe would always time out).
 
 # ── 2. Install JS deps ────────────────────────────────────────────────────────
 echo "[entrypoint] installing app deps"

--- a/tests/e2e/helpers/host.ts
+++ b/tests/e2e/helpers/host.ts
@@ -122,6 +122,26 @@ export async function clickSave(): Promise<void> {
     await btn.click();
 }
 
+/** Toggle the "Connect through SSH tunnel" checkbox to the desired state. */
+export async function setTunnelEnabled(on: boolean): Promise<void> {
+    const cb = await $("[data-testid='host-modal-tunnel-enabled']");
+    await cb.waitForExist({ timeout: 5_000 });
+    if ((await cb.isSelected()) !== on) {
+        await cb.click();
+    }
+}
+
+/** Pick a tunnel host by its id from the tunnel CustomSelect. Modal must be open
+ *  and the tunnel toggle enabled. */
+export async function selectTunnelHost(hostId: string): Promise<void> {
+    const trigger = await $("[data-testid='host-modal-tunnel-host']");
+    await trigger.waitForClickable({ timeout: 5_000 });
+    await trigger.click();
+    const opt = await $(`[data-testid='host-modal-tunnel-host-option-${hostId}']`);
+    await opt.waitForDisplayed({ timeout: 5_000 });
+    await opt.click();
+}
+
 export async function clickConnect(): Promise<void> {
     const btn = await $("[data-testid='host-modal-connect']");
     await btn.waitForClickable({ timeout: 5_000 });

--- a/tests/e2e/specs/56-host-proxyjump-tunnel.spec.ts
+++ b/tests/e2e/specs/56-host-proxyjump-tunnel.spec.ts
@@ -1,0 +1,103 @@
+// ProxyJump / SSH tunnel UI. Covers the HostEditModal tunnel toggle + host
+// selector (proxy_jump_host_id persistence), self-exclusion from the dropdown,
+// the HostCard "via …" badge, and the zero-candidate disabled state.
+
+import { expect } from "chai";
+import { resetApp } from "../helpers/reset.js";
+import { waitForDashboard } from "../helpers/dashboard.js";
+import {
+    clickSave,
+    fillPasswordHostForm,
+    findHostCardByLabel,
+    getHostId,
+    openHostEdit,
+    openNewHostModal,
+    setTunnelEnabled,
+    waitForModalClosed,
+} from "../helpers/host.js";
+
+const SSHD_PASS_HOST = process.env.SSHD_PASS_HOST ?? "sshd-pass";
+const SSHD_PASS_PORT = Number(process.env.SSHD_PASS_PORT ?? 2222);
+const SSH_USER = process.env.SSH_USER ?? "testuser";
+const SSH_PASS = process.env.SSH_PASS ?? "testpass";
+
+async function seedHost(label: string): Promise<void> {
+    await openNewHostModal();
+    await fillPasswordHostForm({
+        label,
+        host: SSHD_PASS_HOST,
+        port: SSHD_PASS_PORT,
+        username: SSH_USER,
+        password: SSH_PASS,
+    });
+    await clickSave();
+    await waitForModalClosed();
+    await findHostCardByLabel(label);
+}
+
+describe("ProxyJump tunnel UI", () => {
+    beforeEach(async () => {
+        await resetApp();
+        await waitForDashboard();
+    });
+
+    it("links a host through a tunnel host and shows the 'via' badge", async () => {
+        await seedHost("bastion");
+        await seedHost("target");
+
+        const bastionId = await getHostId("bastion");
+        const targetId = await getHostId("target");
+
+        // Enable the tunnel on `target` and route it through `bastion`.
+        await openHostEdit("target");
+        await setTunnelEnabled(true);
+
+        // Open the host dropdown once: assert the edited host is excluded (a host
+        // can't tunnel through itself), then pick `bastion` from the open list.
+        const trigger = await $("[data-testid='host-modal-tunnel-host']");
+        await trigger.waitForClickable({ timeout: 5_000 });
+        await trigger.click();
+
+        const selfExists = await (
+            await $(`[data-testid='host-modal-tunnel-host-option-${targetId}']`)
+        ).isExisting();
+        expect(selfExists, "host must not tunnel through itself").to.equal(false);
+
+        const bastionOption = await $(
+            `[data-testid='host-modal-tunnel-host-option-${bastionId}']`,
+        );
+        await bastionOption.waitForDisplayed({ timeout: 5_000 });
+        await bastionOption.click();
+
+        await clickSave();
+        await waitForModalClosed();
+
+        // The card renders a "via bastion" badge. Read textContent directly —
+        // WebKitWebDriver getText() returns "" for small/truncated elements.
+        const badgeSel = `[data-testid='host-card-${targetId}-tunnel']`;
+        await (await $(badgeSel)).waitForExist({ timeout: 10_000 });
+        const text = await browser.execute(
+            (sel: string) => document.querySelector(sel)?.textContent ?? "",
+            badgeSel,
+        );
+        expect(text).to.contain("via");
+        expect(text).to.contain("bastion");
+
+        // Persistence: reopen the editor and confirm the toggle stays enabled.
+        await openHostEdit("target");
+        const checkbox = await $("[data-testid='host-modal-tunnel-enabled']");
+        expect(await checkbox.isSelected(), "tunnel toggle should persist").to.equal(true);
+    });
+
+    it("disables the tunnel toggle when there is no other host to tunnel through", async () => {
+        await seedHost("solo");
+
+        await openHostEdit("solo");
+        const checkbox = await $("[data-testid='host-modal-tunnel-enabled']");
+        await checkbox.waitForExist({ timeout: 5_000 });
+        expect(
+            await checkbox.isEnabled(),
+            "checkbox should be disabled with no candidate hosts",
+        ).to.equal(false);
+    });
+});

--- a/tests/e2e/specs/57-host-proxyjump-connect.spec.ts
+++ b/tests/e2e/specs/57-host-proxyjump-connect.spec.ts
@@ -1,0 +1,105 @@
+// ProxyJump END-TO-END: proves a saved host actually connects THROUGH a jump
+// host. `sshd-tunnel-target` lives on an isolated docker network the runner
+// can't reach, bridged only by `sshd-bastion`. So:
+//   • a DIRECT connection to the target must fail (it's unreachable), and
+//   • a TUNNELLED connection (proxy_jump_host_id → bastion) must succeed and
+//     land a real shell on the target (hostname == anyscp-tunnel-target).
+// Together these show the tunnel — not direct reachability — is what works.
+
+import { expect } from "chai";
+import { resetApp } from "../helpers/reset.js";
+import { waitForDashboard } from "../helpers/dashboard.js";
+import {
+    clickConnect,
+    clickSave,
+    fillPasswordHostForm,
+    findHostCardByLabel,
+    getHostId,
+    openNewHostModal,
+    selectTunnelHost,
+    setTunnelEnabled,
+    waitForModalClosed,
+} from "../helpers/host.js";
+import { runCommand, waitForAnyTerminal, waitForTerminalText } from "../helpers/terminal.js";
+
+const BASTION_HOST = process.env.SSHD_BASTION_HOST ?? "sshd-bastion";
+const BASTION_PORT = Number(process.env.SSHD_BASTION_PORT ?? 2222);
+const TARGET_HOST = process.env.SSHD_TUNNEL_TARGET_HOST ?? "sshd-tunnel-target";
+const TARGET_PORT = Number(process.env.SSHD_TUNNEL_TARGET_PORT ?? 2222);
+const SSH_USER = process.env.SSH_USER ?? "testuser";
+const SSH_PASS = process.env.SSH_PASS ?? "testpass";
+
+// The target's container hostname (docker-compose `hostname:`). A shell that
+// reports this name can only have been reached through the bastion tunnel.
+const TARGET_MARKER = "anyscp-tunnel-target";
+
+describe("ProxyJump end-to-end", () => {
+    beforeEach(async () => {
+        await resetApp();
+        await waitForDashboard();
+    });
+
+    it("cannot reach the isolated target directly (isolation guard)", async () => {
+        // Sanity: without a tunnel the target is unreachable from the runner, so
+        // a direct connect must surface an error rather than a terminal. If this
+        // ever passes, the network isolation is broken and the positive test
+        // below would no longer prove anything.
+        await openNewHostModal();
+        await fillPasswordHostForm({
+            label: "direct-fail",
+            host: TARGET_HOST,
+            port: TARGET_PORT,
+            username: SSH_USER,
+            password: SSH_PASS,
+        });
+        await clickConnect();
+
+        const err = await $("[data-testid='host-modal-error']");
+        await err.waitForDisplayed({ timeout: 30_000 });
+        expect((await err.getText()).length).to.be.greaterThan(0);
+    });
+
+    it("connects through the bastion and runs a command on the target", async () => {
+        // 1. Save the bastion so it becomes selectable as a tunnel host.
+        await openNewHostModal();
+        await fillPasswordHostForm({
+            label: "bastion",
+            host: BASTION_HOST,
+            port: BASTION_PORT,
+            username: SSH_USER,
+            password: SSH_PASS,
+        });
+        await clickSave();
+        await waitForModalClosed();
+        await findHostCardByLabel("bastion");
+        const bastionId = await getHostId("bastion");
+
+        // 2. Save the target with the tunnel routed through the bastion.
+        await openNewHostModal();
+        await fillPasswordHostForm({
+            label: "tunnel-target",
+            host: TARGET_HOST,
+            port: TARGET_PORT,
+            username: SSH_USER,
+            password: SSH_PASS,
+        });
+        await setTunnelEnabled(true);
+        await selectTunnelHost(bastionId);
+        await clickSave();
+        await waitForModalClosed();
+        const targetId = await getHostId("tunnel-target");
+
+        // 3. Connect the SAVED target from its card (uses connect_saved_host,
+        //    which resolves proxy_jump_host_id → the bastion and tunnels).
+        const terminalBtn = await $(`[data-testid='host-card-${targetId}-terminal']`);
+        await terminalBtn.waitForClickable({ timeout: 10_000 });
+        await terminalBtn.click();
+
+        const sessionId = await waitForAnyTerminal(30_000);
+        await waitForTerminalText(sessionId, ":~$", { timeoutMs: 30_000 });
+
+        // 4. The shell must be on the ISOLATED target, only reachable via the
+        //    tunnel — `hostname` proves which host we actually landed on.
+        await runCommand(sessionId, "hostname", TARGET_MARKER, 15_000);
+    });
+});

--- a/tests/e2e/specs/58-host-proxyjump-chain.spec.ts
+++ b/tests/e2e/specs/58-host-proxyjump-chain.spec.ts
@@ -1,0 +1,98 @@
+// Multi-hop ProxyJump (chained bastions) END-TO-END. Proves a connection
+// traverses TWO jump hosts, which is the capability the recursive `establish`
+// rewrite added (the old single-hop code could not do this at all).
+//
+// Topology (see docker-compose.yml):
+//   runner ──e2e──▶ sshd-bastion ──e2e-internal──▶ sshd-bastion2 ──e2e-internal2──▶ sshd-deep-target
+// The deep target and bastion2 share NO network with the runner, so the only
+// way to reach the deep target is to hop bastion1 → bastion2. A working shell on
+// it (hostname == anyscp-deep-target) can only mean both hops were traversed.
+//
+// Regression value: on the pre-fix single-hop code this test FAILS — that code
+// connected directly to the immediate jump (bastion2), which the runner can't
+// reach, so the connection never establishes.
+
+import { resetApp } from "../helpers/reset.js";
+import { waitForDashboard } from "../helpers/dashboard.js";
+import {
+    clickSave,
+    fillPasswordHostForm,
+    findHostCardByLabel,
+    getHostId,
+    openNewHostModal,
+    selectTunnelHost,
+    setTunnelEnabled,
+    waitForModalClosed,
+} from "../helpers/host.js";
+import { runCommand, waitForAnyTerminal, waitForTerminalText } from "../helpers/terminal.js";
+
+const BASTION_HOST = process.env.SSHD_BASTION_HOST ?? "sshd-bastion";
+const BASTION_PORT = Number(process.env.SSHD_BASTION_PORT ?? 2222);
+const BASTION2_HOST = process.env.SSHD_BASTION2_HOST ?? "sshd-bastion2";
+const BASTION2_PORT = Number(process.env.SSHD_BASTION2_PORT ?? 2222);
+const DEEP_TARGET_HOST = process.env.SSHD_DEEP_TARGET_HOST ?? "sshd-deep-target";
+const DEEP_TARGET_PORT = Number(process.env.SSHD_DEEP_TARGET_PORT ?? 2222);
+const SSH_USER = process.env.SSH_USER ?? "testuser";
+const SSH_PASS = process.env.SSH_PASS ?? "testpass";
+
+const DEEP_TARGET_MARKER = "anyscp-deep-target";
+
+/** Save a password host, optionally tunnelled through `tunnelHostId`. */
+async function saveHost(
+    label: string,
+    host: string,
+    port: number,
+    tunnelHostId?: string,
+): Promise<string> {
+    await openNewHostModal();
+    await fillPasswordHostForm({ label, host, port, username: SSH_USER, password: SSH_PASS });
+    if (tunnelHostId) {
+        await setTunnelEnabled(true);
+        await selectTunnelHost(tunnelHostId);
+    }
+    await clickSave();
+    await waitForModalClosed();
+    await findHostCardByLabel(label);
+    return getHostId(label);
+}
+
+describe("ProxyJump multi-hop (chained bastions)", () => {
+    beforeEach(async () => {
+        await resetApp();
+        await waitForDashboard();
+    });
+
+    it("connects through a two-bastion chain to an isolated target", async () => {
+        // bastion1 (runner-reachable) ← bastion2 tunnels through it ← deep target
+        // tunnels through bastion2. Saving in dependency order so each tunnel
+        // host already exists in the picker.
+        const bastion1Id = await saveHost("chain-bastion1", BASTION_HOST, BASTION_PORT);
+        const bastion2Id = await saveHost(
+            "chain-bastion2",
+            BASTION2_HOST,
+            BASTION2_PORT,
+            bastion1Id,
+        );
+        const deepId = await saveHost(
+            "chain-deep-target",
+            DEEP_TARGET_HOST,
+            DEEP_TARGET_PORT,
+            bastion2Id,
+        );
+
+        // Connect the deep target from its card → connect_saved_host resolves the
+        // full chain (deep → bastion2 → bastion1) and establishes it hop by hop.
+        const terminalBtn = await $(`[data-testid='host-card-${deepId}-terminal']`);
+        await terminalBtn.waitForClickable({ timeout: 10_000 });
+        await terminalBtn.click();
+
+        const sessionId = await waitForAnyTerminal(40_000);
+        // Two sequential SSH handshakes + auths before the target shell — allow
+        // extra time for the chain to come up.
+        await waitForTerminalText(sessionId, ":~$", { timeoutMs: 40_000 });
+
+        // The shell must be on the doubly-isolated deep target, reachable only by
+        // traversing BOTH bastions — this is the whole proof of multi-hop.
+        await runCommand(sessionId, "hostname", DEEP_TARGET_MARKER, 15_000);
+    });
+});


### PR DESCRIPTION
This pull request adds robust support for linking SSH hosts via ProxyJump (jump host) relationships, including schema migration, validation to prevent cycles, and improved import logic. It introduces a new `proxy_jump_host_id` field to the database, ensures data integrity by preventing circular ProxyJump configurations, and enhances the SSH import workflow to resolve and link jump hosts automatically. The changes also include tests and internal refactoring to support these features.

**ProxyJump support and validation:**

- Added a new `proxy_jump_host_id` field to the `SavedHost` struct and database schema, enabling hosts to reference another host as a ProxyJump target. Includes schema migration logic to add this column if missing. [[1]](diffhunk://#diff-ddc5c908ba2c743aa17aa0b66eb99e95b34937199225be06ca52f3ab6261abfbR112-R116) [[2]](diffhunk://#diff-ddc5c908ba2c743aa17aa0b66eb99e95b34937199225be06ca52f3ab6261abfbR464-R481) [[3]](diffhunk://#diff-ddc5c908ba2c743aa17aa0b66eb99e95b34937199225be06ca52f3ab6261abfbL475-R508) [[4]](diffhunk://#diff-ddc5c908ba2c743aa17aa0b66eb99e95b34937199225be06ca52f3ab6261abfbL502-R530) [[5]](diffhunk://#diff-ddc5c908ba2c743aa17aa0b66eb99e95b34937199225be06ca52f3ab6261abfbR553) [[6]](diffhunk://#diff-ddc5c908ba2c743aa17aa0b66eb99e95b34937199225be06ca52f3ab6261abfbL541-R570) [[7]](diffhunk://#diff-ddc5c908ba2c743aa17aa0b66eb99e95b34937199225be06ca52f3ab6261abfbR598) [[8]](diffhunk://#diff-ddc5c908ba2c743aa17aa0b66eb99e95b34937199225be06ca52f3ab6261abfbL602-R632) [[9]](diffhunk://#diff-ddc5c908ba2c743aa17aa0b66eb99e95b34937199225be06ca52f3ab6261abfbR660)
- Implemented validation to prevent ProxyJump cycles (e.g., A → B → A) and self-references when saving hosts, returning a specific validation error if detected. [[1]](diffhunk://#diff-bdf11a53f35845da494f207c60bd2d194e8a5f3ac577fe20a721e6731878bc31L14-R52) [[2]](diffhunk://#diff-ddc5c908ba2c743aa17aa0b66eb99e95b34937199225be06ca52f3ab6261abfbR24-R26) [[3]](diffhunk://#diff-ddc5c908ba2c743aa17aa0b66eb99e95b34937199225be06ca52f3ab6261abfbR42)
- Added a dedicated method to set or clear a host's `proxy_jump_host_id`, with appropriate error handling if the target host does not exist.

**Import and data handling improvements:**

- Enhanced SSH config import to resolve ProxyJump directives to saved-host IDs, using alias, label, or hostname matching, and link them via `proxy_jump_host_id` where possible. Unresolved jumps fall back to the free-text field without breaking the import. [[1]](diffhunk://#diff-29cbe1c9d58138f01571b4af1378afdfe5ee53e6fb9fb75668c83cd3f23fdc39R51-R62) [[2]](diffhunk://#diff-29cbe1c9d58138f01571b4af1378afdfe5ee53e6fb9fb75668c83cd3f23fdc39R80) [[3]](diffhunk://#diff-29cbe1c9d58138f01571b4af1378afdfe5ee53e6fb9fb75668c83cd3f23fdc39L84-R118) [[4]](diffhunk://#diff-29cbe1c9d58138f01571b4af1378afdfe5ee53e6fb9fb75668c83cd3f23fdc39R139-R181)
- Updated tests to cover round-tripping and clearing of the new ProxyJump field, ensuring correct persistence and retrieval. [[1]](diffhunk://#diff-ddc5c908ba2c743aa17aa0b66eb99e95b34937199225be06ca52f3ab6261abfbR1526) [[2]](diffhunk://#diff-ddc5c908ba2c743aa17aa0b66eb99e95b34937199225be06ca52f3ab6261abfbR1578-R1603)

**Internal refactoring and minor updates:**

- Refactored SSH connection management to support jump host handles, ensuring tunnel lifetimes are managed correctly. [[1]](diffhunk://#diff-76fcc767dc11d667475e39978d9dabf36d1ed2d3c1e3a9b06d1c20ee2c51a2bbR210-R212) [[2]](diffhunk://#diff-5f2541adc7e7e8237dd35a843f30e1d1f006af7b2289269b82eddb0b279e33adR13-R27) [[3]](diffhunk://#diff-5f2541adc7e7e8237dd35a843f30e1d1f006af7b2289269b82eddb0b279e33adL56-R74)

These changes collectively make ProxyJump relationships first-class, reliable, and safe in the application's SSH host management.