### PR TITLE
Settings redesign: sidebar nav, theming (accent + fonts), live terminal settings

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -53,7 +53,54 @@ pub fn run() {
                 Ok(Some(v)) if v == "light" => "light",
                 _ => "dark",
             };
-            let theme_script = format!("document.documentElement.dataset.theme = {theme:?};");
+            // Same rationale as the theme: inject the persisted accent hue before
+            // first paint so the accent colour doesn't flash from the default.
+            let accent_hue: f64 = host_db
+                .get_setting("app_accent_hue")
+                .ok()
+                .flatten()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(250.0);
+
+            // Optional full custom accent stored as oklch "l c h"; when present it
+            // overrides the hue-based tokens (supports gray / darker shades). Inject
+            // it before first paint too, so a custom accent doesn't flash.
+            let custom_accent_script = host_db
+                .get_setting("app_accent_custom")
+                .ok()
+                .flatten()
+                .and_then(|v| {
+                    let parts: Vec<f64> =
+                        v.split_whitespace().filter_map(|x| x.parse().ok()).collect();
+                    if parts.len() == 3 {
+                        let (l, c, h) = (parts[0], parts[1], parts[2]);
+                        let hover = (l - 0.05).max(0.0);
+                        Some(format!(
+                            "var s=document.documentElement.style;\
+                             s.setProperty('--color-accent','oklch({l} {c} {h})');\
+                             s.setProperty('--color-accent-hover','oklch({hover} {c} {h})');\
+                             s.setProperty('--color-accent-muted','oklch({l} {c} {h} / 0.15)');\
+                             s.setProperty('--color-border-focus','oklch({l} {c} {h})');\
+                             s.setProperty('--color-ring','oklch({l} {c} {h} / 0.40)');\
+                             document.documentElement.dataset.accentCustom='{l} {c} {h}';"
+                        ))
+                    } else {
+                        None
+                    }
+                })
+                .unwrap_or_default();
+
+            // Optional interface (UI) font; inject before first paint too.
+            let font_script = match host_db.get_setting("app_interface_font") {
+                Ok(Some(f)) if !f.is_empty() => format!(
+                    "document.documentElement.style.setProperty('--font-sans', {f:?});document.documentElement.dataset.interfaceFont={f:?};"
+                ),
+                _ => String::new(),
+            };
+
+            let theme_script = format!(
+                "document.documentElement.dataset.theme = {theme:?}; document.documentElement.style.setProperty('--accent-hue', '{accent_hue}');{custom_accent_script}{font_script}"
+            );
 
             WebviewWindowBuilder::new(app.handle(), "main", WebviewUrl::App("index.html".into()))
                 .title("anySCP")

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -24,6 +24,9 @@ import { usePortForwardEvents } from "../../hooks/use-port-forward-events";
 
 export function AppShell() {
   const themeMode = useSettingsStore((s) => s.themeMode);
+  const accentHue = useSettingsStore((s) => s.accentHue);
+  const accentCustom = useSettingsStore((s) => s.accentCustom);
+  const interfaceFont = useSettingsStore((s) => s.interfaceFont);
   const activeTabId = useTabStore((s) => s.activeTabId);
   const allTabs = useTabStore((s) => s.tabs);
   const activeTab = activeTabId ? allTabs.get(activeTabId) : null;
@@ -230,6 +233,35 @@ export function AppShell() {
   useLayoutEffect(() => {
     document.documentElement.dataset.theme = themeMode;
   }, [themeMode]);
+
+  useLayoutEffect(() => {
+    document.documentElement.style.setProperty("--accent-hue", String(accentHue));
+  }, [accentHue]);
+
+  useLayoutEffect(() => {
+    document.documentElement.style.setProperty("--font-sans", interfaceFont);
+    document.documentElement.dataset.interfaceFont = interfaceFont;
+  }, [interfaceFont]);
+
+  // A custom accent overrides the hue-based tokens directly (supports any
+  // lightness/chroma, e.g. gray or darker shades). Clearing it falls back to
+  // the theme's hue-driven accent.
+  useLayoutEffect(() => {
+    const st = document.documentElement.style;
+    const props = ["--color-accent", "--color-accent-hover", "--color-accent-muted", "--color-border-focus", "--color-ring"];
+    if (!accentCustom) {
+      props.forEach((prop) => st.removeProperty(prop));
+      delete document.documentElement.dataset.accentCustom;
+      return;
+    }
+    const { l, c, h } = accentCustom;
+    st.setProperty("--color-accent", `oklch(${l} ${c} ${h})`);
+    st.setProperty("--color-accent-hover", `oklch(${Math.max(0, l - 0.05)} ${c} ${h})`);
+    st.setProperty("--color-accent-muted", `oklch(${l} ${c} ${h} / 0.15)`);
+    st.setProperty("--color-border-focus", `oklch(${l} ${c} ${h})`);
+    st.setProperty("--color-ring", `oklch(${l} ${c} ${h} / 0.40)`);
+    document.documentElement.dataset.accentCustom = `${l} ${c} ${h}`;
+  }, [accentCustom]);
 
   useSftpTransfers();
   usePortForwardEvents();

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -1,14 +1,13 @@
 import { useState, useEffect, useCallback } from "react";
 import { useSettingsStore } from "../../stores/settings-store";
-import { CustomSelect } from "../shared/CustomSelect";
-import { RefreshCw, CheckCircle2, AlertCircle, Download } from "lucide-react";
-import type { CursorStyle } from "../../stores/settings-store";
+import { RefreshCw, CheckCircle2, AlertCircle, Download, Palette, SquareTerminal, ArrowUpDown } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import type { CursorStyle, ThemeMode } from "../../stores/settings-store";
 
 // ─── Shared styles ───────────────────────────────────────────────────────────
 
 const LABEL_CLASS = "text-[length:var(--text-sm)] font-medium text-text-primary";
 const DESC_CLASS = "text-[length:var(--text-xs)] text-text-muted mt-0.5";
-
 
 const INPUT_CLASS = [
   "w-20 px-2.5 py-1.5 rounded-lg text-[length:var(--text-sm)] tabular-nums",
@@ -17,169 +16,254 @@ const INPUT_CLASS = [
   "transition-[border-color,box-shadow] duration-[var(--duration-fast)]",
 ].join(" ");
 
+// ─── Sections ─────────────────────────────────────────────────────────────────
+// Each settings category is a section here. To add a new category, add an entry
+// to SECTIONS, a description, and render its content in <SectionContent />.
+
+type SectionId = "appearance" | "terminal" | "transfers" | "updates";
+
+const SECTIONS: { id: SectionId; label: string; icon: LucideIcon }[] = [
+  { id: "appearance", label: "Appearance", icon: Palette },
+  { id: "terminal", label: "Terminal", icon: SquareTerminal },
+  { id: "transfers", label: "Transfers", icon: ArrowUpDown },
+  { id: "updates", label: "Updates", icon: Download },
+];
+
+const SECTION_DESCRIPTIONS: Record<SectionId, string> = {
+  appearance: "Theme and interface look.",
+  terminal: "Font, cursor, and scrollback history.",
+  transfers: "Control how files are transferred.",
+  updates: "Check for and install app updates.",
+};
+
 // ─── Component ───────────────────────────────────────────────────────────────
 
 export function SettingsPage() {
-  const themeMode = useSettingsStore((s) => s.themeMode);
-  const fontSize = useSettingsStore((s) => s.terminalFontSize);
-  const cursorStyle = useSettingsStore((s) => s.terminalCursorStyle);
-  const cursorBlink = useSettingsStore((s) => s.terminalCursorBlink);
-  const lineHeight = useSettingsStore((s) => s.terminalLineHeight);
-  const scrollback = useSettingsStore((s) => s.terminalScrollback);
-  const transferConcurrency = useSettingsStore((s) => s.transferConcurrency);
-
-  const setThemeMode = useSettingsStore((s) => s.setThemeMode);
-  const setFontSize = useSettingsStore((s) => s.setTerminalFontSize);
-  const setCursorStyle = useSettingsStore((s) => s.setTerminalCursorStyle);
-  const setCursorBlink = useSettingsStore((s) => s.setTerminalCursorBlink);
-  const setLineHeight = useSettingsStore((s) => s.setTerminalLineHeight);
-  const setScrollback = useSettingsStore((s) => s.setTerminalScrollback);
-  const setConcurrency = useSettingsStore((s) => s.setTransferConcurrency);
+  const [active, setActive] = useState<SectionId>("appearance");
+  const activeSection = SECTIONS.find((s) => s.id === active);
 
   return (
-    <div className="h-full overflow-y-auto">
-      <div className="max-w-xl mx-auto px-6 py-8">
-        {/* Header */}
-        <div className="mb-6">
-          <h1 className="text-[length:var(--text-lg)] font-semibold text-text-primary">
+    <div className="flex flex-col h-full p-2">
+      <div className="flex flex-1 min-h-0 rounded-lg overflow-hidden border border-border/60">
+        {/* Sidebar */}
+        <nav
+          aria-label="Settings sections"
+          className="w-60 shrink-0 flex flex-col gap-1 px-3 py-4 border-r border-border/50 bg-bg-surface/40 overflow-y-auto no-select"
+        >
+          <h2 className="px-3 pt-1 pb-2 text-[length:var(--text-2xs)] font-semibold uppercase tracking-wider text-text-muted">
             Settings
-          </h1>
-          <p className="text-[length:var(--text-xs)] text-text-muted mt-1">
-            Configure app appearance, terminal behavior, file transfers, and app updates
-          </p>
+          </h2>
+          {SECTIONS.map(({ id, label, icon: Icon }) => {
+            const isActive = active === id;
+            return (
+              <button
+                key={id}
+                type="button"
+                data-testid={`settings-nav-${id}`}
+                aria-current={isActive ? "page" : undefined}
+                onClick={() => setActive(id)}
+                className={[
+                  "flex items-center gap-2.5 px-3 py-2 rounded-lg text-left",
+                  "text-[length:var(--text-sm)] font-medium",
+                  "transition-colors duration-[var(--duration-fast)]",
+                  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                  isActive
+                    ? "bg-bg-overlay text-text-primary border border-border/60 shadow-[var(--shadow-sm)]"
+                    : "text-text-secondary border border-transparent hover:text-text-primary hover:bg-bg-overlay/50",
+                ].join(" ")}
+              >
+                <Icon
+                  size={17}
+                  strokeWidth={isActive ? 2 : 1.6}
+                  className={`shrink-0 ${isActive ? "text-accent" : "text-text-muted"}`}
+                />
+                {label}
+              </button>
+            );
+          })}
+        </nav>
+
+        {/* Content */}
+        <div className="flex-1 overflow-y-auto bg-bg-base">
+          <div className="max-w-4xl mx-auto px-8 py-6">
+            {/* Section header */}
+            <div className="mb-6">
+              <h1 className="text-2xl font-semibold tracking-tight text-text-primary">
+                {activeSection?.label}
+              </h1>
+              <p className="text-[length:var(--text-sm)] text-text-muted mt-1.5">
+                {SECTION_DESCRIPTIONS[active]}
+              </p>
+            </div>
+
+            <SectionContent section={active} />
+          </div>
         </div>
-
-        {/* Appearance */}
-        <section className="mb-8">
-          <h2 className="text-[length:var(--text-sm)] font-semibold uppercase tracking-wider text-text-muted mb-4">
-            Appearance
-          </h2>
-
-          <div className="flex flex-col gap-4">
-            <SettingRow>
-              <div>
-                <label htmlFor="s-light-theme" className={LABEL_CLASS}>Light Theme</label>
-                <p className={DESC_CLASS}>Use a softer grey interface instead of the dark background</p>
-              </div>
-              <Toggle
-                id="s-light-theme"
-                checked={themeMode === "light"}
-                onChange={(checked) => setThemeMode(checked ? "light" : "dark")}
-              />
-            </SettingRow>
-          </div>
-        </section>
-
-        {/* Terminal Appearance */}
-        <section className="mb-8">
-          <h2 className="text-[length:var(--text-sm)] font-semibold uppercase tracking-wider text-text-muted mb-4">
-            Terminal
-          </h2>
-
-          <div className="flex flex-col gap-4">
-            {/* Font Size */}
-            <SettingRow>
-              <div>
-                <label htmlFor="s-fontsize" className={LABEL_CLASS}>Font Size</label>
-                <p className={DESC_CLASS}>Size in pixels (8–32)</p>
-              </div>
-              <NumberSetting id="s-fontsize" value={fontSize} min={8} max={32} step={1} onChange={setFontSize} />
-            </SettingRow>
-
-            {/* Cursor Style */}
-            <SettingRow>
-              <div>
-                <label htmlFor="s-cursor" className={LABEL_CLASS}>Cursor Style</label>
-                <p className={DESC_CLASS}>Shape of the terminal cursor</p>
-              </div>
-              <CustomSelect
-                id="s-cursor"
-                value={cursorStyle}
-                onChange={(v) => setCursorStyle(v as CursorStyle)}
-                options={[
-                  { value: "bar", label: "Bar" },
-                  { value: "block", label: "Block" },
-                  { value: "underline", label: "Underline" },
-                ]}
-                className="w-32"
-              />
-            </SettingRow>
-
-            {/* Cursor Blink */}
-            <SettingRow>
-              <div>
-                <label htmlFor="s-blink" className={LABEL_CLASS}>Cursor Blink</label>
-                <p className={DESC_CLASS}>Animate the cursor</p>
-              </div>
-              <Toggle
-                id="s-blink"
-                checked={cursorBlink}
-                onChange={setCursorBlink}
-              />
-            </SettingRow>
-
-            {/* Line Height */}
-            <SettingRow>
-              <div>
-                <label htmlFor="s-lineheight" className={LABEL_CLASS}>Line Height</label>
-                <p className={DESC_CLASS}>Spacing between lines (1.0–2.0)</p>
-              </div>
-              <NumberSetting id="s-lineheight" value={lineHeight} min={1.0} max={2.0} step={0.1} onChange={setLineHeight} />
-            </SettingRow>
-
-            {/* Scrollback */}
-            <SettingRow>
-              <div>
-                <label htmlFor="s-scrollback" className={LABEL_CLASS}>Scrollback Buffer</label>
-                <p className={DESC_CLASS}>Number of lines to keep in history (500–100,000)</p>
-              </div>
-              <NumberSetting id="s-scrollback" value={scrollback} min={500} max={100000} step={500} onChange={setScrollback} />
-            </SettingRow>
-          </div>
-        </section>
-
-        {/* Transfers */}
-        <section className="mb-8">
-          <h2 className="text-[length:var(--text-sm)] font-semibold uppercase tracking-wider text-text-muted mb-4">
-            Transfers
-          </h2>
-
-          <div className="flex flex-col gap-4">
-            <SettingRow>
-              <div>
-                <label htmlFor="s-concurrency" className={LABEL_CLASS}>Concurrent Transfers</label>
-                <p className={DESC_CLASS}>Maximum simultaneous file transfers (1–10)</p>
-              </div>
-              <NumberSetting id="s-concurrency" value={transferConcurrency} min={1} max={10} step={1} onChange={setConcurrency} />
-            </SettingRow>
-          </div>
-        </section>
-
-        {/* Updates */}
-        <section className="mb-8">
-          <h2 className="text-[length:var(--text-sm)] font-semibold uppercase tracking-wider text-text-muted mb-4">
-            Updates
-          </h2>
-
-          <div className="flex flex-col gap-4">
-            <UpdateChecker />
-          </div>
-        </section>
-
-        {/* Note */}
-        <p className="text-[length:var(--text-xs)] text-text-muted">
-          Terminal settings apply to new terminals. Existing terminals keep their current settings.
-        </p>
       </div>
     </div>
   );
 }
 
+// ─── Section content ───────────────────────────────────────────────────────────
+
+function SectionContent({ section }: { section: SectionId }) {
+  switch (section) {
+    case "appearance":
+      return <AppearanceSettings />;
+    case "terminal":
+      return <TerminalSettings />;
+    case "transfers":
+      return <TransferSettings />;
+    case "updates":
+      return <UpdateSettings />;
+  }
+}
+
+function AppearanceSettings() {
+  const themeMode = useSettingsStore((s) => s.themeMode);
+  const setThemeMode = useSettingsStore((s) => s.setThemeMode);
+
+  return (
+    <SettingsGroup label="Theme">
+      <SettingRow>
+        <div>
+          <p className={LABEL_CLASS}>Color Theme</p>
+          <p className={DESC_CLASS}>Switch between the dark and softer grey light interface</p>
+        </div>
+        <SegmentedControl<ThemeMode>
+          id="s-light-theme"
+          value={themeMode}
+          onChange={setThemeMode}
+          options={[
+            { value: "dark", label: "Dark" },
+            { value: "light", label: "Light" },
+          ]}
+        />
+      </SettingRow>
+    </SettingsGroup>
+  );
+}
+
+function TerminalSettings() {
+  const fontSize = useSettingsStore((s) => s.terminalFontSize);
+  const cursorStyle = useSettingsStore((s) => s.terminalCursorStyle);
+  const cursorBlink = useSettingsStore((s) => s.terminalCursorBlink);
+  const lineHeight = useSettingsStore((s) => s.terminalLineHeight);
+  const scrollback = useSettingsStore((s) => s.terminalScrollback);
+
+  const setFontSize = useSettingsStore((s) => s.setTerminalFontSize);
+  const setCursorStyle = useSettingsStore((s) => s.setTerminalCursorStyle);
+  const setCursorBlink = useSettingsStore((s) => s.setTerminalCursorBlink);
+  const setLineHeight = useSettingsStore((s) => s.setTerminalLineHeight);
+  const setScrollback = useSettingsStore((s) => s.setTerminalScrollback);
+
+  return (
+    <>
+      <SettingsGroup label="Font">
+        <SettingRow>
+          <div>
+            <label htmlFor="s-fontsize" className={LABEL_CLASS}>Font Size</label>
+            <p className={DESC_CLASS}>Size in pixels (8–32)</p>
+          </div>
+          <NumberSetting id="s-fontsize" value={fontSize} min={8} max={32} step={1} onChange={setFontSize} />
+        </SettingRow>
+
+        <SettingRow>
+          <div>
+            <label htmlFor="s-lineheight" className={LABEL_CLASS}>Line Height</label>
+            <p className={DESC_CLASS}>Spacing between lines (1.0–2.0)</p>
+          </div>
+          <NumberSetting id="s-lineheight" value={lineHeight} min={1.0} max={2.0} step={0.1} onChange={setLineHeight} />
+        </SettingRow>
+      </SettingsGroup>
+
+      <SettingsGroup label="Cursor">
+        <SettingRow>
+          <div>
+            <p className={LABEL_CLASS}>Cursor Style</p>
+            <p className={DESC_CLASS}>Shape of the terminal cursor</p>
+          </div>
+          <SegmentedControl<CursorStyle>
+            id="s-cursor"
+            value={cursorStyle}
+            onChange={setCursorStyle}
+            options={[
+              { value: "bar", label: "Bar" },
+              { value: "block", label: "Block" },
+              { value: "underline", label: "Underline" },
+            ]}
+          />
+        </SettingRow>
+
+        <SettingRow>
+          <div>
+            <label htmlFor="s-blink" className={LABEL_CLASS}>Cursor Blink</label>
+            <p className={DESC_CLASS}>Animate the cursor</p>
+          </div>
+          <Toggle id="s-blink" checked={cursorBlink} onChange={setCursorBlink} />
+        </SettingRow>
+      </SettingsGroup>
+
+      <SettingsGroup label="History">
+        <SettingRow>
+          <div>
+            <label htmlFor="s-scrollback" className={LABEL_CLASS}>Scrollback Buffer</label>
+            <p className={DESC_CLASS}>Number of lines to keep in history (500–100,000)</p>
+          </div>
+          <NumberSetting id="s-scrollback" value={scrollback} min={500} max={100000} step={500} onChange={setScrollback} />
+        </SettingRow>
+        <p className="px-1 text-[length:var(--text-xs)] text-text-muted">
+          Terminal settings apply to new terminals. Existing terminals keep their current settings.
+        </p>
+      </SettingsGroup>
+    </>
+  );
+}
+
+function TransferSettings() {
+  const transferConcurrency = useSettingsStore((s) => s.transferConcurrency);
+  const setConcurrency = useSettingsStore((s) => s.setTransferConcurrency);
+
+  return (
+    <SettingsGroup>
+      <SettingRow>
+        <div>
+          <label htmlFor="s-concurrency" className={LABEL_CLASS}>Concurrent Transfers</label>
+          <p className={DESC_CLASS}>Maximum simultaneous file transfers (1–10)</p>
+        </div>
+        <NumberSetting id="s-concurrency" value={transferConcurrency} min={1} max={10} step={1} onChange={setConcurrency} />
+      </SettingRow>
+    </SettingsGroup>
+  );
+}
+
+function UpdateSettings() {
+  return (
+    <SettingsGroup>
+      <UpdateChecker />
+    </SettingsGroup>
+  );
+}
+
 // ─── Sub-components ──────────────────────────────────────────────────────────
+
+/** A labelled group of setting cards, mirroring the "THEME" / "INTERFACE" sections. */
+function SettingsGroup({ label, children }: { label?: string; children: React.ReactNode }) {
+  return (
+    <section className="mb-6 last:mb-0">
+      {label && (
+        <h2 className="px-1 mb-3 text-[length:var(--text-2xs)] font-semibold uppercase tracking-wider text-text-muted">
+          {label}
+        </h2>
+      )}
+      <div className="flex flex-col gap-2">{children}</div>
+    </section>
+  );
+}
 
 function SettingRow({ children }: { children: React.ReactNode }) {
   return (
-    <div className="flex items-center justify-between gap-4 px-4 py-3 rounded-lg bg-bg-surface border border-border/50">
+    <div className="flex items-center justify-between gap-4 px-4 py-3 rounded-xl bg-bg-surface border border-border/50">
       {children}
     </div>
   );
@@ -207,6 +291,46 @@ function Toggle({ id, checked, onChange }: { id: string; checked: boolean; onCha
         ].join(" ")}
       />
     </button>
+  );
+}
+
+/** Segmented toggle for small option sets (e.g. theme, cursor style). */
+function SegmentedControl<T extends string>({ id, value, onChange, options }: {
+  id?: string;
+  value: T;
+  onChange: (v: T) => void;
+  options: { value: T; label: string }[];
+}) {
+  return (
+    <div
+      id={id}
+      role="radiogroup"
+      className="inline-flex shrink-0 gap-0.5 p-0.5 rounded-lg bg-bg-base border border-border"
+    >
+      {options.map((opt) => {
+        const selected = opt.value === value;
+        return (
+          <button
+            key={opt.value}
+            type="button"
+            role="radio"
+            aria-checked={selected}
+            data-testid={id ? `${id}-${opt.value}` : undefined}
+            onClick={() => onChange(opt.value)}
+            className={[
+              "px-3 py-1.5 rounded-md text-[length:var(--text-sm)] font-medium",
+              "transition-colors duration-[var(--duration-fast)]",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+              selected
+                ? "bg-bg-overlay text-text-primary shadow-[var(--shadow-sm)]"
+                : "text-text-muted hover:text-text-primary",
+            ].join(" ")}
+          >
+            {opt.label}
+          </button>
+        );
+      })}
+    </div>
   );
 }
 
@@ -291,7 +415,7 @@ function UpdateChecker() {
   }, []);
 
   return (
-    <div className="px-4 py-3 rounded-lg bg-bg-surface border border-border/50">
+    <div className="px-4 py-3 rounded-xl bg-bg-surface border border-border/50">
       <div className="flex items-center justify-between gap-4">
         <div>
           <p className={LABEL_CLASS}>App Version</p>

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -394,6 +394,7 @@ function AppearanceSettings() {
         </div>
         <CustomSelect
           id="s-interface-font"
+          data-testid="s-interface-font"
           value={interfaceFont}
           onChange={setInterfaceFont}
           options={fontOptions}
@@ -497,6 +498,7 @@ function TerminalSettings() {
           </div>
           <CustomSelect
             id="s-fontfamily"
+            data-testid="s-fontfamily"
             value={fontFamily}
             onChange={setFontFamily}
             options={termFontOptions}

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import { useSettingsStore } from "../../stores/settings-store";
-import { RefreshCw, CheckCircle2, AlertCircle, Download, Palette, SquareTerminal, ArrowUpDown } from "lucide-react";
+import { RefreshCw, CheckCircle2, AlertCircle, Download, Palette, SquareTerminal, ArrowUpDown, Info, ExternalLink } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import type { CursorStyle, ThemeMode } from "../../stores/settings-store";
 
@@ -16,24 +16,26 @@ const INPUT_CLASS = [
   "transition-[border-color,box-shadow] duration-[var(--duration-fast)]",
 ].join(" ");
 
+const REPO_URL = "https://github.com/macnev2013/anySCP";
+
 // ─── Sections ─────────────────────────────────────────────────────────────────
 // Each settings category is a section here. To add a new category, add an entry
 // to SECTIONS, a description, and render its content in <SectionContent />.
 
-type SectionId = "appearance" | "terminal" | "transfers" | "updates";
+type SectionId = "appearance" | "terminal" | "transfers" | "about";
 
 const SECTIONS: { id: SectionId; label: string; icon: LucideIcon }[] = [
   { id: "appearance", label: "Appearance", icon: Palette },
   { id: "terminal", label: "Terminal", icon: SquareTerminal },
   { id: "transfers", label: "Transfers", icon: ArrowUpDown },
-  { id: "updates", label: "Updates", icon: Download },
+  { id: "about", label: "About & Updates", icon: Info },
 ];
 
 const SECTION_DESCRIPTIONS: Record<SectionId, string> = {
   appearance: "Theme and interface look.",
   terminal: "Font, cursor, and scrollback history.",
   transfers: "Control how files are transferred.",
-  updates: "Check for and install app updates.",
+  about: "App information, links, and updates.",
 };
 
 // ─── Component ───────────────────────────────────────────────────────────────
@@ -114,8 +116,8 @@ function SectionContent({ section }: { section: SectionId }) {
       return <TerminalSettings />;
     case "transfers":
       return <TransferSettings />;
-    case "updates":
-      return <UpdateSettings />;
+    case "about":
+      return <AboutSettings />;
   }
 }
 
@@ -237,11 +239,72 @@ function TransferSettings() {
   );
 }
 
-function UpdateSettings() {
+function AboutSettings() {
   return (
-    <SettingsGroup>
-      <UpdateChecker />
-    </SettingsGroup>
+    <>
+      <SettingsGroup label="About">
+        <AboutCard />
+      </SettingsGroup>
+      <SettingsGroup label="Updates">
+        <UpdateChecker />
+      </SettingsGroup>
+    </>
+  );
+}
+
+function AboutCard() {
+  const [appVersion, setAppVersion] = useState<string | null>(null);
+
+  // Real app version (injected from git tags at build).
+  useEffect(() => {
+    void (async () => {
+      try {
+        const { getVersion } = await import("@tauri-apps/api/app");
+        setAppVersion(await getVersion());
+      } catch { /* best-effort */ }
+    })();
+  }, []);
+
+  const openRepo = useCallback(async () => {
+    try {
+      const { openUrl } = await import("@tauri-apps/plugin-opener");
+      await openUrl(REPO_URL);
+    } catch { /* best-effort */ }
+  }, []);
+
+  return (
+    <div className="px-4 py-3 rounded-xl bg-bg-surface border border-border/50">
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <p className="text-[length:var(--text-base)] font-semibold text-text-primary">anySCP</p>
+          <p className={DESC_CLASS}>A modern desktop client for SSH, SFTP, and S3</p>
+        </div>
+        <span className="shrink-0 text-[length:var(--text-xs)] tabular-nums text-text-muted">
+          {appVersion ? `v${appVersion}` : ""}
+        </span>
+      </div>
+
+      <div className="mt-3 pt-3 border-t border-border/50 flex items-center justify-between gap-4">
+        <div>
+          <p className={LABEL_CLASS}>Repository</p>
+          <p className={DESC_CLASS}>Source code, issues, and releases on GitHub</p>
+        </div>
+        <button
+          onClick={() => void openRepo()}
+          className={[
+            "flex items-center gap-1.5 px-3 py-1.5 rounded-lg shrink-0",
+            "text-[length:var(--text-sm)] font-medium",
+            "bg-bg-base border border-border text-text-secondary",
+            "hover:text-text-primary hover:border-border-focus",
+            "transition-all duration-[var(--duration-fast)]",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+          ].join(" ")}
+        >
+          <ExternalLink size={13} strokeWidth={2} />
+          GitHub
+        </button>
+      </div>
+    </div>
   );
 }
 

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -1,6 +1,7 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { useSettingsStore } from "../../stores/settings-store";
-import { RefreshCw, CheckCircle2, AlertCircle, Download, Palette, SquareTerminal, ArrowUpDown, Info, ExternalLink } from "lucide-react";
+import { CustomSelect, type SelectOption } from "../shared/CustomSelect";
+import { RefreshCw, CheckCircle2, AlertCircle, Download, Palette, SquareTerminal, ArrowUpDown, Info, ExternalLink, Check } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import type { CursorStyle, ThemeMode } from "../../stores/settings-store";
 
@@ -121,11 +122,126 @@ function SectionContent({ section }: { section: SectionId }) {
   }
 }
 
+// Candidates for the interface font. Entries without a `family` are always
+// offered (Geist is bundled; System UI is a generic). Entries with a `family`
+// are only shown when that font is actually installed (see availableFonts),
+// since an unavailable font silently falls back to the system default.
+const INTERFACE_FONT_CANDIDATES: { value: string; label: string; family?: string }[] = [
+  { value: "'Geist', system-ui, sans-serif", label: "Geist (Default)" },
+  { value: "system-ui, sans-serif", label: "System UI" },
+  { value: "'Arial', system-ui, sans-serif", label: "Arial", family: "Arial" },
+  { value: "'Avenir', system-ui, sans-serif", label: "Avenir", family: "Avenir" },
+  { value: "'Avenir Next', system-ui, sans-serif", label: "Avenir Next", family: "Avenir Next" },
+  { value: "'Calibri', system-ui, sans-serif", label: "Calibri", family: "Calibri" },
+  { value: "'Cantarell', system-ui, sans-serif", label: "Cantarell", family: "Cantarell" },
+  { value: "'DejaVu Sans', system-ui, sans-serif", label: "DejaVu Sans", family: "DejaVu Sans" },
+  { value: "'Fira Sans', system-ui, sans-serif", label: "Fira Sans", family: "Fira Sans" },
+  { value: "'FreeSans', system-ui, sans-serif", label: "FreeSans", family: "FreeSans" },
+  { value: "'Helvetica', system-ui, sans-serif", label: "Helvetica", family: "Helvetica" },
+  { value: "'Helvetica Neue', system-ui, sans-serif", label: "Helvetica Neue", family: "Helvetica Neue" },
+  { value: "'Inter', system-ui, sans-serif", label: "Inter", family: "Inter" },
+  { value: "'Lato', system-ui, sans-serif", label: "Lato", family: "Lato" },
+  { value: "'Liberation Sans', system-ui, sans-serif", label: "Liberation Sans", family: "Liberation Sans" },
+  { value: "'Lucida Grande', system-ui, sans-serif", label: "Lucida Grande", family: "Lucida Grande" },
+  { value: "'Nimbus Sans', system-ui, sans-serif", label: "Nimbus Sans", family: "Nimbus Sans" },
+  { value: "'Noto Sans', system-ui, sans-serif", label: "Noto Sans", family: "Noto Sans" },
+  { value: "'Open Sans', system-ui, sans-serif", label: "Open Sans", family: "Open Sans" },
+  { value: "'Roboto', system-ui, sans-serif", label: "Roboto", family: "Roboto" },
+  { value: "'Segoe UI', system-ui, sans-serif", label: "Segoe UI", family: "Segoe UI" },
+  { value: "'Source Sans 3', system-ui, sans-serif", label: "Source Sans 3", family: "Source Sans 3" },
+  { value: "'Source Sans Pro', system-ui, sans-serif", label: "Source Sans Pro", family: "Source Sans Pro" },
+  { value: "'Tahoma', system-ui, sans-serif", label: "Tahoma", family: "Tahoma" },
+  { value: "'Trebuchet MS', system-ui, sans-serif", label: "Trebuchet MS", family: "Trebuchet MS" },
+  { value: "'Ubuntu', system-ui, sans-serif", label: "Ubuntu", family: "Ubuntu" },
+  { value: "'Verdana', system-ui, sans-serif", label: "Verdana", family: "Verdana" },
+  { value: "'Work Sans', system-ui, sans-serif", label: "Work Sans", family: "Work Sans" },
+];
+
+/**
+ * Whether a named font is actually installed. document.fonts.check() is
+ * unreliable (it returns true for unknown names), so measure a test string:
+ * if rendering with the font matches every generic fallback exactly, the font
+ * isn't present and the browser fell back.
+ */
+function isFontAvailable(family: string): boolean {
+  if (typeof document === "undefined") return false;
+  const ctx = document.createElement("canvas").getContext("2d");
+  if (!ctx) return false;
+  const sample = "mmmmmmmmmmlli MWQ 0123";
+  const size = "72px";
+  for (const base of ["monospace", "serif", "sans-serif"]) {
+    ctx.font = `${size} ${base}`;
+    const baseWidth = ctx.measureText(sample).width;
+    ctx.font = `${size} "${family}", ${base}`;
+    if (ctx.measureText(sample).width !== baseWidth) return true;
+  }
+  return false;
+}
+
+/** Filter the candidates down to those actually available on this system. */
+function computeFontOptions(): SelectOption[] {
+  return INTERFACE_FONT_CANDIDATES
+    .filter((f) => !f.family || isFontAvailable(f.family))
+    .map(({ value, label }) => ({ value, label }));
+}
+
+const ACCENT_PRESETS: { name: string; hue: number }[] = [
+  { name: "Blue", hue: 250 },
+  { name: "Indigo", hue: 277 },
+  { name: "Violet", hue: 300 },
+  { name: "Pink", hue: 350 },
+  { name: "Red", hue: 25 },
+  { name: "Orange", hue: 70 },
+  { name: "Green", hue: 150 },
+  { name: "Teal", hue: 195 },
+];
+
 function AppearanceSettings() {
   const themeMode = useSettingsStore((s) => s.themeMode);
   const setThemeMode = useSettingsStore((s) => s.setThemeMode);
+  const accentHue = useSettingsStore((s) => s.accentHue);
+  const setAccentHue = useSettingsStore((s) => s.setAccentHue);
+  const accentCustom = useSettingsStore((s) => s.accentCustom);
+  const setAccentCustom = useSettingsStore((s) => s.setAccentCustom);
+  const interfaceFont = useSettingsStore((s) => s.interfaceFont);
+  const setInterfaceFont = useSettingsStore((s) => s.setInterfaceFont);
+
+  const [availableFonts, setAvailableFonts] = useState<SelectOption[]>(computeFontOptions);
+  // Re-check once web fonts have finished loading (Geist arrives via @font-face).
+  useEffect(() => {
+    let cancelled = false;
+    document.fonts?.ready?.then(() => { if (!cancelled) setAvailableFonts(computeFontOptions()); }).catch(() => {});
+    return () => { cancelled = true; };
+  }, []);
+  // Keep the saved font selectable even if it isn't detected on this system.
+  const fontOptions = availableFonts.some((o) => o.value === interfaceFont)
+    ? availableFonts
+    : [{ value: interfaceFont, label: INTERFACE_FONT_CANDIDATES.find((c) => c.value === interfaceFont)?.label ?? "Current" }, ...availableFonts];
+
+  const [wheelOpen, setWheelOpen] = useState(false);
+  const customRef = useRef<HTMLDivElement>(null);
+  const isCustom = accentCustom !== null;
+  const working = accentCustom ?? { l: 0.70, c: 0.15, h: accentHue };
+  const workingColor = `oklch(${working.l} ${working.c} ${working.h})`;
+  const updateCustom = (patch: Partial<typeof working>) => setAccentCustom({ ...working, ...patch });
+
+  // Close the wheel popover on outside click / Escape.
+  useEffect(() => {
+    if (!wheelOpen) return;
+    const onDown = (e: PointerEvent) => {
+      if (customRef.current && !customRef.current.contains(e.target as Node)) setWheelOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") setWheelOpen(false); };
+    document.addEventListener("pointerdown", onDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("pointerdown", onDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [wheelOpen]);
 
   return (
+    <>
     <SettingsGroup label="Theme">
       <SettingRow>
         <div>
@@ -142,7 +258,179 @@ function AppearanceSettings() {
           ]}
         />
       </SettingRow>
+
+      <SettingRow>
+        <div>
+          <p className={LABEL_CLASS}>Accent Color</p>
+          <p className={DESC_CLASS}>Used for buttons, links, and active states</p>
+        </div>
+        <div className="flex items-center gap-2.5 shrink-0">
+          {ACCENT_PRESETS.map((preset) => {
+            const selected = !isCustom && accentHue === preset.hue;
+            const color = `oklch(0.70 0.15 ${preset.hue})`;
+            return (
+              <button
+                key={preset.hue}
+                type="button"
+                title={preset.name}
+                aria-label={preset.name}
+                aria-pressed={selected}
+                data-testid={`s-accent-${preset.hue}`}
+                onClick={() => setAccentHue(preset.hue)}
+                className="relative flex items-center justify-center w-6 h-6 rounded-full shrink-0 transition-transform duration-[var(--duration-fast)] hover:scale-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                style={{
+                  backgroundColor: color,
+                  boxShadow: selected ? `0 0 0 2px var(--color-bg-surface), 0 0 0 4px ${color}` : undefined,
+                }}
+              >
+                {selected && <Check size={13} strokeWidth={3} className="text-white" />}
+              </button>
+            );
+          })}
+
+          {/* Custom — a rainbow swatch that opens the hue wheel */}
+          <div className="relative" ref={customRef}>
+            <button
+              type="button"
+              title="Custom"
+              aria-label="Custom color"
+              aria-haspopup="dialog"
+              aria-expanded={wheelOpen}
+              aria-pressed={isCustom}
+              data-testid="s-accent-custom"
+              onClick={() => setWheelOpen((o) => !o)}
+              className="relative flex items-center justify-center w-6 h-6 rounded-full shrink-0 transition-transform duration-[var(--duration-fast)] hover:scale-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              style={{
+                background: isCustom
+                  ? workingColor
+                  : "conic-gradient(oklch(0.70 0.15 0), oklch(0.70 0.15 60), oklch(0.70 0.15 120), oklch(0.70 0.15 180), oklch(0.70 0.15 240), oklch(0.70 0.15 300), oklch(0.70 0.15 360))",
+                boxShadow: isCustom ? `0 0 0 2px var(--color-bg-surface), 0 0 0 4px ${workingColor}` : undefined,
+              }}
+            >
+              {isCustom && <Check size={13} strokeWidth={3} className="text-white [filter:drop-shadow(0_1px_1px_rgb(0_0_0/0.5))]" />}
+            </button>
+
+            {wheelOpen && (
+              <div
+                role="dialog"
+                aria-label="Custom accent color"
+                className="absolute right-0 top-full mt-2 z-50 flex flex-col items-center gap-2 p-3 rounded-xl bg-bg-overlay border border-border shadow-[var(--shadow-lg)]"
+              >
+                <HueWheel
+                  hue={working.h}
+                  l={working.l}
+                  c={working.c}
+                  onChange={(h) => updateCustom({ h })}
+                  size={140}
+                />
+                <div className="w-full flex flex-col gap-2.5">
+                  <label className="flex flex-col gap-1">
+                    <span className="text-[length:var(--text-2xs)] uppercase tracking-wider text-text-muted">Lightness</span>
+                    <input
+                      type="range" min={0.45} max={0.85} step={0.01} value={working.l}
+                      onChange={(e) => updateCustom({ l: Number(e.target.value) })}
+                      className="w-full h-1.5 cursor-pointer"
+                      style={{ accentColor: workingColor }}
+                    />
+                  </label>
+                  <label className="flex flex-col gap-1">
+                    <span className="text-[length:var(--text-2xs)] uppercase tracking-wider text-text-muted">Saturation</span>
+                    <input
+                      type="range" min={0} max={0.3} step={0.005} value={working.c}
+                      onChange={(e) => updateCustom({ c: Number(e.target.value) })}
+                      className="w-full h-1.5 cursor-pointer"
+                      style={{ accentColor: workingColor }}
+                    />
+                  </label>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </SettingRow>
     </SettingsGroup>
+
+    <SettingsGroup label="Interface">
+      <SettingRow>
+        <div>
+          <p className={LABEL_CLASS}>Interface Font</p>
+          <p className={DESC_CLASS}>Font for menus, labels, and panels</p>
+        </div>
+        <CustomSelect
+          id="s-interface-font"
+          value={interfaceFont}
+          onChange={setInterfaceFont}
+          options={fontOptions}
+          className="w-44"
+        />
+      </SettingRow>
+    </SettingsGroup>
+    </>
+  );
+}
+
+/** Circular hue picker — click/drag around the ring to set the hue.
+ *  Ring + thumb colours use the given lightness/chroma so the preview is honest
+ *  (e.g. at zero chroma the ring turns gray). */
+function HueWheel({ hue, onChange, size = 96, l = 0.70, c = 0.15 }: {
+  hue: number; onChange: (h: number) => void; size?: number; l?: number; c?: number;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  const setFromPointer = useCallback((clientX: number, clientY: number) => {
+    const el = ref.current;
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    const dx = clientX - (rect.left + rect.width / 2);
+    const dy = clientY - (rect.top + rect.height / 2);
+    let deg = Math.atan2(dx, -dy) * (180 / Math.PI);
+    if (deg < 0) deg += 360;
+    onChange(Math.round(deg) % 360);
+  }, [onChange]);
+
+  const r = size / 2;
+  const ringWidth = 14;
+  const tr = r - ringWidth / 2; // thumb track radius (centre of the ring band)
+  const rad = (hue * Math.PI) / 180;
+  const thumbX = r + tr * Math.sin(rad);
+  const thumbY = r - tr * Math.cos(rad);
+
+  const stops: string[] = [];
+  for (let d = 0; d <= 360; d += 15) stops.push(`oklch(${l} ${c} ${d}) ${d}deg`);
+
+  return (
+    <div
+      ref={ref}
+      role="slider"
+      aria-label="Accent hue"
+      aria-valuemin={0}
+      aria-valuemax={360}
+      aria-valuenow={hue}
+      tabIndex={0}
+      onPointerDown={(e) => {
+        e.preventDefault();
+        e.currentTarget.setPointerCapture(e.pointerId);
+        setFromPointer(e.clientX, e.clientY);
+      }}
+      onPointerMove={(e) => {
+        if (e.buttons === 0) return;
+        setFromPointer(e.clientX, e.clientY);
+      }}
+      onKeyDown={(e) => {
+        if (e.key === "ArrowRight" || e.key === "ArrowUp") { e.preventDefault(); onChange((hue + 1) % 360); }
+        if (e.key === "ArrowLeft" || e.key === "ArrowDown") { e.preventDefault(); onChange((hue + 359) % 360); }
+      }}
+      className="relative shrink-0 rounded-full cursor-pointer touch-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      style={{ width: size, height: size, background: `conic-gradient(${stops.join(", ")})` }}
+    >
+      {/* Donut hole — matches the card surface so the wheel reads as a ring */}
+      <div className="absolute rounded-full bg-bg-overlay pointer-events-none" style={{ inset: ringWidth }} />
+      {/* Thumb */}
+      <span
+        className="absolute w-4 h-4 rounded-full border-2 border-white shadow-[var(--shadow-md)] pointer-events-none -translate-x-1/2 -translate-y-1/2"
+        style={{ left: thumbX, top: thumbY, backgroundColor: `oklch(${l} ${c} ${hue})` }}
+      />
+    </div>
   );
 }
 

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -368,7 +368,8 @@ function SegmentedControl<T extends string>({ id, value, onChange, options }: {
     <div
       id={id}
       role="radiogroup"
-      className="inline-flex shrink-0 gap-0.5 p-0.5 rounded-lg bg-bg-base border border-border"
+      className="inline-grid shrink-0 gap-0.5 p-0.5 rounded-lg bg-bg-base border border-border"
+      style={{ gridTemplateColumns: `repeat(${options.length}, 1fr)` }}
     >
       {options.map((opt) => {
         const selected = opt.value === value;
@@ -381,7 +382,7 @@ function SegmentedControl<T extends string>({ id, value, onChange, options }: {
             data-testid={id ? `${id}-${opt.value}` : undefined}
             onClick={() => onChange(opt.value)}
             className={[
-              "px-3 py-1.5 rounded-md text-[length:var(--text-sm)] font-medium",
+              "px-3 py-1.5 rounded-md text-center text-[length:var(--text-sm)] font-medium",
               "transition-colors duration-[var(--duration-fast)]",
               "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
               selected

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -39,10 +39,15 @@ const SECTION_DESCRIPTIONS: Record<SectionId, string> = {
   about: "App information, links, and updates.",
 };
 
+// Remember the last-open section across tab switches. The settings page
+// unmounts when another tab is active, so component state alone would reset.
+let lastSettingsSection: SectionId = "appearance";
+
 // ─── Component ───────────────────────────────────────────────────────────────
 
 export function SettingsPage() {
-  const [active, setActive] = useState<SectionId>("appearance");
+  const [active, setActive] = useState<SectionId>(() => lastSettingsSection);
+  const selectSection = (id: SectionId) => { lastSettingsSection = id; setActive(id); };
   const activeSection = SECTIONS.find((s) => s.id === active);
 
   return (
@@ -64,7 +69,7 @@ export function SettingsPage() {
                 type="button"
                 data-testid={`settings-nav-${id}`}
                 aria-current={isActive ? "page" : undefined}
-                onClick={() => setActive(id)}
+                onClick={() => selectSection(id)}
                 className={[
                   "flex items-center gap-2.5 px-3 py-2 rounded-lg text-left",
                   "text-[length:var(--text-sm)] font-medium",
@@ -157,6 +162,31 @@ const INTERFACE_FONT_CANDIDATES: { value: string; label: string; family?: string
   { value: "'Work Sans', system-ui, sans-serif", label: "Work Sans", family: "Work Sans" },
 ];
 
+// Monospace candidates for the terminal. The default matches the store's
+// terminalFontFamily so it selects correctly; JetBrains Mono is bundled.
+const TERMINAL_FONT_CANDIDATES: FontCandidate[] = [
+  { value: "'JetBrains Mono', 'Fira Code', 'SF Mono', Menlo, monospace", label: "JetBrains Mono (Default)" },
+  { value: "monospace", label: "System Monospace" },
+  { value: "'Cascadia Code', monospace", label: "Cascadia Code", family: "Cascadia Code" },
+  { value: "'Cascadia Mono', monospace", label: "Cascadia Mono", family: "Cascadia Mono" },
+  { value: "'Consolas', monospace", label: "Consolas", family: "Consolas" },
+  { value: "'Courier New', monospace", label: "Courier New", family: "Courier New" },
+  { value: "'DejaVu Sans Mono', monospace", label: "DejaVu Sans Mono", family: "DejaVu Sans Mono" },
+  { value: "'Fira Code', monospace", label: "Fira Code", family: "Fira Code" },
+  { value: "'Fira Mono', monospace", label: "Fira Mono", family: "Fira Mono" },
+  { value: "'Hack', monospace", label: "Hack", family: "Hack" },
+  { value: "'IBM Plex Mono', monospace", label: "IBM Plex Mono", family: "IBM Plex Mono" },
+  { value: "'Inconsolata', monospace", label: "Inconsolata", family: "Inconsolata" },
+  { value: "'Liberation Mono', monospace", label: "Liberation Mono", family: "Liberation Mono" },
+  { value: "'Menlo', monospace", label: "Menlo", family: "Menlo" },
+  { value: "'Monaco', monospace", label: "Monaco", family: "Monaco" },
+  { value: "'Noto Sans Mono', monospace", label: "Noto Sans Mono", family: "Noto Sans Mono" },
+  { value: "'Roboto Mono', monospace", label: "Roboto Mono", family: "Roboto Mono" },
+  { value: "'SF Mono', monospace", label: "SF Mono", family: "SF Mono" },
+  { value: "'Source Code Pro', monospace", label: "Source Code Pro", family: "Source Code Pro" },
+  { value: "'Ubuntu Mono', monospace", label: "Ubuntu Mono", family: "Ubuntu Mono" },
+];
+
 /**
  * Whether a named font is actually installed. document.fonts.check() is
  * unreliable (it returns true for unknown names), so measure a test string:
@@ -178,11 +208,27 @@ function isFontAvailable(family: string): boolean {
   return false;
 }
 
-/** Filter the candidates down to those actually available on this system. */
-function computeFontOptions(): SelectOption[] {
-  return INTERFACE_FONT_CANDIDATES
+type FontCandidate = { value: string; label: string; family?: string };
+
+/** Filter candidates down to those actually installed on this system. */
+function filterInstalledFonts(candidates: FontCandidate[]): SelectOption[] {
+  return candidates
     .filter((f) => !f.family || isFontAvailable(f.family))
     .map(({ value, label }) => ({ value, label }));
+}
+
+/** Font-picker options: installed candidates, re-checked once web fonts load,
+ *  with the current value kept selectable even if it isn't detected. */
+function useInstalledFontOptions(candidates: FontCandidate[], current: string): SelectOption[] {
+  const [available, setAvailable] = useState<SelectOption[]>(() => filterInstalledFonts(candidates));
+  useEffect(() => {
+    let cancelled = false;
+    document.fonts?.ready?.then(() => { if (!cancelled) setAvailable(filterInstalledFonts(candidates)); }).catch(() => {});
+    return () => { cancelled = true; };
+  }, [candidates]);
+  if (available.some((o) => o.value === current)) return available;
+  const cur = candidates.find((c) => c.value === current);
+  return [{ value: current, label: cur?.label ?? "Current" }, ...available];
 }
 
 const ACCENT_PRESETS: { name: string; hue: number }[] = [
@@ -206,17 +252,7 @@ function AppearanceSettings() {
   const interfaceFont = useSettingsStore((s) => s.interfaceFont);
   const setInterfaceFont = useSettingsStore((s) => s.setInterfaceFont);
 
-  const [availableFonts, setAvailableFonts] = useState<SelectOption[]>(computeFontOptions);
-  // Re-check once web fonts have finished loading (Geist arrives via @font-face).
-  useEffect(() => {
-    let cancelled = false;
-    document.fonts?.ready?.then(() => { if (!cancelled) setAvailableFonts(computeFontOptions()); }).catch(() => {});
-    return () => { cancelled = true; };
-  }, []);
-  // Keep the saved font selectable even if it isn't detected on this system.
-  const fontOptions = availableFonts.some((o) => o.value === interfaceFont)
-    ? availableFonts
-    : [{ value: interfaceFont, label: INTERFACE_FONT_CANDIDATES.find((c) => c.value === interfaceFont)?.label ?? "Current" }, ...availableFonts];
+  const fontOptions = useInstalledFontOptions(INTERFACE_FONT_CANDIDATES, interfaceFont);
 
   const [wheelOpen, setWheelOpen] = useState(false);
   const customRef = useRef<HTMLDivElement>(null);
@@ -446,16 +482,34 @@ function TerminalSettings() {
   const setCursorBlink = useSettingsStore((s) => s.setTerminalCursorBlink);
   const setLineHeight = useSettingsStore((s) => s.setTerminalLineHeight);
   const setScrollback = useSettingsStore((s) => s.setTerminalScrollback);
+  const fontFamily = useSettingsStore((s) => s.terminalFontFamily);
+  const setFontFamily = useSettingsStore((s) => s.setTerminalFontFamily);
+
+  const termFontOptions = useInstalledFontOptions(TERMINAL_FONT_CANDIDATES, fontFamily);
 
   return (
     <>
       <SettingsGroup label="Font">
         <SettingRow>
           <div>
-            <label htmlFor="s-fontsize" className={LABEL_CLASS}>Font Size</label>
-            <p className={DESC_CLASS}>Size in pixels (8–32)</p>
+            <label htmlFor="s-fontfamily" className={LABEL_CLASS}>Font Family</label>
+            <p className={DESC_CLASS}>Monospace font used by terminals</p>
           </div>
-          <NumberSetting id="s-fontsize" value={fontSize} min={8} max={32} step={1} onChange={setFontSize} />
+          <CustomSelect
+            id="s-fontfamily"
+            value={fontFamily}
+            onChange={setFontFamily}
+            options={termFontOptions}
+            className="w-44"
+          />
+        </SettingRow>
+
+        <SettingRow>
+          <div>
+            <label htmlFor="s-fontsize" className={LABEL_CLASS}>Font Size</label>
+            <p className={DESC_CLASS}>Size in pixels (8–42)</p>
+          </div>
+          <RangeSetting id="s-fontsize" value={fontSize} min={8} max={42} step={1} unit="px" onChange={setFontSize} />
         </SettingRow>
 
         <SettingRow>
@@ -463,7 +517,7 @@ function TerminalSettings() {
             <label htmlFor="s-lineheight" className={LABEL_CLASS}>Line Height</label>
             <p className={DESC_CLASS}>Spacing between lines (1.0–2.0)</p>
           </div>
-          <NumberSetting id="s-lineheight" value={lineHeight} min={1.0} max={2.0} step={0.1} onChange={setLineHeight} />
+          <RangeSetting id="s-lineheight" value={lineHeight} min={1.0} max={2.0} step={0.1} decimals={1} onChange={setLineHeight} />
         </SettingRow>
       </SettingsGroup>
 
@@ -503,7 +557,7 @@ function TerminalSettings() {
           <NumberSetting id="s-scrollback" value={scrollback} min={500} max={100000} step={500} onChange={setScrollback} />
         </SettingRow>
         <p className="px-1 text-[length:var(--text-xs)] text-text-muted">
-          Terminal settings apply to new terminals. Existing terminals keep their current settings.
+          Changes apply to open terminals immediately.
         </p>
       </SettingsGroup>
     </>
@@ -656,7 +710,7 @@ function SegmentedControl<T extends string>({ id, value, onChange, options }: {
     <div
       id={id}
       role="radiogroup"
-      className="inline-grid shrink-0 gap-0.5 p-0.5 rounded-lg bg-bg-base border border-border"
+      className="inline-grid shrink-0 gap-1 p-1 rounded-lg bg-bg-base border border-border"
       style={{ gridTemplateColumns: `repeat(${options.length}, 1fr)` }}
     >
       {options.map((opt) => {
@@ -858,6 +912,38 @@ function UpdateChecker() {
           )}
         </div>
       </div>
+    </div>
+  );
+}
+
+/** Slider with a live value readout, for bounded numeric settings. */
+function RangeSetting({ id, value, min, max, step, decimals = 0, unit = "", onChange }: {
+  id: string;
+  value: number;
+  min: number;
+  max: number;
+  step: number;
+  decimals?: number;
+  unit?: string;
+  onChange: (v: number) => void;
+}) {
+  return (
+    <div className="flex items-center gap-3 shrink-0">
+      <input
+        id={id}
+        data-testid={id}
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+        className="w-36 h-1.5 cursor-pointer"
+        style={{ accentColor: "var(--color-accent)" }}
+      />
+      <span className="w-10 shrink-0 text-right text-[length:var(--text-sm)] tabular-nums text-text-secondary">
+        {value.toFixed(decimals)}{unit}
+      </span>
     </div>
   );
 }

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -58,23 +58,24 @@ function PillButton({
         aria-current={isActive ? "page" : undefined}
         aria-expanded={ariaExpanded}
         className={[
-          "relative flex items-center rounded-xl",
+          "relative flex items-center rounded-lg",
           "transition-all duration-[var(--duration-fast)]",
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-          expanded ? "w-full gap-2.5 px-2.5 h-9" : "justify-center w-9 h-9",
+          expanded ? "w-full gap-2.5 px-3 h-9" : "justify-center w-9 h-9",
           isActive
-            ? "bg-accent/15 text-accent border border-accent/40"
-            : "text-text-muted border border-transparent hover:text-text-primary hover:bg-bg-overlay hover:border-border/60",
+            ? "bg-bg-overlay text-text-primary border border-border/60 shadow-[var(--shadow-sm)]"
+            : "text-text-secondary border border-transparent hover:text-text-primary hover:bg-bg-overlay/50",
         ].join(" ")}
       >
-        <Icon size={17} strokeWidth={isActive ? 2 : 1.5} className="shrink-0" />
+        <Icon
+          size={17}
+          strokeWidth={isActive ? 2 : 1.6}
+          className={`shrink-0 ${isActive ? "text-accent" : "text-text-muted"}`}
+        />
 
         {/* Label — expanded only */}
         {expanded && (
-          <span className={[
-            "text-[length:var(--text-sm)] truncate",
-            isActive ? "font-semibold" : "font-medium",
-          ].join(" ")}>
+          <span className="text-[length:var(--text-sm)] font-medium truncate">
             {label}
           </span>
         )}
@@ -175,10 +176,10 @@ export function Sidebar() {
         data-sidebar-expanded={expanded}
         aria-label="Main navigation"
         className={[
-          "no-select flex flex-col shrink-0 h-full py-3",
+          "no-select flex flex-col shrink-0 h-[calc(100%-8px)] py-3",
           "bg-bg-surface border border-border/60 rounded-2xl",
           "transition-[width] duration-[var(--duration-base)] ease-[var(--ease-expo-out)]",
-          expanded ? "w-[168px] items-stretch px-2" : "w-[48px] items-center",
+          expanded ? "w-[208px] items-stretch px-3" : "w-[48px] items-center",
         ].join(" ")}
       >
         {/* Nav items */}

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -176,8 +176,8 @@ export function Sidebar() {
         data-sidebar-expanded={expanded}
         aria-label="Main navigation"
         className={[
-          "no-select flex flex-col shrink-0 h-[calc(100%-8px)] py-3",
-          "bg-bg-surface border border-border/60 rounded-2xl",
+          "no-select flex flex-col shrink-0 h-[calc(100%-16px)] py-3 ml-2 mt-2",
+          "bg-bg-surface border border-border/60 rounded-lg",
           "transition-[width] duration-[var(--duration-base)] ease-[var(--ease-expo-out)]",
           expanded ? "w-[208px] items-stretch px-3" : "w-[48px] items-center",
         ].join(" ")}

--- a/src/components/terminal/Terminal.tsx
+++ b/src/components/terminal/Terminal.tsx
@@ -94,6 +94,12 @@ export function Terminal({ sessionId }: TerminalProps) {
   const terminalRef = useRef<XTerm | null>(null);
   const fitAddonRef = useRef<FitAddon | null>(null);
   const themeMode = useSettingsStore((s) => s.themeMode);
+  const fontFamily = useSettingsStore((s) => s.terminalFontFamily);
+  const fontSize = useSettingsStore((s) => s.terminalFontSize);
+  const lineHeight = useSettingsStore((s) => s.terminalLineHeight);
+  const cursorStyle = useSettingsStore((s) => s.terminalCursorStyle);
+  const cursorBlink = useSettingsStore((s) => s.terminalCursorBlink);
+  const scrollback = useSettingsStore((s) => s.terminalScrollback);
 
   const settings = useSettingsStore.getState();
 
@@ -231,6 +237,21 @@ export function Terminal({ sessionId }: TerminalProps) {
       terminalRef.current.options.theme = getTerminalTheme();
     }
   }, [themeMode]);
+
+  // Apply appearance changes to the already-open terminal (not just new ones).
+  useEffect(() => {
+    const term = terminalRef.current;
+    if (!term) return;
+    term.options.fontFamily = fontFamily;
+    term.options.fontSize = fontSize;
+    term.options.lineHeight = lineHeight;
+    term.options.cursorStyle = cursorStyle;
+    term.options.cursorBlink = cursorBlink;
+    term.options.scrollback = scrollback;
+    // Re-fit so the new glyph metrics recompute rows/cols, then repaint.
+    fitAddonRef.current?.fit();
+    term.refresh(0, term.rows - 1);
+  }, [fontFamily, fontSize, lineHeight, cursorStyle, cursorBlink, scrollback]);
 
   return (
     <div

--- a/src/stores/settings-store.ts
+++ b/src/stores/settings-store.ts
@@ -157,7 +157,7 @@ export const useSettingsStore = create<SettingsState>((set) => ({
   },
 
   setTerminalFontSize: (size) => {
-    const clamped = Math.max(8, Math.min(32, size));
+    const clamped = Math.max(8, Math.min(42, size));
     set({ terminalFontSize: clamped });
     persist("terminal_font_size", String(clamped));
   },

--- a/src/stores/settings-store.ts
+++ b/src/stores/settings-store.ts
@@ -3,9 +3,15 @@ import { create } from "zustand";
 export type CursorStyle = "block" | "bar" | "underline";
 export type ThemeMode = "dark" | "light";
 
+/** Full custom accent colour in oklch components (lightness, chroma, hue). */
+export interface AccentCustom { l: number; c: number; h: number }
+
 interface SettingsState {
   // Appearance
   themeMode: ThemeMode;
+  accentHue: number;
+  accentCustom: AccentCustom | null;
+  interfaceFont: string;
 
   // Terminal appearance
   terminalFontSize: number;
@@ -23,6 +29,9 @@ interface SettingsState {
 
   // Actions
   setThemeMode: (mode: ThemeMode) => void;
+  setAccentHue: (hue: number) => void;
+  setAccentCustom: (custom: AccentCustom | null) => void;
+  setInterfaceFont: (font: string) => void;
   setTerminalFontSize: (size: number) => void;
   setTerminalFontFamily: (family: string) => void;
   setTerminalCursorStyle: (style: CursorStyle) => void;
@@ -36,6 +45,9 @@ interface SettingsState {
 // Defaults
 const DEFAULTS = {
   themeMode: "dark" as ThemeMode,
+  accentHue: 250,
+  accentCustom: null as AccentCustom | null,
+  interfaceFont: "'Geist', system-ui, sans-serif",
   terminalFontSize: 14,
   terminalFontFamily: "'JetBrains Mono', 'Fira Code', 'SF Mono', Menlo, monospace",
   terminalCursorStyle: "bar" as CursorStyle,
@@ -59,6 +71,46 @@ function initialThemeMode(): ThemeMode {
   return DEFAULTS.themeMode;
 }
 
+/**
+ * Seed the accent hue from the --accent-hue CSS variable injected by the Rust
+ * setup() hook before first paint (mirrors initialThemeMode), so the initial
+ * render matches the persisted accent and there's no flash. Falls back to the
+ * default when absent.
+ */
+function initialAccentHue(): number {
+  if (typeof document !== "undefined") {
+    const v = document.documentElement.style.getPropertyValue("--accent-hue").trim();
+    const n = Number(v);
+    if (v && !Number.isNaN(n)) return n;
+  }
+  return DEFAULTS.accentHue;
+}
+
+/** Seed the custom accent from the data-accent-custom attribute injected by Rust
+ *  before first paint (so a custom accent doesn't flash on startup). */
+function initialAccentCustom(): AccentCustom | null {
+  if (typeof document !== "undefined") {
+    const v = document.documentElement.dataset.accentCustom;
+    if (v) {
+      const parts = v.trim().split(/\s+/).map(Number);
+      if (parts.length === 3 && parts.every((n) => !Number.isNaN(n))) {
+        return { l: parts[0], c: parts[1], h: parts[2] };
+      }
+    }
+  }
+  return null;
+}
+
+/** Seed the interface font from the data-interface-font attribute injected by
+ *  Rust before first paint, so a custom UI font doesn't flash on startup. */
+function initialInterfaceFont(): string {
+  if (typeof document !== "undefined") {
+    const v = document.documentElement.dataset.interfaceFont;
+    if (v) return v;
+  }
+  return DEFAULTS.interfaceFont;
+}
+
 /** Persist a single setting to the backend. Fire-and-forget. */
 function persist(key: string, value: string) {
   void (async () => {
@@ -69,14 +121,39 @@ function persist(key: string, value: string) {
   })();
 }
 
+let accentPersistTimer: ReturnType<typeof setTimeout> | undefined;
+
 export const useSettingsStore = create<SettingsState>((set) => ({
   ...DEFAULTS,
   themeMode: initialThemeMode(),
+  accentHue: initialAccentHue(),
+  accentCustom: initialAccentCustom(),
+  interfaceFont: initialInterfaceFont(),
   loaded: false,
 
   setThemeMode: (mode) => {
     set({ themeMode: mode });
     persist("app_theme", mode);
+  },
+
+  setAccentHue: (hue) => {
+    // Choosing a preset hue clears any custom colour.
+    set({ accentHue: hue, accentCustom: null });
+    persist("app_accent_hue", String(hue));
+    persist("app_accent_custom", "");
+  },
+
+  setAccentCustom: (custom) => {
+    set({ accentCustom: custom });
+    // Debounce so dragging the wheel / sliders doesn't spam the backend.
+    if (accentPersistTimer) clearTimeout(accentPersistTimer);
+    const value = custom ? `${custom.l} ${custom.c} ${custom.h}` : "";
+    accentPersistTimer = setTimeout(() => persist("app_accent_custom", value), 200);
+  },
+
+  setInterfaceFont: (font) => {
+    set({ interfaceFont: font });
+    persist("app_interface_font", font);
   },
 
   setTerminalFontSize: (size) => {
@@ -134,6 +211,14 @@ export const useSettingsStore = create<SettingsState>((set) => ({
       for (const [key, value] of pairs) {
         switch (key) {
           case "app_theme": updates.themeMode = value === "light" ? "light" : DEFAULTS.themeMode; break;
+          case "app_accent_hue": updates.accentHue = Number(value) || DEFAULTS.accentHue; break;
+          case "app_accent_custom": {
+            const parts = value.trim().split(/\s+/).map(Number);
+            updates.accentCustom = parts.length === 3 && parts.every((n) => !Number.isNaN(n))
+              ? { l: parts[0], c: parts[1], h: parts[2] }
+              : null;
+            break;
+          }
           case "terminal_font_size": updates.terminalFontSize = Number(value) || DEFAULTS.terminalFontSize; break;
           case "terminal_font_family": updates.terminalFontFamily = value || DEFAULTS.terminalFontFamily; break;
           case "terminal_cursor_style": updates.terminalCursorStyle = (value as CursorStyle) || DEFAULTS.terminalCursorStyle; break;
@@ -141,6 +226,7 @@ export const useSettingsStore = create<SettingsState>((set) => ({
           case "terminal_line_height": updates.terminalLineHeight = Number(value) || DEFAULTS.terminalLineHeight; break;
           case "terminal_scrollback": updates.terminalScrollback = Number(value) || DEFAULTS.terminalScrollback; break;
           case "transfer_concurrency": updates.transferConcurrency = Number(value) || DEFAULTS.transferConcurrency; break;
+          case "app_interface_font": updates.interfaceFont = value || DEFAULTS.interfaceFont; break;
         }
       }
 

--- a/src/theme.css
+++ b/src/theme.css
@@ -71,10 +71,10 @@
   --color-text-muted:     oklch(0.595 0.015 264);
   --color-text-inverse:   oklch(0.145 0.015 264);
 
-  /* Accent */
-  --color-accent:       oklch(0.700 0.150 250);
-  --color-accent-hover: oklch(0.650 0.150 250);
-  --color-accent-muted: oklch(0.700 0.150 250 / 0.15);
+  /* Accent — hue is runtime-configurable via --accent-hue (see settings) */
+  --color-accent:       oklch(0.700 0.150 var(--accent-hue, 250));
+  --color-accent-hover: oklch(0.650 0.150 var(--accent-hue, 250));
+  --color-accent-muted: oklch(0.700 0.150 var(--accent-hue, 250) / 0.15);
 
   /* Status */
   --color-status-connected:    oklch(0.720 0.180 155);
@@ -84,8 +84,8 @@
 
   /* Semantic — border lifted ~0.13 above surfaces so edges are visible */
   --color-border:       oklch(0.320 0.012 264);
-  --color-border-focus: oklch(0.700 0.150 250);
-  --color-ring:         oklch(0.700 0.150 250 / 0.40);
+  --color-border-focus: oklch(0.700 0.150 var(--accent-hue, 250));
+  --color-ring:         oklch(0.700 0.150 var(--accent-hue, 250) / 0.40);
 
   /* Typography */
   --font-sans: 'Geist', system-ui, sans-serif;
@@ -136,9 +136,9 @@
   --color-text-muted:     oklch(0.555 0.016 260);
   --color-text-inverse:   oklch(0.985 0.003 255);
 
-  --color-accent:       oklch(0.575 0.170 250);
-  --color-accent-hover: oklch(0.520 0.170 250);
-  --color-accent-muted: oklch(0.575 0.170 250 / 0.14);
+  --color-accent:       oklch(0.575 0.170 var(--accent-hue, 250));
+  --color-accent-hover: oklch(0.520 0.170 var(--accent-hue, 250));
+  --color-accent-muted: oklch(0.575 0.170 var(--accent-hue, 250) / 0.14);
 
   --color-status-connected:    oklch(0.575 0.145 155);
   --color-status-connecting:   oklch(0.640 0.130 80);
@@ -146,8 +146,8 @@
   --color-status-disconnected: oklch(0.580 0.012 260);
 
   --color-border:       oklch(0.785 0.010 255);
-  --color-border-focus: oklch(0.575 0.170 250);
-  --color-ring:         oklch(0.575 0.170 250 / 0.28);
+  --color-border-focus: oklch(0.575 0.170 var(--accent-hue, 250));
+  --color-ring:         oklch(0.575 0.170 var(--accent-hue, 250) / 0.28);
 
   --shadow-sm:  0 1px 2px oklch(0.290 0.020 260 / 0.08);
   --shadow-md:  0 2px 10px oklch(0.290 0.020 260 / 0.10), 0 1px 2px oklch(0.290 0.020 260 / 0.06);

--- a/tests/e2e/specs/23-settings-persist.spec.ts
+++ b/tests/e2e/specs/23-settings-persist.spec.ts
@@ -7,6 +7,10 @@ async function gotoSettings(): Promise<void> {
     const nav = await $("[aria-label='Settings']");
     await nav.waitForClickable({ timeout: 10_000 });
     await nav.click();
+    // The settings page uses a sidebar; open the Terminal section to reach font size.
+    const terminalNav = await $("[data-testid='settings-nav-terminal']");
+    await terminalNav.waitForClickable({ timeout: 10_000 });
+    await terminalNav.click();
     await (await $("[data-testid='s-fontsize']")).waitForDisplayed({ timeout: 10_000 });
 }
 

--- a/tests/e2e/specs/23-settings-persist.spec.ts
+++ b/tests/e2e/specs/23-settings-persist.spec.ts
@@ -22,12 +22,17 @@ describe("settings persistence", () => {
     it("font size persists across an app restart", async () => {
         await gotoSettings();
 
-        const fontInput = await $("[data-testid='s-fontsize']");
-        await fontInput.click();
-        await browser.keys(["Control", "a"]);
-        await browser.keys(["Delete"]);
-        await fontInput.setValue("18");
-        await browser.keys(["Enter"]);
+        // Font size is a range slider; set its value via the native setter so
+        // React's onChange fires (typing/keys don't work on type=range).
+        await (await $("[data-testid='s-fontsize']")).waitForDisplayed({ timeout: 10_000 });
+        await browser.execute((val) => {
+            const node = document.querySelector("[data-testid='s-fontsize']") as HTMLInputElement | null;
+            if (!node) return;
+            const setter = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(node), "value")?.set;
+            setter?.call(node, val);
+            node.dispatchEvent(new Event("input", { bubbles: true }));
+            node.dispatchEvent(new Event("change", { bubbles: true }));
+        }, "18");
 
         await relaunchApp();
         await gotoSettings();

--- a/tests/e2e/specs/61-settings-appearance.spec.ts
+++ b/tests/e2e/specs/61-settings-appearance.spec.ts
@@ -1,0 +1,112 @@
+// Appearance settings: accent colour, interface/terminal fonts, and the
+// active-section memory all persist (or behave) as expected.
+
+import { expect } from "chai";
+import { relaunchApp, resetApp } from "../helpers/reset.js";
+
+async function openSettings(): Promise<void> {
+    const nav = await $("[aria-label='Settings']");
+    await nav.waitForClickable({ timeout: 10_000 });
+    await nav.click();
+    await (await $("[data-testid='settings-nav-appearance']")).waitForDisplayed({ timeout: 10_000 });
+}
+
+async function openSection(section: string): Promise<void> {
+    const tab = await $(`[data-testid='settings-nav-${section}']`);
+    await tab.waitForClickable({ timeout: 10_000 });
+    await tab.click();
+}
+
+/** Open a CustomSelect by trigger test id and pick an option by its value. */
+async function pickFromSelect(testid: string, optionValue: string): Promise<void> {
+    const trigger = await $(`[data-testid='${testid}']`);
+    await trigger.waitForClickable({ timeout: 10_000 });
+    await trigger.click();
+    // Option value can contain spaces/commas, so quote the attribute selector.
+    const option = await $(`[data-testid="${testid}-option-${optionValue}"]`);
+    await option.waitForClickable({ timeout: 10_000 });
+    await option.click();
+}
+
+async function selectedValue(testid: string): Promise<string | null> {
+    return (await $(`[data-testid='${testid}']`)).getAttribute("data-value");
+}
+
+describe("settings appearance", () => {
+    beforeEach(async () => {
+        await resetApp();
+    });
+
+    it("accent colour preset persists across a restart", async () => {
+        await openSettings();
+
+        // Default accent is Blue (hue 250); switch to Orange (hue 70).
+        const orange = await $("[data-testid='s-accent-70']");
+        await orange.waitForClickable({ timeout: 10_000 });
+        await orange.click();
+        await browser.waitUntil(
+            async () => (await orange.getAttribute("aria-pressed")) === "true",
+            { timeout: 5_000, timeoutMsg: "accent swatch did not become selected" },
+        );
+
+        await relaunchApp();
+        await openSettings();
+
+        const after = await $("[data-testid='s-accent-70']");
+        await after.waitForDisplayed({ timeout: 10_000 });
+        expect(await after.getAttribute("aria-pressed")).to.equal("true");
+    });
+
+    it("interface font persists across a restart", async () => {
+        await openSettings();
+
+        await pickFromSelect("s-interface-font", "system-ui, sans-serif");
+        await browser.waitUntil(
+            async () => (await selectedValue("s-interface-font")) === "system-ui, sans-serif",
+            { timeout: 5_000, timeoutMsg: "interface font was not applied" },
+        );
+
+        await relaunchApp();
+        await openSettings();
+
+        expect(await selectedValue("s-interface-font")).to.equal("system-ui, sans-serif");
+    });
+
+    it("terminal font persists across a restart", async () => {
+        await openSettings();
+        await openSection("terminal");
+
+        await pickFromSelect("s-fontfamily", "monospace");
+        await browser.waitUntil(
+            async () => (await selectedValue("s-fontfamily")) === "monospace",
+            { timeout: 5_000, timeoutMsg: "terminal font was not applied" },
+        );
+
+        await relaunchApp();
+        await openSettings();
+        await openSection("terminal");
+
+        expect(await selectedValue("s-fontfamily")).to.equal("monospace");
+    });
+
+    it("remembers the active section when switching away and back", async () => {
+        await openSettings();
+        await openSection("terminal");
+        const termNav = await $("[data-testid='settings-nav-terminal']");
+        expect(await termNav.getAttribute("aria-current")).to.equal("page");
+
+        // Switch to another page tab, then back to Settings.
+        const hosts = await $("[aria-label='Hosts']");
+        await hosts.waitForClickable({ timeout: 10_000 });
+        await hosts.click();
+        const settings = await $("[aria-label='Settings']");
+        await settings.waitForClickable({ timeout: 10_000 });
+        await settings.click();
+
+        // The Terminal section should still be active (not reset to Appearance).
+        const termNavAfter = await $("[data-testid='settings-nav-terminal']");
+        await termNavAfter.waitForDisplayed({ timeout: 10_000 });
+        expect(await termNavAfter.getAttribute("aria-current")).to.equal("page");
+        expect(await (await $("[data-testid='s-fontsize']")).isDisplayed()).to.equal(true);
+    });
+});


### PR DESCRIPTION
## Summary

Reworks the Settings page from a single scrolling page into a sidebar-navigated layout, and adds a set of appearance/theming options plus live-applying terminal settings.

## What's included

**Navigation & layout**
- Settings page now uses a left sidebar of categories (Appearance, Terminal, Transfers, About & Updates) with a content pane showing only the active category.
- Settings are grouped under labelled sections in spacious cards; segmented controls for theme and cursor style.
- The active section persists across tab switches.
- Main sidebar restyled to match the page cards (active item, radius, 16px window inset).

**Appearance / theming**
- **Accent color**: 8 preset swatches (hue-based, theme-adaptive) plus a custom picker (hue wheel + lightness/chroma sliders) supporting any colour, including gray and darker shades. Lightness is bounded so the accent stays visible in both themes.
- **Interface font**: pick the UI font (`--font-sans`); only fonts actually installed are listed (canvas-measurement detection) from a broad curated set.
- Accent and font are persisted and injected at startup (no flash).

**Terminal**
- **Font family picker** (installed monospace fonts only).
- Terminal appearance (font family/size, line height, cursor, scrollback) now applies **live to open terminals**, not just new ones.
- Font size and line height are sliders with a live value readout; max font size raised to 42px.

**About & Updates**
- The old "Updates" section is now "About & Updates" with app info and a link to the project repository, alongside the existing manual update check.

## Testing
- `npx tsc --noEmit` passes.
- `cargo check` passes (startup-injection changes in `src-tauri/src/lib.rs`).
- Updated the settings-persistence e2e test to drive the new font-size slider.