### PR TITLE
fix(updater): never self-install on debug/dev builds

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -23,6 +23,20 @@ use ssh::manager::SshManager;
 use std::sync::Arc;
 use tauri::{Manager, WebviewUrl, WebviewWindowBuilder};
 
+/// Whether this is a real release build — i.e. a packaged binary that can
+/// safely self-update via the updater plugin.
+///
+/// False for `tauri dev` and `tauri build --debug` (the E2E binary). Those
+/// builds must never download + install a release over themselves: it
+/// overwrites the running executable and corrupts it (the E2E suite would
+/// otherwise fail with "Permission denied" launching the binary mid-run).
+/// `debug_assertions` is the correct discriminator — it is off only for an
+/// actual `--release` build.
+#[tauri::command]
+fn is_release_build() -> bool {
+    !cfg!(debug_assertions)
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tracing_subscriber::fmt()
@@ -285,6 +299,8 @@ pub fn run() {
             snippets::commands::list_snippet_folders,
             snippets::commands::delete_snippet_folder,
             snippets::commands::snippet_execute,
+            // Build info
+            is_release_build,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/stores/updater-store.ts
+++ b/src/stores/updater-store.ts
@@ -31,11 +31,34 @@ interface UpdaterState {
 const message = (err: unknown, fallback: string) =>
   err instanceof Error ? err.message : fallback;
 
+// A debug/dev binary (`tauri dev` or `tauri build --debug`, e.g. the E2E build)
+// must NEVER download + install a release over itself — that overwrites the
+// running executable and corrupts it. Only a real release build self-updates.
+// Resolved once from the Rust side (`is_release_build`) and cached.
+let releaseBuild: boolean | null = null;
+async function isReleaseBuild(): Promise<boolean> {
+  if (releaseBuild === null) {
+    try {
+      const { invoke } = await import("@tauri-apps/api/core");
+      releaseBuild = await invoke<boolean>("is_release_build");
+    } catch {
+      releaseBuild = false; // be conservative — never self-install if unknown
+    }
+  }
+  return releaseBuild;
+}
+
 /** Download + install an update, reporting progress into the store. */
 async function downloadInstall(
   update: Update,
   set: (partial: Partial<UpdaterState>) => void,
 ): Promise<void> {
+  // Guard every install path here: a non-release build can't self-install
+  // without corrupting its own binary, so just surface that an update exists.
+  if (!(await isReleaseBuild())) {
+    set({ status: "available" });
+    return;
+  }
   set({ status: "downloading", progress: 0 });
   let downloaded = 0;
   let total = 0;
@@ -82,13 +105,9 @@ export const useUpdaterStore = create<UpdaterState>((set, get) => ({
       const { autoUpdate, skippedUpdateVersion } = useSettingsStore.getState();
 
       if (autoUpdate) {
-        // A dev build can't self-install; just surface that an update exists
-        // rather than downloading a full release on every dev launch.
-        if (import.meta.env.PROD) {
-          await downloadInstall(update, set);
-        } else {
-          set({ status: "available" });
-        }
+        // downloadInstall self-guards: on a debug/dev binary it just surfaces
+        // that an update exists instead of overwriting the running executable.
+        await downloadInstall(update, set);
       } else if (skippedUpdateVersion === update.version) {
         set({ status: "idle" });
       } else {
@@ -128,6 +147,9 @@ export const useUpdaterStore = create<UpdaterState>((set, get) => ({
       const update = await check();
       if (!update) { set({ status: "up-to-date" }); return; }
       await downloadInstall(update, set);
+      // downloadInstall no-ops on a non-release build (status stays
+      // "available"); only relaunch once an update is actually installed.
+      if (get().status !== "ready") return;
       const { relaunch } = await import("@tauri-apps/plugin-process");
       await relaunch();
     } catch (err) {


### PR DESCRIPTION
## What's failing

Not the build itself — the **E2E shards 3/4 and 4/4** (frontend build, typecheck, and Rust jobs all pass). The symptom was confusing:

```
Failed to execute child process "/workspace/src-tauri/target/debug/anyscp" (Permission denied)
```

The binary launches fine for the first ~12 specs, then **every** launch after fails. In both shards it breaks at exactly the 13th session — different spec files, same count — so it isn't any single spec's fault.

## Root cause

The auto-update-on-launch feature (#55) replaces the running E2E binary mid-suite:

1. `AppShell` runs `checkOnStartup()` on every launch; `autoUpdate` defaults to **on**.
2. The E2E binary is built with `tauri build --debug`, which runs `vite build`, so the embedded frontend has `import.meta.env.PROD === true`.
3. `checkOnStartup` therefore took the silent `downloadAndInstall` path.
4. The updater endpoint is real and reachable, and app version `0.0.0-dev` < released `v0.9.0`, so `check()` returns an update.
5. The app **downloaded and installed the real release over `src-tauri/target/debug/anyscp`**. Once the install finished (~13 launches in), the running binary was clobbered → "Permission denied" for every subsequent launch.

`import.meta.env.PROD` is the wrong discriminator — it's true for *any* `vite build`, including the `--debug` E2E binary.

## Fix

- New Rust command `is_release_build` → `!cfg!(debug_assertions)`, which is `false` only for an actual `--release` build (so `tauri dev` and `tauri build --debug`/E2E are correctly non-self-updating).
- Centralize the guard inside `downloadInstall`, so **every** install path (startup, manual "Check", popup "Install") is safe — a debug build just surfaces "update available" instead of overwriting itself.
- Skip the post-install `relaunch()` when nothing was actually installed.

## Beyond CI

This also fixes real behavior: any non-release build a user runs (e.g. a locally-built debug binary) would otherwise silently try to replace itself with a release.

## Testing

- `tsc --noEmit` clean
- `cargo check` clean
- E2E not run locally; CI on this PR will exercise the shards.