### PR TITLE
fix(terminal): remove orphaned host tab after SSH session exits (#42)

### DIFF
--- a/src/components/terminal/DisconnectOverlay.tsx
+++ b/src/components/terminal/DisconnectOverlay.tsx
@@ -6,6 +6,8 @@ import { useTabStore } from "../../stores/tab-store";
 
 interface DisconnectOverlayProps {
   sessionId: SessionId;
+  /** The unified tab that owns this pane — needed to clean up the tab bar. */
+  tabId: string;
   status: "Disconnected" | "Error";
   message?: string;
   hostConfig: HostConfig;
@@ -13,6 +15,7 @@ interface DisconnectOverlayProps {
 
 export function DisconnectOverlay({
   sessionId,
+  tabId,
   status,
   message,
   hostConfig,
@@ -59,7 +62,24 @@ export function DisconnectOverlay({
   }
 
   function handleClose() {
-    useSessionStore.getState().removeSession(sessionId);
+    void (async () => {
+      // Tear down the (already dead) backend session so it doesn't linger in
+      // the manager's session map — mirrors the tab X button and ⌘W.
+      try {
+        const { invoke } = await import("@tauri-apps/api/core");
+        await invoke("ssh_disconnect", { sessionId });
+      } catch { /* already disconnected */ }
+
+      useSessionStore.getState().removeSession(sessionId);
+
+      // removeSession only prunes the session-store's layout tree. If this was
+      // the tab's last pane, the unified tab is now orphaned in the tab bar
+      // with no working session, so remove it too. For a split, the tab still
+      // owns the surviving pane and must stay. (issue #42)
+      if (!useSessionStore.getState().tabs.get(tabId)) {
+        useTabStore.getState().removeTab(tabId);
+      }
+    })();
   }
 
   return (

--- a/src/components/terminal/PaneHeader.tsx
+++ b/src/components/terminal/PaneHeader.tsx
@@ -1,11 +1,14 @@
 import { Columns2, Rows2, Maximize2, Minimize2, X } from "lucide-react";
 import { useSessionStore } from "../../stores/session-store";
+import { useTabStore } from "../../stores/tab-store";
 
 interface PaneHeaderProps {
   sessionId: string;
+  /** The unified tab that owns this pane — needed to clean up the tab bar. */
+  tabId: string;
 }
 
-export function PaneHeader({ sessionId }: PaneHeaderProps) {
+export function PaneHeader({ sessionId, tabId }: PaneHeaderProps) {
   const session = useSessionStore((s) => s.sessions.get(sessionId));
   const isActive = useSessionStore((s) => s.activeSessionId === sessionId);
   const isZoomed = useSessionStore((s) => s.zoomedPaneId === sessionId);
@@ -51,6 +54,14 @@ export function PaneHeader({ sessionId }: PaneHeaderProps) {
         store.unsplitPane(sessionId);
       }
       store.removeSession(sessionId);
+
+      // Defensive: if that emptied the owning tab's layout, drop the GUI tab
+      // too so it can't be orphaned in the tab bar (issue #42). In the normal
+      // split flow the close button is hidden once a single pane remains, so
+      // the tab survives here — this only fires if the tab truly has no panes.
+      if (!useSessionStore.getState().tabs.get(tabId)) {
+        useTabStore.getState().removeTab(tabId);
+      }
     })();
   };
 

--- a/src/components/terminal/TerminalArea.tsx
+++ b/src/components/terminal/TerminalArea.tsx
@@ -13,7 +13,7 @@ interface TerminalAreaProps {
   tabId: string;
 }
 
-export function TerminalPane({ sessionId }: { sessionId: string }) {
+export function TerminalPane({ sessionId, tabId }: { sessionId: string; tabId: string }) {
   const session = useSessionStore((s) => s.sessions.get(sessionId));
   const isActive = useSessionStore((s) => s.activeSessionId === sessionId);
   const isZoomed = useSessionStore((s) => s.zoomedPaneId === sessionId);
@@ -48,7 +48,7 @@ export function TerminalPane({ sessionId }: { sessionId: string }) {
         if (!isActive) setActiveSession(sessionId);
       }}
     >
-      <PaneHeader sessionId={sessionId} />
+      <PaneHeader sessionId={sessionId} tabId={tabId} />
 
       <div className="relative flex-1 min-h-0">
         <Terminal sessionId={sessionId} />
@@ -58,6 +58,7 @@ export function TerminalPane({ sessionId }: { sessionId: string }) {
         {showOverlay && session && (
           <DisconnectOverlay
             sessionId={sessionId}
+            tabId={tabId}
             status={session.status as "Disconnected" | "Error"}
             message={session.statusMessage}
             hostConfig={session.hostConfig}
@@ -70,7 +71,7 @@ export function TerminalPane({ sessionId }: { sessionId: string }) {
 
 export function TerminalArea({ node, path = [], tabId }: TerminalAreaProps) {
   if (node.type === "pane") {
-    return <TerminalPane sessionId={node.sessionId} />;
+    return <TerminalPane sessionId={node.sessionId} tabId={tabId} />;
   }
 
   return <SplitContainer node={node} path={path} tabId={tabId} />;

--- a/tests/e2e/specs/61-exit-overlay-close-removes-tab.spec.ts
+++ b/tests/e2e/specs/61-exit-overlay-close-removes-tab.spec.ts
@@ -1,0 +1,73 @@
+// Regression for issue #42: after the remote shell exits (`exit`), the
+// terminal pane shows the disconnect overlay. Clicking that overlay's Close
+// (X) button must remove the tab from the top tab bar — previously the tab was
+// left orphaned (a dead host stuck at the top of the GUI with no function that
+// only vanished on a full reload), because handleClose pruned the session but
+// forgot to remove the unified tab.
+
+import { expect } from "chai";
+import { resetApp } from "../helpers/reset.js";
+import { waitForDashboard } from "../helpers/dashboard.js";
+import {
+    clickConnect,
+    fillPasswordHostForm,
+    openNewHostModal,
+    waitForModalClosed,
+} from "../helpers/host.js";
+import {
+    typeIntoTerminal,
+    waitForAnyTerminal,
+    waitForTerminalText,
+} from "../helpers/terminal.js";
+import { tabCountOfType } from "../helpers/tabs.js";
+
+const SSHD_PASS_HOST = process.env.SSHD_PASS_HOST ?? "sshd-pass";
+const SSHD_PASS_PORT = Number(process.env.SSHD_PASS_PORT ?? 2222);
+const SSH_USER = process.env.SSH_USER ?? "testuser";
+const SSH_PASS = process.env.SSH_PASS ?? "testpass";
+
+describe("exit then overlay close removes the tab", () => {
+    beforeEach(async () => {
+        await resetApp();
+        await waitForDashboard();
+    });
+
+    it("removes the dead terminal tab when the disconnect overlay is closed", async () => {
+        await openNewHostModal();
+        await fillPasswordHostForm({
+            label: "overlay-close-target",
+            host: SSHD_PASS_HOST,
+            port: SSHD_PASS_PORT,
+            username: SSH_USER,
+            password: SSH_PASS,
+        });
+        await clickConnect();
+        await waitForModalClosed();
+
+        const sessionId = await waitForAnyTerminal();
+        await waitForTerminalText(sessionId, ":~$");
+        expect(await tabCountOfType("terminal")).to.equal(1);
+
+        // Exit the remote shell — the SSH session tears down and the pane shows
+        // the disconnect overlay.
+        await typeIntoTerminal(sessionId, "exit\n");
+
+        // Click the overlay's Close (X) button once it appears.
+        const closeBtn = await $("[aria-label='Close session']");
+        await closeBtn.waitForClickable({ timeout: 15_000 });
+        await closeBtn.click();
+
+        // The orphaned terminal tab must be gone (issue #42). Before the fix it
+        // lingered at the top of the GUI until a full reload.
+        await browser.waitUntil(
+            async () => (await tabCountOfType("terminal")) === 0,
+            {
+                timeout: 10_000,
+                timeoutMsg: "terminal tab was not removed after closing the disconnect overlay",
+            },
+        );
+
+        // The app should fall back to the permanent Hosts page tab.
+        expect(await tabCountOfType("page")).to.be.at.least(1);
+    });
+});


### PR DESCRIPTION
## Summary

Fixes #42 — after closing an SSH session with `exit`, the host stayed stuck at the top of the GUI (a non-functional tab) and only disappeared after a manual reload.

## Root cause

Tabs live in two stores: `useTabStore` renders the top tab bar, while `useSessionStore` holds the session + pane layout. When a remote shell exits, the pane shows the disconnect overlay; its **Close (X)** handler (`DisconnectOverlay.handleClose`) called `removeSession()` but **not** `removeTab()`. The session/layout were cleaned up, but the unified tab was orphaned in the tab bar with no working session. A reload only "fixed" it because neither store is persisted.

Every other close path — the tab X button, ⌘W, and the overlay's own Reconnect — already removes from both stores. `handleClose` was the lone exception.

## Fix

- Thread the owning `tabId` down through `TerminalArea` → `TerminalPane` → `DisconnectOverlay` / `PaneHeader`.
- After `removeSession`, remove the GUI tab too **only when** the tab's layout has no panes left — mirrors the ⌘W handler in `AppShell`. Splits are unaffected: the tab survives as long as a sibling pane remains.
- Opportunistically call `ssh_disconnect` so the backend session map doesn't linger (matches the other close paths).
- Add the same defensive guard to `PaneHeader`'s pane-close path so the bug class is closed there too.

## Tests

Adds e2e regression spec `61-exit-overlay-close-removes-tab`: connect → `exit` → click the overlay Close → assert the terminal tab is removed. This fails on the pre-fix code and passes after.

Frontend `tsc --noEmit` passes. The e2e suite (Docker) has not been run locally yet.