### PR TITLE
feat(updater): working restart, automatic updates, and update popup

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-dialog": "^2.6.0",
     "@tauri-apps/plugin-opener": "^2",
+    "@tauri-apps/plugin-process": "^2.3.1",
     "@tauri-apps/plugin-updater": "^2.10.0",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-search": "^0.16.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@tauri-apps/plugin-opener':
         specifier: ^2
         version: 2.5.3
+      '@tauri-apps/plugin-process':
+        specifier: ^2.3.1
+        version: 2.3.1
       '@tauri-apps/plugin-updater':
         specifier: ^2.10.0
         version: 2.10.0
@@ -364,66 +367,79 @@ packages:
     resolution: {integrity: sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.0':
     resolution: {integrity: sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.0':
     resolution: {integrity: sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.0':
     resolution: {integrity: sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.0':
     resolution: {integrity: sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.0':
     resolution: {integrity: sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.0':
     resolution: {integrity: sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.0':
     resolution: {integrity: sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.0':
     resolution: {integrity: sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.0':
     resolution: {integrity: sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.0':
     resolution: {integrity: sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.0':
     resolution: {integrity: sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.0':
     resolution: {integrity: sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.0':
     resolution: {integrity: sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw==}
@@ -493,24 +509,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
     resolution: {integrity: sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
     resolution: {integrity: sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.2':
     resolution: {integrity: sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.2':
     resolution: {integrity: sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==}
@@ -571,30 +591,35 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tauri-apps/cli-linux-arm64-musl@2.10.1':
     resolution: {integrity: sha512-MIj78PDDGjkg3NqGptDOGgfXks7SYJwhiMh8SBoZS+vfdz7yP5jN18bNaLnDhsVIPARcAhE1TlsZe/8Yxo2zqg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tauri-apps/cli-linux-riscv64-gnu@2.10.1':
     resolution: {integrity: sha512-X0lvOVUg8PCVaoEtEAnpxmnkwlE1gcMDTqfhbefICKDnOTJ5Est3qL0SrWxizDackIOKBcvtpejrSiVpuJI1kw==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-gnu@2.10.1':
     resolution: {integrity: sha512-2/12bEzsJS9fAKybxgicCDFxYD1WEI9kO+tlDwX5znWG2GwMBaiWcmhGlZ8fi+DMe9CXlcVarMTYc0L3REIRxw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-musl@2.10.1':
     resolution: {integrity: sha512-Y8J0ZzswPz50UcGOFuXGEMrxbjwKSPgXftx5qnkuMs2rmwQB5ssvLb6tn54wDSYxe7S6vlLob9vt0VKuNOaCIQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tauri-apps/cli-win32-arm64-msvc@2.10.1':
     resolution: {integrity: sha512-iSt5B86jHYAPJa/IlYw++SXtFPGnWtFJriHn7X0NFBVunF6zu9+/zOn8OgqIWSl8RgzhLGXQEEtGBdR4wzpVgg==}
@@ -624,6 +649,9 @@ packages:
 
   '@tauri-apps/plugin-opener@2.5.3':
     resolution: {integrity: sha512-CCcUltXMOfUEArbf3db3kCE7Ggy1ExBEBl51Ko2ODJ6GDYHRp1nSNlQm5uNCFY5k7/ufaK5Ib3Du/Zir19IYQQ==}
+
+  '@tauri-apps/plugin-process@2.3.1':
+    resolution: {integrity: sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA==}
 
   '@tauri-apps/plugin-updater@2.10.0':
     resolution: {integrity: sha512-ljN8jPlnT0aSn8ecYhuBib84alxfMx6Hc8vJSKMJyzGbTPFZAC44T2I1QNFZssgWKrAlofvJqCC6Rr472JWfkQ==}
@@ -790,24 +818,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -1380,6 +1412,10 @@ snapshots:
       '@tauri-apps/api': 2.10.1
 
   '@tauri-apps/plugin-opener@2.5.3':
+    dependencies:
+      '@tauri-apps/api': 2.10.1
+
+  '@tauri-apps/plugin-process@2.3.1':
     dependencies:
       '@tauri-apps/api': 2.10.1
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -117,6 +117,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-dialog",
  "tauri-plugin-opener",
+ "tauri-plugin-process",
  "tauri-plugin-updater",
  "tempfile",
  "thiserror 2.0.18",
@@ -5717,6 +5718,16 @@ dependencies = [
  "url",
  "windows 0.61.3",
  "zbus",
+]
+
+[[package]]
+name = "tauri-plugin-process"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
+dependencies = [
+ "tauri",
+ "tauri-plugin",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -68,6 +68,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 keyring = { version = "3", features = ["apple-native", "linux-native", "windows-native"] }
 tauri-plugin-dialog = "2.6.0"
 tauri-plugin-updater = "2"
+tauri-plugin-process = "2"
 ssh2-config = "0.7.0"
 rust-s3 = { version = "0.37.1", default-features = false, features = ["tokio-rustls-tls"] }
 

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -7,6 +7,7 @@
     "core:default",
     "opener:default",
     "dialog:default",
-    "updater:default"
+    "updater:default",
+    "process:default"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -33,6 +33,7 @@ pub fn run() {
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
+        .plugin(tauri_plugin_process::init())
         .setup(|app| {
             let app_data_dir = app
                 .path()

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -233,11 +233,12 @@ export function AppShell() {
   }, []);
 
   // Check for updates once on launch, after settings load so the auto-update
-  // preference is known. Skipped in dev (a dev build can't self-update).
+  // preference is known. The check always runs; the silent download/install
+  // only happens in packaged builds (see updater store).
   const settingsLoaded = useSettingsStore((s) => s.loaded);
   const didUpdateCheck = useRef(false);
   useEffect(() => {
-    if (!settingsLoaded || didUpdateCheck.current || !import.meta.env.PROD) return;
+    if (!settingsLoaded || didUpdateCheck.current) return;
     didUpdateCheck.current = true;
     void useUpdaterStore.getState().loadAppVersion();
     void useUpdaterStore.getState().checkOnStartup();

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useLayoutEffect, useMemo } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef } from "react";
 import { useTabStore } from "../../stores/tab-store";
 import { useSessionStore } from "../../stores/session-store";
 import { useTerminalSearchStore } from "../../stores/terminal-search-store";
 import { useSettingsStore } from "../../stores/settings-store";
+import { useUpdaterStore } from "../../stores/updater-store";
 import { useUiStore } from "../../stores/ui-store";
 import { useKeyboardShortcuts } from "../../hooks/use-keyboard-shortcuts";
 import { useSshStatus } from "../../hooks/use-ssh-status";
@@ -21,6 +22,7 @@ import { SettingsPage } from "../settings";
 import { PortForwardingPage } from "../port-forwarding";
 import { HistoryPage } from "../history";
 import { usePortForwardEvents } from "../../hooks/use-port-forward-events";
+import { UpdateDialog } from "../updater/UpdateDialog";
 
 export function AppShell() {
   const themeMode = useSettingsStore((s) => s.themeMode);
@@ -230,6 +232,17 @@ export function AppShell() {
     void useSettingsStore.getState().loadSettings();
   }, []);
 
+  // Check for updates once on launch, after settings load so the auto-update
+  // preference is known. Skipped in dev (a dev build can't self-update).
+  const settingsLoaded = useSettingsStore((s) => s.loaded);
+  const didUpdateCheck = useRef(false);
+  useEffect(() => {
+    if (!settingsLoaded || didUpdateCheck.current || !import.meta.env.PROD) return;
+    didUpdateCheck.current = true;
+    void useUpdaterStore.getState().loadAppVersion();
+    void useUpdaterStore.getState().checkOnStartup();
+  }, [settingsLoaded]);
+
   useLayoutEffect(() => {
     document.documentElement.dataset.theme = themeMode;
   }, [themeMode]);
@@ -349,6 +362,9 @@ export function AppShell() {
 
       {/* Host modal (new + edit) */}
       <HostEditModal />
+
+      {/* Update-available popup */}
+      <UpdateDialog />
 
       {/* Snippet command palette */}
       <SnippetPalette />

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { useSettingsStore } from "../../stores/settings-store";
 import { CustomSelect, type SelectOption } from "../shared/CustomSelect";
-import { RefreshCw, CheckCircle2, AlertCircle, Download, Palette, SquareTerminal, ArrowUpDown, Info, ExternalLink, Check } from "lucide-react";
+import { useUpdaterStore } from "../../stores/updater-store";
+import { RefreshCw, CheckCircle2, AlertCircle, Palette, SquareTerminal, ArrowUpDown, Info, ExternalLink, Check } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import type { CursorStyle, ThemeMode } from "../../stores/settings-store";
 
@@ -584,12 +585,22 @@ function TransferSettings() {
 }
 
 function AboutSettings() {
+  const autoUpdate = useSettingsStore((s) => s.autoUpdate);
+  const setAutoUpdate = useSettingsStore((s) => s.setAutoUpdate);
+
   return (
     <>
       <SettingsGroup label="About">
         <AboutCard />
       </SettingsGroup>
       <SettingsGroup label="Updates">
+        <SettingRow>
+          <div>
+            <label htmlFor="s-auto-update" className={LABEL_CLASS}>Automatic Updates</label>
+            <p className={DESC_CLASS}>Download and install updates in the background, applied on the next launch</p>
+          </div>
+          <Toggle id="s-auto-update" checked={autoUpdate} onChange={setAutoUpdate} />
+        </SettingRow>
         <UpdateChecker />
       </SettingsGroup>
     </>
@@ -744,84 +755,21 @@ function SegmentedControl<T extends string>({ id, value, onChange, options }: {
 
 // ─── Update checker ─────────────────────────────────────────────────────────
 
-type UpdateStatus = "idle" | "checking" | "available" | "up-to-date" | "downloading" | "ready" | "error";
-
 function UpdateChecker() {
-  const [status, setStatus] = useState<UpdateStatus>("idle");
-  const [version, setVersion] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const [progress, setProgress] = useState(0);
-  const [appVersion, setAppVersion] = useState<string | null>(null);
+  const status = useUpdaterStore((s) => s.status);
+  const version = useUpdaterStore((s) => s.version);
+  const error = useUpdaterStore((s) => s.error);
+  const progress = useUpdaterStore((s) => s.progress);
+  const appVersion = useUpdaterStore((s) => s.appVersion);
+  const checkManually = useUpdaterStore((s) => s.checkManually);
+  const relaunchNow = useUpdaterStore((s) => s.relaunchNow);
 
-  // Read the real app version (injected from git tags at build) instead of hardcoding.
   useEffect(() => {
-    void (async () => {
-      try {
-        const { getVersion } = await import("@tauri-apps/api/app");
-        setAppVersion(await getVersion());
-      } catch { /* best-effort */ }
-    })();
+    void useUpdaterStore.getState().loadAppVersion();
   }, []);
 
-  const checkForUpdate = useCallback(async () => {
-    setStatus("checking");
-    setError(null);
-    try {
-      const { check } = await import("@tauri-apps/plugin-updater");
-      const update = await check();
-
-      if (update) {
-        setVersion(update.version);
-        setStatus("available");
-      } else {
-        setStatus("up-to-date");
-      }
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to check for updates");
-      setStatus("error");
-    }
-  }, []);
-
-  const installUpdate = useCallback(async () => {
-    setStatus("downloading");
-    setProgress(0);
-    try {
-      const { check } = await import("@tauri-apps/plugin-updater");
-      const update = await check();
-      if (!update) return;
-
-      let downloaded = 0;
-      let totalBytes = 0;
-
-      await update.downloadAndInstall((event) => {
-        if (event.event === "Started") {
-          totalBytes = event.data.contentLength ?? 0;
-        } else if (event.event === "Progress") {
-          downloaded += event.data.chunkLength;
-          if (totalBytes > 0) {
-            setProgress(Math.round((downloaded / totalBytes) * 100));
-          }
-        } else if (event.event === "Finished") {
-          setStatus("ready");
-        }
-      });
-
-      setStatus("ready");
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Download failed");
-      setStatus("error");
-    }
-  }, []);
-
-  const handleRelaunch = useCallback(async () => {
-    try {
-      const { relaunch } = await import("@tauri-apps/plugin-process");
-      await relaunch();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Couldn't restart automatically — please reopen the app");
-      setStatus("error");
-    }
-  }, []);
+  const showCheck =
+    status === "idle" || status === "up-to-date" || status === "error" || status === "available";
 
   return (
     <div className="px-4 py-3 rounded-xl bg-bg-surface border border-border/50">
@@ -834,12 +782,11 @@ function UpdateChecker() {
             {status === "downloading" && `Downloading update... ${progress}%`}
             {status === "ready" && "Update downloaded. Restart to apply."}
             {status === "error" && (error ?? "Something went wrong")}
-            {(status === "idle" || status === "checking") && (appVersion ? `Current: v${appVersion}` : "Reading version…")}
+            {(status === "idle" || status === "checking") && (appVersion ? `Current: v${appVersion}` : "Reading version\u2026")}
           </p>
         </div>
 
         <div className="flex items-center gap-2">
-          {/* Status icon */}
           {status === "up-to-date" && (
             <CheckCircle2 size={15} strokeWidth={2} className="text-status-connected shrink-0" />
           )}
@@ -847,10 +794,9 @@ function UpdateChecker() {
             <AlertCircle size={15} strokeWidth={2} className="text-status-error shrink-0" />
           )}
 
-          {/* Action button */}
-          {(status === "idle" || status === "up-to-date" || status === "error") && (
+          {showCheck && (
             <button
-              onClick={() => void checkForUpdate()}
+              onClick={() => void checkManually()}
               className={[
                 "flex items-center gap-1.5 px-3 py-1.5 rounded-lg",
                 "text-[length:var(--text-sm)] font-medium",
@@ -872,23 +818,6 @@ function UpdateChecker() {
             </span>
           )}
 
-          {status === "available" && (
-            <button
-              onClick={() => void installUpdate()}
-              className={[
-                "flex items-center gap-1.5 px-3 py-1.5 rounded-lg",
-                "text-[length:var(--text-sm)] font-medium",
-                "bg-accent text-text-inverse",
-                "hover:bg-accent-hover",
-                "transition-all duration-[var(--duration-fast)]",
-                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-              ].join(" ")}
-            >
-              <Download size={13} strokeWidth={2} />
-              Update to v{version}
-            </button>
-          )}
-
           {status === "downloading" && (
             <div className="w-24 h-1.5 rounded-full bg-bg-muted overflow-hidden">
               <div
@@ -900,7 +829,7 @@ function UpdateChecker() {
 
           {status === "ready" && (
             <button
-              onClick={() => void handleRelaunch()}
+              onClick={() => void relaunchNow()}
               className={[
                 "flex items-center gap-1.5 px-3 py-1.5 rounded-lg",
                 "text-[length:var(--text-sm)] font-medium",

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -815,10 +815,11 @@ function UpdateChecker() {
 
   const handleRelaunch = useCallback(async () => {
     try {
-      const { invoke } = await import("@tauri-apps/api/core");
-      await invoke("plugin:updater|restart");
-    } catch {
-      // Fallback: just tell the user to restart manually
+      const { relaunch } = await import("@tauri-apps/plugin-process");
+      await relaunch();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Couldn't restart automatically — please reopen the app");
+      setStatus("error");
     }
   }, []);
 

--- a/src/components/updater/UpdateDialog.tsx
+++ b/src/components/updater/UpdateDialog.tsx
@@ -1,0 +1,85 @@
+import { ExternalLink } from "lucide-react";
+import { useUpdaterStore } from "../../stores/updater-store";
+
+const REPO_URL = "https://github.com/macnev2013/anySCP";
+
+const BTN_BASE = [
+  "px-3 py-1.5 rounded-lg text-[length:var(--text-sm)] font-medium",
+  "transition-all duration-[var(--duration-fast)]",
+  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+].join(" ");
+
+/**
+ * Shown when an update is available and automatic updates are off (or the user
+ * triggered a manual check with auto off). Lets them install now, defer, or
+ * skip the version. The changelog lives on the tagged GitHub release.
+ */
+export function UpdateDialog() {
+  const open = useUpdaterStore((s) => s.dialogOpen);
+  const version = useUpdaterStore((s) => s.version);
+  const appVersion = useUpdaterStore((s) => s.appVersion);
+  const install = useUpdaterStore((s) => s.installAndRelaunch);
+  const dismiss = useUpdaterStore((s) => s.dismissDialog);
+  const skip = useUpdaterStore((s) => s.skipUpdate);
+
+  if (!open || !version) return null;
+
+  const openChangelog = async () => {
+    try {
+      const { openUrl } = await import("@tauri-apps/plugin-opener");
+      await openUrl(`${REPO_URL}/releases/tag/v${version}`);
+    } catch { /* best-effort */ }
+  };
+
+  return (
+    <div className="fixed inset-0 z-[200] flex items-center justify-center bg-black/50 p-4 no-select animate-[fadeIn_120ms_var(--ease-expo-out)_both]">
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Update available"
+        className="w-full max-w-md rounded-2xl bg-bg-overlay border border-border shadow-[var(--shadow-lg)] p-5"
+      >
+        <h2 className="text-[length:var(--text-lg)] font-semibold text-text-primary">
+          Update available
+        </h2>
+        <p className="mt-1 text-[length:var(--text-sm)] text-text-secondary">
+          anySCP <span className="font-medium text-text-primary">v{version}</span> is available
+          {appVersion ? <span className="text-text-muted"> — you have v{appVersion}</span> : null}.
+        </p>
+
+        <button
+          type="button"
+          onClick={() => void openChangelog()}
+          className="mt-3 inline-flex items-center gap-1.5 text-[length:var(--text-sm)] font-medium text-accent hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded"
+        >
+          View changelog on GitHub
+          <ExternalLink size={13} strokeWidth={2} />
+        </button>
+
+        <div className="mt-5 flex items-center justify-end gap-2">
+          <button
+            type="button"
+            onClick={skip}
+            className={`${BTN_BASE} text-text-muted hover:text-text-primary`}
+          >
+            Skip this version
+          </button>
+          <button
+            type="button"
+            onClick={dismiss}
+            className={`${BTN_BASE} bg-bg-base border border-border text-text-secondary hover:text-text-primary hover:border-border-focus`}
+          >
+            Later
+          </button>
+          <button
+            type="button"
+            onClick={() => void install()}
+            className={`${BTN_BASE} bg-accent text-text-inverse hover:bg-accent-hover`}
+          >
+            Install
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/stores/settings-store.ts
+++ b/src/stores/settings-store.ts
@@ -13,6 +13,10 @@ interface SettingsState {
   accentCustom: AccentCustom | null;
   interfaceFont: string;
 
+  // Updates
+  autoUpdate: boolean;
+  skippedUpdateVersion: string | null;
+
   // Terminal appearance
   terminalFontSize: number;
   terminalFontFamily: string;
@@ -32,6 +36,8 @@ interface SettingsState {
   setAccentHue: (hue: number) => void;
   setAccentCustom: (custom: AccentCustom | null) => void;
   setInterfaceFont: (font: string) => void;
+  setAutoUpdate: (enabled: boolean) => void;
+  setSkippedUpdateVersion: (version: string) => void;
   setTerminalFontSize: (size: number) => void;
   setTerminalFontFamily: (family: string) => void;
   setTerminalCursorStyle: (style: CursorStyle) => void;
@@ -48,6 +54,8 @@ const DEFAULTS = {
   accentHue: 250,
   accentCustom: null as AccentCustom | null,
   interfaceFont: "'Geist', system-ui, sans-serif",
+  autoUpdate: true,
+  skippedUpdateVersion: null as string | null,
   terminalFontSize: 14,
   terminalFontFamily: "'JetBrains Mono', 'Fira Code', 'SF Mono', Menlo, monospace",
   terminalCursorStyle: "bar" as CursorStyle,
@@ -156,6 +164,16 @@ export const useSettingsStore = create<SettingsState>((set) => ({
     persist("app_interface_font", font);
   },
 
+  setAutoUpdate: (enabled) => {
+    set({ autoUpdate: enabled });
+    persist("app_auto_update", String(enabled));
+  },
+
+  setSkippedUpdateVersion: (version) => {
+    set({ skippedUpdateVersion: version });
+    persist("app_skipped_update", version);
+  },
+
   setTerminalFontSize: (size) => {
     const clamped = Math.max(8, Math.min(42, size));
     set({ terminalFontSize: clamped });
@@ -227,6 +245,8 @@ export const useSettingsStore = create<SettingsState>((set) => ({
           case "terminal_scrollback": updates.terminalScrollback = Number(value) || DEFAULTS.terminalScrollback; break;
           case "transfer_concurrency": updates.transferConcurrency = Number(value) || DEFAULTS.transferConcurrency; break;
           case "app_interface_font": updates.interfaceFont = value || DEFAULTS.interfaceFont; break;
+          case "app_auto_update": updates.autoUpdate = value !== "false"; break;
+          case "app_skipped_update": updates.skippedUpdateVersion = value || null; break;
         }
       }
 

--- a/src/stores/updater-store.ts
+++ b/src/stores/updater-store.ts
@@ -1,0 +1,148 @@
+import { create } from "zustand";
+import { useSettingsStore } from "./settings-store";
+import type { Update } from "@tauri-apps/plugin-updater";
+
+export type UpdaterStatus =
+  | "idle"
+  | "checking"
+  | "available"   // found, awaiting user decision (auto-update off)
+  | "downloading"
+  | "ready"       // downloaded + installed, pending restart
+  | "up-to-date"
+  | "error";
+
+interface UpdaterState {
+  status: UpdaterStatus;
+  version: string | null;
+  progress: number;
+  error: string | null;
+  appVersion: string | null;
+  dialogOpen: boolean;
+
+  loadAppVersion: () => Promise<void>;
+  checkOnStartup: () => Promise<void>;
+  checkManually: () => Promise<void>;
+  installAndRelaunch: () => Promise<void>;
+  relaunchNow: () => Promise<void>;
+  dismissDialog: () => void;
+  skipUpdate: () => void;
+}
+
+const message = (err: unknown, fallback: string) =>
+  err instanceof Error ? err.message : fallback;
+
+/** Download + install an update, reporting progress into the store. */
+async function downloadInstall(
+  update: Update,
+  set: (partial: Partial<UpdaterState>) => void,
+): Promise<void> {
+  set({ status: "downloading", progress: 0 });
+  let downloaded = 0;
+  let total = 0;
+  await update.downloadAndInstall((event) => {
+    if (event.event === "Started") {
+      total = event.data.contentLength ?? 0;
+    } else if (event.event === "Progress") {
+      downloaded += event.data.chunkLength;
+      if (total > 0) set({ progress: Math.round((downloaded / total) * 100) });
+    } else if (event.event === "Finished") {
+      set({ status: "ready" });
+    }
+  });
+  set({ status: "ready" });
+}
+
+export const useUpdaterStore = create<UpdaterState>((set, get) => ({
+  status: "idle",
+  version: null,
+  progress: 0,
+  error: null,
+  appVersion: null,
+  dialogOpen: false,
+
+  loadAppVersion: async () => {
+    try {
+      const { getVersion } = await import("@tauri-apps/api/app");
+      set({ appVersion: await getVersion() });
+    } catch { /* best-effort */ }
+  },
+
+  // Runs once on launch. With auto-update on, silently downloads + installs the
+  // update (applied next launch). With it off, surfaces a popup unless the user
+  // skipped this exact version.
+  checkOnStartup: async () => {
+    if (get().status === "checking" || get().status === "downloading") return;
+    set({ status: "checking", error: null });
+    try {
+      const { check } = await import("@tauri-apps/plugin-updater");
+      const update = await check();
+      if (!update) { set({ status: "up-to-date" }); return; }
+
+      set({ version: update.version });
+      const { autoUpdate, skippedUpdateVersion } = useSettingsStore.getState();
+
+      if (autoUpdate) {
+        await downloadInstall(update, set);
+      } else if (skippedUpdateVersion === update.version) {
+        set({ status: "idle" });
+      } else {
+        set({ status: "available", dialogOpen: true });
+      }
+    } catch (err) {
+      set({ status: "error", error: message(err, "Failed to check for updates") });
+    }
+  },
+
+  // The Settings "Check" button. Honours the auto-update setting: installs
+  // silently when on, otherwise opens the popup.
+  checkManually: async () => {
+    if (get().status === "checking" || get().status === "downloading") return;
+    set({ status: "checking", error: null });
+    try {
+      const { check } = await import("@tauri-apps/plugin-updater");
+      const update = await check();
+      if (!update) { set({ status: "up-to-date" }); return; }
+
+      set({ version: update.version });
+      if (useSettingsStore.getState().autoUpdate) {
+        await downloadInstall(update, set);
+      } else {
+        set({ status: "available", dialogOpen: true });
+      }
+    } catch (err) {
+      set({ status: "error", error: message(err, "Failed to check for updates") });
+    }
+  },
+
+  // Popup "Install" — download, install, and restart right away.
+  installAndRelaunch: async () => {
+    set({ dialogOpen: false, error: null });
+    try {
+      const { check } = await import("@tauri-apps/plugin-updater");
+      const update = await check();
+      if (!update) { set({ status: "up-to-date" }); return; }
+      await downloadInstall(update, set);
+      const { relaunch } = await import("@tauri-apps/plugin-process");
+      await relaunch();
+    } catch (err) {
+      set({ status: "error", error: message(err, "Download failed") });
+    }
+  },
+
+  relaunchNow: async () => {
+    try {
+      const { relaunch } = await import("@tauri-apps/plugin-process");
+      await relaunch();
+    } catch (err) {
+      set({ status: "error", error: message(err, "Couldn't restart automatically — please reopen the app") });
+    }
+  },
+
+  dismissDialog: () => set({ dialogOpen: false }),
+
+  skipUpdate: () => {
+    const v = get().version;
+    if (v) useSettingsStore.getState().setSkippedUpdateVersion(v);
+    set({ dialogOpen: false, status: "idle" });
+  },
+}));

--- a/src/stores/updater-store.ts
+++ b/src/stores/updater-store.ts
@@ -82,7 +82,13 @@ export const useUpdaterStore = create<UpdaterState>((set, get) => ({
       const { autoUpdate, skippedUpdateVersion } = useSettingsStore.getState();
 
       if (autoUpdate) {
-        await downloadInstall(update, set);
+        // A dev build can't self-install; just surface that an update exists
+        // rather than downloading a full release on every dev launch.
+        if (import.meta.env.PROD) {
+          await downloadInstall(update, set);
+        } else {
+          set({ status: "available" });
+        }
       } else if (skippedUpdateVersion === update.version) {
         set({ status: "idle" });
       } else {


### PR DESCRIPTION
## Summary

Makes the in-app updater fully functional and adds automatic updates with a new-version popup.

## 1. Fix "Restart Now" (bug)

The restart button invoked a non-existent command (`invoke("plugin:updater|restart")`) whose error was silently swallowed, so it did nothing. Added the **process plugin** (`@tauri-apps/plugin-process` + `tauri-plugin-process` + `process:default` capability) and relaunch via `relaunch()`; failures now surface as an error.

## 2. Automatic updates (feature)

- New **Automatic Updates** setting in About & Updates, **on by default**.
- **Enabled:** on launch the app silently checks → downloads → installs the update and applies it on the next start. While an update is downloaded-and-pending, the Settings card shows **Restart Now** instead of **Check**.
- **Disabled:** on launch, if an update is available (and not skipped), an **Update available** popup appears with **Install**, **Later**, and **Skip this version** (skip is remembered per version). It links to the tagged GitHub release for the changelog.
- The Settings "Check" button honours the toggle (silent install when on, popup when off).
- The update lifecycle is centralised in a new `updater-store` shared by the startup check, the Settings card, and the popup.
- The startup auto-check is skipped in dev builds (a dev instance can't self-update).

## Testing
- `npx tsc --noEmit` passes.
- `cargo check` passes (process plugin compiles + registers).
- Note: the real check→download→restart flow only applies to packaged/installed release builds; a `tauri dev` instance (version `0.0.0-dev`) can't self-update in place.

## Note on the changelog link
The repo's release workflow writes the generated changelog to the GitHub **release page** after `tauri-action` builds `latest.json`, so the updater's `update.body` isn't the changelog. Rather than depend on that, the popup links to the tagged release page. If you'd prefer the changelog inline, a follow-up can feed it into `latest.json`'s notes.