### PR TITLE
fix(dialogs): focus the first input when host/S3 dialogs open

### DIFF
--- a/src/components/dashboard/HostEditModal.tsx
+++ b/src/components/dashboard/HostEditModal.tsx
@@ -146,7 +146,7 @@ export function HostEditModal() {
   const [credCleared, setCredCleared] = useState(false);
 
   const backdropRef = useRef<HTMLDivElement>(null);
-  const hostInputRef = useRef<HTMLInputElement>(null);
+  const firstInputRef = useRef<HTMLInputElement>(null);
   const scrollBodyRef = useRef<HTMLDivElement>(null);
 
   const isOpen = editingHostId !== null;
@@ -227,12 +227,12 @@ export function HostEditModal() {
     })();
   }, [isOpen, editingHostId, isNewHost, loadGroups, loadHosts]);
 
-  // Scroll to top and focus Host field when modal opens
+  // Scroll to top and focus the first field (Label) when the modal opens.
   useEffect(() => {
     if (visible && !loadingHost) {
       requestAnimationFrame(() => {
         scrollBodyRef.current?.scrollTo(0, 0);
-        hostInputRef.current?.focus();
+        firstInputRef.current?.focus();
       });
     }
   }, [visible, loadingHost]);
@@ -525,6 +525,7 @@ export function HostEditModal() {
                   <span className="ml-1 text-text-muted font-normal">(optional)</span>
                 </label>
                 <input
+                  ref={firstInputRef}
                   id="hem-label"
                   data-testid="host-modal-label"
                   type="text"
@@ -543,7 +544,6 @@ export function HostEditModal() {
                     Host <RequiredMark />
                   </label>
                   <input
-                    ref={hostInputRef}
                     id="hem-host"
                     data-testid="host-modal-host"
                     type="text"

--- a/src/components/s3/S3ConnectDialog.tsx
+++ b/src/components/s3/S3ConnectDialog.tsx
@@ -217,6 +217,7 @@ export function S3ConnectDialog({ onClose, editConnection }: S3ConnectDialogProp
               onChange={(e) => setLabel(e.target.value)}
               placeholder="My S3 Bucket"
               className={inputClass}
+              autoFocus
             />
           </div>
 
@@ -237,7 +238,6 @@ export function S3ConnectDialog({ onClose, editConnection }: S3ConnectDialogProp
               onChange={(e) => setAccessKey(e.target.value)}
               placeholder={isEdit ? "••••••••••••" : "AKIAIOSFODNN7EXAMPLE"}
               className={`${inputClass} font-mono`}
-              autoFocus={!isEdit}
             />
           </div>
 

--- a/tests/e2e/specs/52-dialog-focus-first-input.spec.ts
+++ b/tests/e2e/specs/52-dialog-focus-first-input.spec.ts
@@ -1,0 +1,35 @@
+// When the new-host and new-S3 dialogs open, focus should land on their first
+// input (the Label field) so the user can start typing immediately.
+
+import { resetApp } from "../helpers/reset.js";
+import { waitForDashboard } from "../helpers/dashboard.js";
+import { openNewHostModal } from "../helpers/host.js";
+import { openNewS3Dialog } from "../helpers/s3.js";
+
+/** Wait until the focused element carries the given data-testid. */
+async function waitForFocusedTestId(testid: string): Promise<void> {
+    await browser.waitUntil(
+        async () =>
+            (await browser.execute(
+                () => document.activeElement?.getAttribute("data-testid") ?? "",
+            )) === testid,
+        { timeout: 5_000, timeoutMsg: `focus never landed on '${testid}'` },
+    );
+}
+
+describe("dialog focuses first input on open", () => {
+    beforeEach(async () => {
+        await resetApp();
+        await waitForDashboard();
+    });
+
+    it("focuses the Label field when the new-host dialog opens", async () => {
+        await openNewHostModal();
+        await waitForFocusedTestId("host-modal-label");
+    });
+
+    it("focuses the Label field when the new-S3 dialog opens", async () => {
+        await openNewS3Dialog();
+        await waitForFocusedTestId("s3-dialog-label");
+    });
+});


### PR DESCRIPTION
When the **new-host** and **S3 connection** dialogs open, focus now lands on their first field (**Label**) so you can start typing immediately.

## What changed
- **Host dialog** (`HostEditModal.tsx`) — the open-focus effect now targets the Label field instead of the Host field. Renamed `hostInputRef` → `firstInputRef` and moved it onto the Label input.
- **S3 dialog** (`S3ConnectDialog.tsx`) — moved `autoFocus` from the Access Key field to the Label field (now applies in edit mode too, matching the host dialog).

## Tests
- New e2e spec `52-dialog-focus-first-input.spec.ts`: opens each dialog and asserts `document.activeElement` is the Label input (`host-modal-label` / `s3-dialog-label`).

Existing specs are unaffected — their form helpers click each field before typing, so they never relied on autofocus.

Verified: `tsc --noEmit` passes. The e2e spec needs the dockerized harness (`make e2e`), not run here.