### PR TITLE
feat(editors): external editor support — detect, Open With, and auto-config

### DIFF
--- a/src-tauri/src/editors/mod.rs
+++ b/src-tauri/src/editors/mod.rs
@@ -96,7 +96,7 @@ const fn term_spec(
 /// terminal editors are listed for completeness but skipped by `detect`.
 #[rustfmt::skip]
 const REGISTRY: &[EditorSpec] = &[
-    spec("Visual Studio Code", &["Visual Studio Code.app"], &["code"], &["com.visualstudio.code"],
+    spec("VS Code", &["Visual Studio Code.app"], &["code"], &["com.visualstudio.code"],
         &[r"%LOCALAPPDATA%\Programs\Microsoft VS Code\Code.exe", r"%ProgramFiles%\Microsoft VS Code\Code.exe", r"%ProgramFiles(x86)%\Microsoft VS Code\Code.exe", r"%LOCALAPPDATA%\Programs\Microsoft VS Code\bin\code.cmd", r"%ProgramFiles%\Microsoft VS Code\bin\code.cmd"],
         &["code.cmd", "Code.exe"]),
     spec("VS Code Insiders", &["Visual Studio Code - Insiders.app"], &["code-insiders"], &["com.visualstudio.code.insiders"],
@@ -455,7 +455,7 @@ fn wildcard_match(pattern: &str, name: &str) -> bool {
 /// editor, preferring the popular IDEs (and the VS Code family the old
 /// hard-coded path targeted).
 pub fn resolve_default() -> Option<EditorConfig> {
-    const PREFERRED: &[&str] = &["Visual Studio Code", "VSCodium", "Cursor", "Windsurf", "Sublime Text", "Zed"];
+    const PREFERRED: &[&str] = &["VS Code", "VSCodium", "Cursor", "Windsurf", "Sublime Text", "Zed"];
     let detected = detect();
     detected
         .iter()

--- a/src-tauri/src/editors/mod.rs
+++ b/src-tauri/src/editors/mod.rs
@@ -76,7 +76,16 @@ const fn spec(
     win_paths: &'static [&'static str],
     win_bins: &'static [&'static str],
 ) -> EditorSpec {
-    EditorSpec { name, mac_apps, linux_bins, linux_flatpak_ids, win_paths, win_bins, args: "{path}", terminal: false }
+    EditorSpec {
+        name,
+        mac_apps,
+        linux_bins,
+        linux_flatpak_ids,
+        win_paths,
+        win_bins,
+        args: "{path}",
+        terminal: false,
+    }
 }
 
 /// Same as `spec` but flagged as a terminal/TUI editor.
@@ -89,7 +98,16 @@ const fn term_spec(
     win_bins: &'static [&'static str],
     args: &'static str,
 ) -> EditorSpec {
-    EditorSpec { name, mac_apps, linux_bins, linux_flatpak_ids, win_paths, win_bins, args, terminal: true }
+    EditorSpec {
+        name,
+        mac_apps,
+        linux_bins,
+        linux_flatpak_ids,
+        win_paths,
+        win_bins,
+        args,
+        terminal: true,
+    }
 }
 
 /// Known editors, ordered roughly by popularity. GUI editors are auto-detected;
@@ -219,7 +237,11 @@ pub fn detect() -> Vec<EditorConfig> {
             .flat_map(|app| dirs.iter().map(move |d| d.join(app)))
             .find(|p| p.exists())
         {
-            out.push(EditorConfig { name: s.name.into(), exec_path: path.to_string_lossy().into(), args: s.args.into() });
+            out.push(EditorConfig {
+                name: s.name.into(),
+                exec_path: path.to_string_lossy().into(),
+                args: s.args.into(),
+            });
         }
     }
     dedup(out)
@@ -242,7 +264,11 @@ pub fn detect() -> Vec<EditorConfig> {
             .chain(s.linux_flatpak_ids.iter())
             .find_map(|name| which_in(&dirs, name));
         if let Some(path) = found {
-            out.push(EditorConfig { name: s.name.into(), exec_path: path.to_string_lossy().into(), args: s.args.into() });
+            out.push(EditorConfig {
+                name: s.name.into(),
+                exec_path: path.to_string_lossy().into(),
+                args: s.args.into(),
+            });
         }
     }
     dedup(out)
@@ -262,7 +288,11 @@ pub fn detect() -> Vec<EditorConfig> {
             .find_map(|p| resolve_win_path(p))
             .or_else(|| s.win_bins.iter().find_map(|b| which_windows(b)));
         if let Some(path) = found {
-            out.push(EditorConfig { name: s.name.into(), exec_path: path.to_string_lossy().into(), args: s.args.into() });
+            out.push(EditorConfig {
+                name: s.name.into(),
+                exec_path: path.to_string_lossy().into(),
+                args: s.args.into(),
+            });
         }
     }
     dedup(out)
@@ -381,7 +411,7 @@ fn resolve_glob(path: &str) -> Vec<PathBuf> {
         let pb = PathBuf::from(path);
         return if pb.exists() { vec![pb] } else { vec![] };
     }
-    let segments: Vec<&str> = path.split(|c| c == '/' || c == '\\').collect();
+    let segments: Vec<&str> = path.split(['/', '\\']).collect();
     // Seed the search base from the first segment (root / drive / relative).
     let first = segments[0];
     let mut current: Vec<PathBuf> = if first.is_empty() {
@@ -455,7 +485,14 @@ fn wildcard_match(pattern: &str, name: &str) -> bool {
 /// editor, preferring the popular IDEs (and the VS Code family the old
 /// hard-coded path targeted).
 pub fn resolve_default() -> Option<EditorConfig> {
-    const PREFERRED: &[&str] = &["VS Code", "VSCodium", "Cursor", "Windsurf", "Sublime Text", "Zed"];
+    const PREFERRED: &[&str] = &[
+        "VS Code",
+        "VSCodium",
+        "Cursor",
+        "Windsurf",
+        "Sublime Text",
+        "Zed",
+    ];
     let detected = detect();
     detected
         .iter()
@@ -570,13 +607,19 @@ mod tests {
     #[test]
     fn substitutes_path_placeholder() {
         assert_eq!(build_args("{path}", "/tmp/a.txt"), vec!["/tmp/a.txt"]);
-        assert_eq!(build_args("-n -w {path}", "/tmp/a.txt"), vec!["-n", "-w", "/tmp/a.txt"]);
+        assert_eq!(
+            build_args("-n -w {path}", "/tmp/a.txt"),
+            vec!["-n", "-w", "/tmp/a.txt"]
+        );
     }
 
     #[test]
     fn appends_path_when_no_placeholder() {
         assert_eq!(build_args("", "/tmp/a.txt"), vec!["/tmp/a.txt"]);
-        assert_eq!(build_args("--reuse-window", "/tmp/a.txt"), vec!["--reuse-window", "/tmp/a.txt"]);
+        assert_eq!(
+            build_args("--reuse-window", "/tmp/a.txt"),
+            vec!["--reuse-window", "/tmp/a.txt"]
+        );
     }
 
     #[test]
@@ -589,7 +632,10 @@ mod tests {
 
     #[test]
     fn placeholder_inside_quoted_token() {
-        assert_eq!(build_args("\"{path}\"", "/tmp/a b.txt"), vec!["/tmp/a b.txt"]);
+        assert_eq!(
+            build_args("\"{path}\"", "/tmp/a b.txt"),
+            vec!["/tmp/a b.txt"]
+        );
     }
 
     #[test]

--- a/src-tauri/src/editors/mod.rs
+++ b/src-tauri/src/editors/mod.rs
@@ -1,0 +1,635 @@
+//! External editor detection and launching.
+//!
+//! The "Edit in editor" feature downloads a remote file to a temp dir, opens it
+//! in a desktop editor, and re-uploads on save. This module owns the two pieces
+//! that are independent of the transport (SFTP/SCP/S3): finding installed
+//! editors and launching one against a local file.
+//!
+//! Why this exists: the old code hard-coded `Command::new("code")`, which relies
+//! on `code` being on `PATH`. GUI apps launched from Finder/Dock on macOS do NOT
+//! inherit the shell `PATH`, so that spawn failed for most users — and the
+//! failure was swallowed by the frontend, so nothing happened at all (issues
+//! #12, #45, #56). Detection resolves absolute paths up front and `launch` uses
+//! them directly, sidestepping `PATH` entirely, and the registry below lets the
+//! app auto-detect and offer any installed editor rather than only VS Code
+//! (#45, #56).
+//!
+//! The registry (display name + per-OS install identifiers) was compiled from
+//! cross-platform research and adversarially fact-checked; see REGISTRY.
+
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+/// A configured or detected editor.
+///
+/// `args` is a command template in which the literal `{path}` is replaced with
+/// the file to open; if the template contains no `{path}`, the file is appended
+/// as a final argument. Serialised camelCase to match the TypeScript shape
+/// (`{ name, execPath, args }`). Extra fields sent by the frontend (e.g. a UI
+/// `id`) are ignored.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EditorConfig {
+    pub name: String,
+    pub exec_path: String,
+    #[serde(default = "default_args")]
+    pub args: String,
+}
+
+fn default_args() -> String {
+    "{path}".to_string()
+}
+
+// ─── Registry ───────────────────────────────────────────────────────────────
+
+/// Per-OS install fingerprints for one editor. Each platform's detector reads
+/// only the fields relevant to it (hence the broad `allow(dead_code)`).
+#[allow(dead_code)]
+struct EditorSpec {
+    /// Display name shown in the UI.
+    name: &'static str,
+    /// macOS `.app` bundle names to look for under the standard app dirs.
+    mac_apps: &'static [&'static str],
+    /// Linux executable names to resolve on `PATH` / known dirs.
+    linux_bins: &'static [&'static str],
+    /// Flatpak app ids — also the filename of the wrapper in the flatpak
+    /// `exports/bin` directories, so they're resolved the same way as bins.
+    linux_flatpak_ids: &'static [&'static str],
+    /// Windows install paths, with `%ENV%` placeholders and `*` globs for
+    /// versioned directories.
+    win_paths: &'static [&'static str],
+    /// Bare Windows exe names to resolve via `PATH`.
+    win_bins: &'static [&'static str],
+    /// File-open argument template; `{path}` is substituted with the file.
+    args: &'static str,
+    /// TUI editors that need a terminal — excluded from auto-detection because
+    /// the app launches editors as detached GUI processes.
+    terminal: bool,
+}
+
+/// Convenience constructor keeping the registry literal terse.
+const fn spec(
+    name: &'static str,
+    mac_apps: &'static [&'static str],
+    linux_bins: &'static [&'static str],
+    linux_flatpak_ids: &'static [&'static str],
+    win_paths: &'static [&'static str],
+    win_bins: &'static [&'static str],
+) -> EditorSpec {
+    EditorSpec { name, mac_apps, linux_bins, linux_flatpak_ids, win_paths, win_bins, args: "{path}", terminal: false }
+}
+
+/// Same as `spec` but flagged as a terminal/TUI editor.
+const fn term_spec(
+    name: &'static str,
+    mac_apps: &'static [&'static str],
+    linux_bins: &'static [&'static str],
+    linux_flatpak_ids: &'static [&'static str],
+    win_paths: &'static [&'static str],
+    win_bins: &'static [&'static str],
+    args: &'static str,
+) -> EditorSpec {
+    EditorSpec { name, mac_apps, linux_bins, linux_flatpak_ids, win_paths, win_bins, args, terminal: true }
+}
+
+/// Known editors, ordered roughly by popularity. GUI editors are auto-detected;
+/// terminal editors are listed for completeness but skipped by `detect`.
+#[rustfmt::skip]
+const REGISTRY: &[EditorSpec] = &[
+    spec("Visual Studio Code", &["Visual Studio Code.app"], &["code"], &["com.visualstudio.code"],
+        &[r"%LOCALAPPDATA%\Programs\Microsoft VS Code\Code.exe", r"%ProgramFiles%\Microsoft VS Code\Code.exe", r"%ProgramFiles(x86)%\Microsoft VS Code\Code.exe", r"%LOCALAPPDATA%\Programs\Microsoft VS Code\bin\code.cmd", r"%ProgramFiles%\Microsoft VS Code\bin\code.cmd"],
+        &["code.cmd", "Code.exe"]),
+    spec("VS Code Insiders", &["Visual Studio Code - Insiders.app"], &["code-insiders"], &["com.visualstudio.code.insiders"],
+        &[r"%LOCALAPPDATA%\Programs\Microsoft VS Code Insiders\Code - Insiders.exe", r"%ProgramFiles%\Microsoft VS Code Insiders\Code - Insiders.exe", r"%LOCALAPPDATA%\Programs\Microsoft VS Code Insiders\bin\code-insiders.cmd"],
+        &["code-insiders.cmd", "Code - Insiders.exe"]),
+    spec("Cursor", &["Cursor.app"], &["cursor"], &[],
+        &[r"%LOCALAPPDATA%\Programs\cursor\Cursor.exe", r"%ProgramFiles%\cursor\Cursor.exe", r"%LOCALAPPDATA%\Programs\cursor\resources\app\bin\cursor.cmd"],
+        &["cursor.cmd", "Cursor.exe"]),
+    spec("Windsurf", &["Windsurf.app"], &["windsurf"], &[],
+        &[r"%LOCALAPPDATA%\Programs\Windsurf\Windsurf.exe", r"%ProgramFiles%\Windsurf\Windsurf.exe", r"%LOCALAPPDATA%\Programs\Windsurf\bin\windsurf.cmd"],
+        &["windsurf.cmd", "Windsurf.exe"]),
+    spec("VSCodium", &["VSCodium.app", "VSCodium - Insiders.app"], &["codium", "vscodium"], &["com.vscodium.codium"],
+        &[r"%LOCALAPPDATA%\Programs\VSCodium\VSCodium.exe", r"%ProgramFiles%\VSCodium\VSCodium.exe", r"%LOCALAPPDATA%\Programs\VSCodium\bin\codium.cmd", r"%ProgramFiles%\VSCodium\bin\codium.cmd"],
+        &["codium.cmd", "VSCodium.exe"]),
+    spec("Sublime Text", &["Sublime Text.app", "Sublime Text 3.app"], &["subl", "sublime_text"], &["com.sublimetext.three"],
+        &[r"%ProgramFiles%\Sublime Text\subl.exe", r"%ProgramFiles%\Sublime Text\sublime_text.exe", r"%ProgramFiles(x86)%\Sublime Text\sublime_text.exe", r"%ProgramFiles%\Sublime Text 3\sublime_text.exe"],
+        &["subl.exe", "sublime_text.exe"]),
+    spec("Zed", &["Zed.app", "Zed Preview.app"], &["zed", "zeditor", "zedit"], &["dev.zed.Zed"],
+        &[r"%LOCALAPPDATA%\Programs\Zed\zed.exe", r"%LOCALAPPDATA%\Zed\zed.exe"], &["zed.exe"]),
+    spec("Lapce", &["Lapce.app", "Lapce Code Editor.app"], &["lapce"], &["dev.lapce.lapce"],
+        &[r"%ProgramFiles%\Lapce\lapce.exe", r"%LOCALAPPDATA%\Programs\Lapce\lapce.exe", r"%LOCALAPPDATA%\lapce\lapce.exe"],
+        &["lapce.exe", "Lapce.exe"]),
+
+    // JetBrains IDEs (standalone installs + Toolbox shell-script shims on PATH).
+    spec("IntelliJ IDEA", &["IntelliJ IDEA.app", "IntelliJ IDEA Ultimate.app", "IntelliJ IDEA CE.app", "IntelliJ IDEA Community Edition.app"], &["idea", "idea.sh"], &["com.jetbrains.IntelliJ-IDEA-Ultimate", "com.jetbrains.IntelliJ-IDEA-Community"],
+        &[r"%ProgramFiles%\JetBrains\IntelliJ IDEA*\bin\idea64.exe", r"%LOCALAPPDATA%\Programs\IntelliJ IDEA Ultimate\bin\idea64.exe", r"%LOCALAPPDATA%\JetBrains\Toolbox\apps\IDEA-U\*\bin\idea64.exe", r"%LOCALAPPDATA%\JetBrains\Toolbox\scripts\idea.cmd"],
+        &["idea64.exe", "idea.cmd"]),
+    spec("PyCharm", &["PyCharm.app", "PyCharm Professional.app", "PyCharm CE.app", "PyCharm Community Edition.app"], &["pycharm", "pycharm.sh"], &["com.jetbrains.PyCharm-Professional", "com.jetbrains.PyCharm-Community"],
+        &[r"%ProgramFiles%\JetBrains\PyCharm*\bin\pycharm64.exe", r"%LOCALAPPDATA%\Programs\PyCharm Professional\bin\pycharm64.exe", r"%LOCALAPPDATA%\JetBrains\Toolbox\apps\PyCharm-P\*\bin\pycharm64.exe", r"%LOCALAPPDATA%\JetBrains\Toolbox\scripts\pycharm.cmd"],
+        &["pycharm64.exe", "pycharm.cmd"]),
+    spec("WebStorm", &["WebStorm.app"], &["webstorm", "webstorm.sh"], &["com.jetbrains.WebStorm"],
+        &[r"%ProgramFiles%\JetBrains\WebStorm*\bin\webstorm64.exe", r"%LOCALAPPDATA%\JetBrains\Toolbox\apps\WebStorm\*\bin\webstorm64.exe", r"%LOCALAPPDATA%\JetBrains\Toolbox\scripts\webstorm.cmd"],
+        &["webstorm64.exe", "webstorm.cmd"]),
+    spec("GoLand", &["GoLand.app"], &["goland", "goland.sh"], &["com.jetbrains.GoLand"],
+        &[r"%ProgramFiles%\JetBrains\GoLand*\bin\goland64.exe", r"%LOCALAPPDATA%\JetBrains\Toolbox\apps\GoLand\*\bin\goland64.exe", r"%LOCALAPPDATA%\JetBrains\Toolbox\scripts\goland.cmd"],
+        &["goland64.exe", "goland.cmd"]),
+    spec("PhpStorm", &["PhpStorm.app"], &["phpstorm", "phpstorm.sh"], &["com.jetbrains.PhpStorm"],
+        &[r"%ProgramFiles%\JetBrains\PhpStorm*\bin\phpstorm64.exe", r"%LOCALAPPDATA%\JetBrains\Toolbox\apps\PhpStorm\*\bin\phpstorm64.exe", r"%LOCALAPPDATA%\JetBrains\Toolbox\scripts\phpstorm.cmd"],
+        &["phpstorm64.exe", "phpstorm.cmd"]),
+    spec("CLion", &["CLion.app"], &["clion", "clion.sh"], &["com.jetbrains.CLion"],
+        &[r"%ProgramFiles%\JetBrains\CLion*\bin\clion64.exe", r"%LOCALAPPDATA%\JetBrains\Toolbox\apps\CLion\*\bin\clion64.exe", r"%LOCALAPPDATA%\JetBrains\Toolbox\scripts\clion.cmd"],
+        &["clion64.exe", "clion.cmd"]),
+    spec("Rider", &["Rider.app", "JetBrains Rider.app"], &["rider", "rider.sh"], &["com.jetbrains.Rider"],
+        &[r"%ProgramFiles%\JetBrains\JetBrains Rider*\bin\rider64.exe", r"%LOCALAPPDATA%\JetBrains\Toolbox\apps\Rider\*\bin\rider64.exe", r"%LOCALAPPDATA%\JetBrains\Toolbox\scripts\rider.cmd"],
+        &["rider64.exe", "rider.cmd"]),
+    spec("RubyMine", &["RubyMine.app"], &["rubymine", "rubymine.sh"], &["com.jetbrains.RubyMine"],
+        &[r"%ProgramFiles%\JetBrains\RubyMine*\bin\rubymine64.exe", r"%LOCALAPPDATA%\JetBrains\Toolbox\apps\RubyMine\*\bin\rubymine64.exe", r"%LOCALAPPDATA%\JetBrains\Toolbox\scripts\rubymine.cmd"],
+        &["rubymine64.exe", "rubymine.cmd"]),
+    spec("DataGrip", &["DataGrip.app"], &["datagrip", "datagrip.sh"], &["com.jetbrains.DataGrip"],
+        &[r"%ProgramFiles%\JetBrains\DataGrip*\bin\datagrip64.exe", r"%LOCALAPPDATA%\JetBrains\Toolbox\apps\DataGrip\*\bin\datagrip64.exe", r"%LOCALAPPDATA%\JetBrains\Toolbox\scripts\datagrip.cmd"],
+        &["datagrip64.exe", "datagrip.cmd"]),
+    spec("RustRover", &["RustRover.app"], &["rustrover", "rustrover.sh"], &["com.jetbrains.RustRover"],
+        &[r"%ProgramFiles%\JetBrains\RustRover*\bin\rustrover64.exe", r"%LOCALAPPDATA%\JetBrains\Toolbox\apps\RustRover\*\bin\rustrover64.exe", r"%LOCALAPPDATA%\JetBrains\Toolbox\scripts\rustrover.cmd"],
+        &["rustrover64.exe", "rustrover.cmd"]),
+    spec("JetBrains Fleet", &["Fleet.app", "JetBrains Fleet.app", "Fleet Nightly.app"], &["fleet"], &[],
+        &[r"%LOCALAPPDATA%\JetBrains\Toolbox\apps\fleet\*\bin\Fleet.exe", r"%LOCALAPPDATA%\Programs\Fleet\Fleet.exe"], &["Fleet.exe", "fleet.cmd"]),
+    spec("Android Studio", &["Android Studio.app", "Android Studio Preview.app"], &["studio.sh", "android-studio", "studio"], &["com.google.AndroidStudio"],
+        &[r"%ProgramFiles%\Android\Android Studio\bin\studio64.exe", r"%LOCALAPPDATA%\Programs\Android Studio\bin\studio64.exe", r"%LOCALAPPDATA%\JetBrains\Toolbox\apps\AndroidStudio\*\bin\studio64.exe"], &["studio64.exe"]),
+    spec("Xcode", &["Xcode.app"], &[], &[], &[], &[]),
+    spec("Eclipse", &["Eclipse.app"], &["eclipse"], &["org.eclipse.Java"],
+        &[r"%ProgramFiles%\eclipse\eclipse.exe", r"%ProgramFiles%\Eclipse Foundation\*\eclipse.exe", r"%USERPROFILE%\eclipse\*\eclipse.exe"], &["eclipse.exe"]),
+    spec("Apache NetBeans", &["NetBeans.app", "Apache NetBeans.app"], &["netbeans"], &["org.apache.netbeans"],
+        &[r"%ProgramFiles%\NetBeans*\bin\netbeans64.exe", r"%ProgramFiles%\NetBeans*\netbeans\bin\netbeans64.exe"], &["netbeans64.exe"]),
+
+    // Lightweight / native GUI editors.
+    spec("Kate", &[], &["kate"], &["org.kde.kate"], &[r"%ProgramFiles%\Kate\bin\kate.exe", r"%LOCALAPPDATA%\Microsoft\WindowsApps\kate.exe"], &["kate.exe"]),
+    spec("KWrite", &[], &["kwrite"], &["org.kde.kwrite"], &[r"%ProgramFiles%\Kate\bin\kwrite.exe"], &["kwrite.exe"]),
+    spec("GNOME Text Editor", &[], &["gnome-text-editor"], &["org.gnome.TextEditor"], &[], &[]),
+    spec("gedit", &[], &["gedit"], &["org.gnome.gedit"], &[], &[]),
+    spec("Geany", &[], &["geany"], &["org.geany.Geany"], &[r"%ProgramFiles%\Geany\bin\geany.exe", r"%ProgramFiles(x86)%\Geany\bin\geany.exe", r"%ProgramFiles%\Geany\geany.exe"], &["geany.exe"]),
+    spec("Mousepad", &[], &["mousepad"], &["org.xfce.mousepad"], &[], &[]),
+    spec("Xed", &[], &["xed"], &[], &[], &[]),
+    spec("Pluma", &[], &["pluma"], &[], &[], &[]),
+    spec("Bluefish", &[], &["bluefish"], &[], &[], &[]),
+    spec("Leafpad", &[], &["leafpad"], &[], &[], &[]),
+    spec("Notepad++", &[], &["notepad-plus-plus"], &[], &[r"%ProgramFiles%\Notepad++\notepad++.exe", r"%ProgramFiles(x86)%\Notepad++\notepad++.exe"], &["notepad++.exe"]),
+    spec("Notepad", &[], &[], &[], &[r"%SystemRoot%\System32\notepad.exe", r"%SystemRoot%\notepad.exe"], &["notepad.exe"]),
+    spec("Atom", &["Atom.app"], &["atom"], &["io.atom.Atom"], &[r"%LOCALAPPDATA%\atom\atom.exe", r"%LOCALAPPDATA%\atom\bin\atom.cmd"], &["atom.cmd", "atom.exe"]),
+    spec("Brackets", &["Brackets.app"], &["brackets"], &[], &[r"%ProgramFiles(x86)%\Brackets\Brackets.exe", r"%ProgramFiles%\Brackets\Brackets.exe"], &["Brackets.exe"]),
+    spec("Light Table", &["LightTable.app"], &["lighttable"], &[], &[r"%LOCALAPPDATA%\LightTable\LightTable.exe"], &["LightTable.exe"]),
+
+    // macOS-only GUI editors.
+    spec("Nova", &["Nova.app"], &[], &[], &[], &[]),
+    spec("BBEdit", &["BBEdit.app"], &[], &[], &[], &[]),
+    spec("TextMate", &["TextMate.app"], &[], &[], &[], &[]),
+    spec("CotEditor", &["CotEditor.app"], &[], &[], &[], &[]),
+    spec("TextEdit", &["TextEdit.app"], &[], &[], &[], &[]),
+
+    // Vim/Neovim GUI front-ends (the TUI variants are terminal-only, below).
+    spec("MacVim", &["MacVim.app"], &["mvim", "gvim"], &[], &[], &[]),
+    spec("gVim", &[], &["gvim"], &[], &[r"%ProgramFiles%\Vim\vim91\gvim.exe", r"%ProgramFiles(x86)%\Vim\vim91\gvim.exe", r"%ProgramFiles(x86)%\Vim\vim90\gvim.exe"], &["gvim.exe", "gvim.bat"]),
+    spec("VimR", &["VimR.app"], &[], &[], &[], &[]),
+    spec("Neovide", &["Neovide.app"], &["neovide"], &[], &[], &["neovide.exe"]),
+    spec("Emacs", &["Emacs.app", "Aquamacs.app"], &["emacs"], &["org.gnu.emacs"],
+        &[r"%ProgramFiles%\Emacs\*\bin\runemacs.exe", r"%ProgramFiles%\Emacs\emacs-*\bin\runemacs.exe"], &["runemacs.exe"]),
+
+    // Terminal/TUI editors — listed for completeness, skipped by auto-detect.
+    term_spec("Neovim", &[], &["nvim"], &["io.neovim.nvim"], &[r"%ProgramFiles%\Neovim\bin\nvim.exe"], &["nvim.exe"], "{path}"),
+    term_spec("Vim", &[], &["vim"], &["org.vim.Vim"], &[r"%ProgramFiles%\Vim\vim91\vim.exe", r"%ProgramFiles(x86)%\Vim\vim91\vim.exe"], &["vim.exe"], "{path}"),
+    term_spec("Helix", &[], &["hx", "helix"], &["com.helix_editor.Helix"], &[], &["hx.exe"], "{path}"),
+    term_spec("Micro", &[], &["micro"], &["io.github.zyedidia.micro"], &[], &["micro.exe"], "{path}"),
+    term_spec("Nano", &[], &["nano"], &[], &[], &["nano.exe"], "{path}"),
+    term_spec("Emacs (terminal)", &[], &["emacs"], &["org.gnu.emacs"], &[], &["emacs.exe"], "-nw {path}"),
+];
+
+// ─── Detection ────────────────────────────────────────────────────────────────
+
+/// Discover installed GUI editors on this machine, with absolute exec paths.
+#[cfg(target_os = "macos")]
+pub fn detect() -> Vec<EditorConfig> {
+    let dirs = mac_app_dirs();
+    let mut out = Vec::new();
+    for s in REGISTRY {
+        if s.terminal {
+            continue;
+        }
+        if let Some(path) = s
+            .mac_apps
+            .iter()
+            .flat_map(|app| dirs.iter().map(move |d| d.join(app)))
+            .find(|p| p.exists())
+        {
+            out.push(EditorConfig { name: s.name.into(), exec_path: path.to_string_lossy().into(), args: s.args.into() });
+        }
+    }
+    dedup(out)
+}
+
+/// Discover installed GUI editors on this machine, with absolute exec paths.
+#[cfg(all(unix, not(target_os = "macos")))]
+pub fn detect() -> Vec<EditorConfig> {
+    let dirs = linux_search_dirs();
+    let mut out = Vec::new();
+    for s in REGISTRY {
+        if s.terminal {
+            continue;
+        }
+        // Plain binaries first, then flatpak wrappers (filename == app id, found
+        // in the flatpak export dirs that linux_search_dirs() includes).
+        let found = s
+            .linux_bins
+            .iter()
+            .chain(s.linux_flatpak_ids.iter())
+            .find_map(|name| which_in(&dirs, name));
+        if let Some(path) = found {
+            out.push(EditorConfig { name: s.name.into(), exec_path: path.to_string_lossy().into(), args: s.args.into() });
+        }
+    }
+    dedup(out)
+}
+
+/// Discover installed GUI editors on this machine, with absolute exec paths.
+#[cfg(target_os = "windows")]
+pub fn detect() -> Vec<EditorConfig> {
+    let mut out = Vec::new();
+    for s in REGISTRY {
+        if s.terminal {
+            continue;
+        }
+        let found = s
+            .win_paths
+            .iter()
+            .find_map(|p| resolve_win_path(p))
+            .or_else(|| s.win_bins.iter().find_map(|b| which_windows(b)));
+        if let Some(path) = found {
+            out.push(EditorConfig { name: s.name.into(), exec_path: path.to_string_lossy().into(), args: s.args.into() });
+        }
+    }
+    dedup(out)
+}
+
+/// Drop entries that resolved to the same executable, keeping the first.
+fn dedup(mut v: Vec<EditorConfig>) -> Vec<EditorConfig> {
+    let mut seen = std::collections::HashSet::new();
+    v.retain(|e| seen.insert(e.exec_path.clone()));
+    v
+}
+
+#[cfg(unix)]
+fn expand_tilde(p: &str) -> PathBuf {
+    if let Some(rest) = p.strip_prefix("~/") {
+        if let Some(home) = dirs::home_dir() {
+            return home.join(rest);
+        }
+    }
+    PathBuf::from(p)
+}
+
+#[cfg(target_os = "macos")]
+fn mac_app_dirs() -> Vec<PathBuf> {
+    const DIRS: &[&str] = &[
+        "/Applications",
+        "/Applications/Utilities",
+        "~/Applications",
+        "~/Applications/JetBrains Toolbox",
+        "/System/Applications",
+        "/System/Applications/Utilities",
+    ];
+    DIRS.iter().map(|d| expand_tilde(d)).collect()
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn linux_search_dirs() -> Vec<PathBuf> {
+    // GUI apps often launch with a reduced PATH, so search $PATH PLUS the common
+    // locations editors install into, including flatpak/snap export bins and
+    // JetBrains Toolbox shim scripts.
+    const EXTRA: &[&str] = &[
+        "/usr/local/bin",
+        "/usr/bin",
+        "/bin",
+        "/snap/bin",
+        "/opt",
+        "/var/lib/flatpak/exports/bin",
+        "~/.local/share/flatpak/exports/bin",
+        "~/.local/bin",
+        "~/bin",
+        "/home/linuxbrew/.linuxbrew/bin",
+        "~/.local/share/JetBrains/Toolbox/scripts",
+    ];
+    let mut dirs: Vec<PathBuf> = std::env::var_os("PATH")
+        .map(|p| std::env::split_paths(&p).collect())
+        .unwrap_or_default();
+    for e in EXTRA {
+        dirs.push(expand_tilde(e));
+    }
+    if let Some(xdg) = std::env::var_os("XDG_DATA_HOME") {
+        dirs.push(PathBuf::from(xdg).join("flatpak/exports/bin"));
+    }
+    dirs
+}
+
+/// Find `name` as a regular file in any of `dirs` (symlinks/scripts included).
+#[allow(dead_code)]
+fn which_in(dirs: &[PathBuf], name: &str) -> Option<PathBuf> {
+    dirs.iter().map(|d| d.join(name)).find(|p| p.is_file())
+}
+
+#[cfg(target_os = "windows")]
+fn which_windows(bin: &str) -> Option<PathBuf> {
+    let dirs: Vec<PathBuf> = std::env::var_os("PATH")
+        .map(|p| std::env::split_paths(&p).collect())
+        .unwrap_or_default();
+    which_in(&dirs, bin)
+}
+
+/// Expand `%VAR%` placeholders. Returns None if any referenced var is unset, so
+/// a path that can't be resolved is simply skipped.
+#[cfg(target_os = "windows")]
+fn expand_env_win(s: &str) -> Option<String> {
+    let mut out = String::new();
+    let mut rest = s;
+    while let Some(start) = rest.find('%') {
+        out.push_str(&rest[..start]);
+        let after = &rest[start + 1..];
+        match after.find('%') {
+            Some(end) => {
+                out.push_str(&std::env::var(&after[..end]).ok()?);
+                rest = &after[end + 1..];
+            }
+            None => {
+                out.push_str(&rest[start..]);
+                return Some(out);
+            }
+        }
+    }
+    out.push_str(rest);
+    Some(out)
+}
+
+#[cfg(target_os = "windows")]
+fn resolve_win_path(pat: &str) -> Option<PathBuf> {
+    let expanded = expand_env_win(pat)?;
+    resolve_glob(&expanded).into_iter().find(|p| p.is_file())
+}
+
+/// Resolve a path that may contain `*` wildcards in directory components into
+/// all existing matches (e.g. `JetBrains\IntelliJ IDEA*\bin\idea64.exe`). No
+/// recursive `**`. Used for Windows versioned install dirs.
+#[allow(dead_code)]
+fn resolve_glob(path: &str) -> Vec<PathBuf> {
+    if !path.contains('*') {
+        let pb = PathBuf::from(path);
+        return if pb.exists() { vec![pb] } else { vec![] };
+    }
+    let segments: Vec<&str> = path.split(|c| c == '/' || c == '\\').collect();
+    // Seed the search base from the first segment (root / drive / relative).
+    let first = segments[0];
+    let mut current: Vec<PathBuf> = if first.is_empty() {
+        vec![PathBuf::from("/")]
+    } else if first.ends_with(':') {
+        vec![PathBuf::from(format!("{first}\\"))]
+    } else {
+        vec![PathBuf::from(first)]
+    };
+    for seg in &segments[1..] {
+        if seg.is_empty() {
+            continue;
+        }
+        let mut next = Vec::new();
+        for base in &current {
+            if seg.contains('*') {
+                if let Ok(rd) = std::fs::read_dir(base) {
+                    for entry in rd.flatten() {
+                        let name = entry.file_name();
+                        let name = name.to_string_lossy();
+                        if wildcard_match(seg, &name) {
+                            next.push(base.join(&*name));
+                        }
+                    }
+                }
+            } else {
+                let cand = base.join(seg);
+                if cand.exists() {
+                    next.push(cand);
+                }
+            }
+        }
+        current = next;
+        if current.is_empty() {
+            break;
+        }
+    }
+    current
+}
+
+/// Case-insensitive glob match for a single path component supporting `*`.
+#[allow(dead_code)]
+fn wildcard_match(pattern: &str, name: &str) -> bool {
+    let p: Vec<char> = pattern.to_lowercase().chars().collect();
+    let s: Vec<char> = name.to_lowercase().chars().collect();
+    let (mut pi, mut si) = (0usize, 0usize);
+    let (mut star, mut mark) = (None, 0usize);
+    while si < s.len() {
+        if pi < p.len() && (p[pi] == s[si]) {
+            pi += 1;
+            si += 1;
+        } else if pi < p.len() && p[pi] == '*' {
+            star = Some(pi);
+            mark = si;
+            pi += 1;
+        } else if let Some(st) = star {
+            pi = st + 1;
+            mark += 1;
+            si = mark;
+        } else {
+            return false;
+        }
+    }
+    while pi < p.len() && p[pi] == '*' {
+        pi += 1;
+    }
+    pi == p.len()
+}
+
+/// Pick a sensible editor when the caller didn't specify one: the first detected
+/// editor, preferring the popular IDEs (and the VS Code family the old
+/// hard-coded path targeted).
+pub fn resolve_default() -> Option<EditorConfig> {
+    const PREFERRED: &[&str] = &["Visual Studio Code", "VSCodium", "Cursor", "Windsurf", "Sublime Text", "Zed"];
+    let detected = detect();
+    detected
+        .iter()
+        .find(|e| PREFERRED.contains(&e.name.as_str()))
+        .cloned()
+        .or_else(|| detected.into_iter().next())
+}
+
+// ─── Launching ──────────────────────────────────────────────────────────────
+
+/// Launch `editor` against `file`. Spawns and returns immediately (the caller's
+/// file watcher handles save-and-re-upload, so we never pass a `--wait` flag).
+/// Returns a user-facing message on failure.
+pub fn launch(editor: &EditorConfig, file: &Path) -> Result<(), String> {
+    let file_str = file.to_string_lossy().to_string();
+
+    // macOS .app bundles aren't executables — open them via `open -a`, which
+    // also works regardless of whether the editor's CLI shim is on PATH.
+    #[cfg(target_os = "macos")]
+    if editor.exec_path.ends_with(".app") {
+        return std::process::Command::new("open")
+            .arg("-a")
+            .arg(&editor.exec_path)
+            .arg(&file_str)
+            .spawn()
+            .map(|_| ())
+            .map_err(|e| format!("Failed to open {}: {e}", editor.name));
+    }
+
+    let exec = editor.exec_path.trim();
+    if exec.is_empty() {
+        return Err(format!("{} has no executable path set.", editor.name));
+    }
+    // An absolute/relative path that doesn't exist is a misconfiguration; a bare
+    // command name is left for the OS to resolve via PATH.
+    if exec.contains(std::path::MAIN_SEPARATOR) && !Path::new(exec).exists() {
+        return Err(format!(
+            "{} not found at {exec}. Update its path in Settings → Editors.",
+            editor.name
+        ));
+    }
+
+    let args = build_args(&editor.args, &file_str);
+    std::process::Command::new(exec)
+        .args(&args)
+        .spawn()
+        .map(|_| ())
+        .map_err(|e| format!("Failed to launch {} ({exec}): {e}", editor.name))
+}
+
+/// Split an args template into individual arguments, substituting `{path}` with
+/// the target file. Honours single/double quotes so a quoted token survives as
+/// one argument. If the template has no `{path}`, the file is appended last.
+fn build_args(template: &str, file: &str) -> Vec<String> {
+    let mut args: Vec<String> = Vec::new();
+    let mut cur = String::new();
+    let mut in_single = false;
+    let mut in_double = false;
+    let mut has_token = false;
+
+    for ch in template.chars() {
+        match ch {
+            '\'' if !in_double => {
+                in_single = !in_single;
+                has_token = true;
+            }
+            '"' if !in_single => {
+                in_double = !in_double;
+                has_token = true;
+            }
+            c if c.is_whitespace() && !in_single && !in_double => {
+                if has_token {
+                    args.push(std::mem::take(&mut cur));
+                    has_token = false;
+                }
+            }
+            c => {
+                cur.push(c);
+                has_token = true;
+            }
+        }
+    }
+    if has_token {
+        args.push(cur);
+    }
+
+    let mut substituted = false;
+    for a in args.iter_mut() {
+        if a.contains("{path}") {
+            *a = a.replace("{path}", file);
+            substituted = true;
+        }
+    }
+    if !substituted {
+        args.push(file.to_string());
+    }
+    args
+}
+
+// ─── Commands ─────────────────────────────────────────────────────────────────
+
+/// List editors detected on this machine, for the Settings → Editors picker.
+#[tauri::command]
+pub fn detect_editors() -> Vec<EditorConfig> {
+    detect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn substitutes_path_placeholder() {
+        assert_eq!(build_args("{path}", "/tmp/a.txt"), vec!["/tmp/a.txt"]);
+        assert_eq!(build_args("-n -w {path}", "/tmp/a.txt"), vec!["-n", "-w", "/tmp/a.txt"]);
+    }
+
+    #[test]
+    fn appends_path_when_no_placeholder() {
+        assert_eq!(build_args("", "/tmp/a.txt"), vec!["/tmp/a.txt"]);
+        assert_eq!(build_args("--reuse-window", "/tmp/a.txt"), vec!["--reuse-window", "/tmp/a.txt"]);
+    }
+
+    #[test]
+    fn honours_quotes() {
+        assert_eq!(
+            build_args("--flag \"some value\" {path}", "/tmp/a b.txt"),
+            vec!["--flag", "some value", "/tmp/a b.txt"]
+        );
+    }
+
+    #[test]
+    fn placeholder_inside_quoted_token() {
+        assert_eq!(build_args("\"{path}\"", "/tmp/a b.txt"), vec!["/tmp/a b.txt"]);
+    }
+
+    #[test]
+    fn wildcard_matches() {
+        assert!(wildcard_match("IntelliJ IDEA*", "IntelliJ IDEA 2024.1"));
+        assert!(wildcard_match("*", "anything"));
+        assert!(wildcard_match("vim9*", "vim91"));
+        assert!(!wildcard_match("PyCharm*", "IntelliJ IDEA"));
+        assert!(wildcard_match("NetBeans*", "netbeans 21")); // case-insensitive
+    }
+
+    #[test]
+    fn glob_resolves_versioned_dirs() {
+        // Build a temp tree: <tmp>/JetBrains/IDEA 2024.1/bin/idea64.exe
+        let root = std::env::temp_dir().join(format!("anyscp_glob_{}", uuid::Uuid::new_v4()));
+        let bin = root.join("JetBrains").join("IDEA 2024.1").join("bin");
+        std::fs::create_dir_all(&bin).unwrap();
+        let exe = bin.join("idea64.exe");
+        std::fs::write(&exe, b"x").unwrap();
+
+        let pattern = format!("{}/JetBrains/IDEA*/bin/idea64.exe", root.to_string_lossy());
+        let matches = resolve_glob(&pattern);
+        assert_eq!(matches, vec![exe]);
+
+        // A non-matching glob yields nothing.
+        let none = resolve_glob(&format!("{}/JetBrains/NOPE*/x", root.to_string_lossy()));
+        assert!(none.is_empty());
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn registry_has_no_empty_names_and_terminal_uses_args() {
+        for s in REGISTRY {
+            assert!(!s.name.is_empty());
+            assert!(!s.args.is_empty());
+        }
+        // detect() never returns terminal editors.
+        for e in detect() {
+            assert!(REGISTRY.iter().any(|s| s.name == e.name && !s.terminal));
+        }
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 mod ai;
 mod db;
+mod editors;
 mod import;
 mod portforward;
 mod s3;
@@ -180,7 +181,7 @@ pub fn run() {
             sftp::commands::sftp_download,
             sftp::commands::sftp_upload,
             sftp::commands::sftp_cancel_transfer,
-            sftp::commands::sftp_edit_in_vscode,
+            sftp::commands::sftp_edit_external,
             // SFTP — queue-based Transfer Manager
             sftp::commands::sftp_enqueue_upload,
             sftp::commands::sftp_enqueue_download,
@@ -205,7 +206,7 @@ pub fn run() {
             scp::commands::scp_download,
             scp::commands::scp_upload,
             scp::commands::scp_cancel_transfer,
-            scp::commands::scp_edit_in_vscode,
+            scp::commands::scp_edit_external,
             // SCP — queue-based Transfer Manager
             scp::commands::scp_enqueue_upload,
             scp::commands::scp_enqueue_download,
@@ -243,6 +244,8 @@ pub fn run() {
             // App settings
             db::commands::save_setting,
             db::commands::load_all_settings,
+            // External editors
+            editors::detect_editors,
             // Credential vault
             vault::vault_save_credential,
             vault::vault_delete_credential,
@@ -276,7 +279,7 @@ pub fn run() {
             s3::commands::s3_retry_transfer,
             s3::commands::s3_list_transfers,
             s3::commands::s3_clear_finished_transfers,
-            s3::commands::s3_edit_in_vscode,
+            s3::commands::s3_edit_external,
             // SSH config import
             import::commands::import_parse_ssh_config,
             import::commands::import_save_ssh_hosts,

--- a/src-tauri/src/s3/commands.rs
+++ b/src-tauri/src/s3/commands.rs
@@ -899,13 +899,15 @@ pub async fn s3_clear_finished_transfers(
 
 // ─── Edit in VS Code ─────────────────────────────────────────────────────────
 
-/// Download an S3 object to a temp directory, open it in VS Code,
-/// watch for saves, and re-upload to S3 each time the file is saved.
+/// Download an S3 object to a temp directory, open it in an external editor,
+/// watch for saves, and re-upload to S3 each time the file is saved. `editor` is
+/// the editor to use; when `None`, an installed one is auto-detected.
 #[tauri::command]
-#[instrument(skip(s3_manager, app_handle), fields(s3_session_id = %s3_session_id, key = %key))]
-pub async fn s3_edit_in_vscode(
+#[instrument(skip(s3_manager, app_handle, editor), fields(s3_session_id = %s3_session_id, key = %key))]
+pub async fn s3_edit_external(
     s3_session_id: String,
     key: String,
+    editor: Option<crate::editors::EditorConfig>,
     s3_manager: State<'_, Arc<S3Manager>>,
     app_handle: AppHandle,
 ) -> Result<(), S3Error> {
@@ -937,17 +939,18 @@ pub async fn s3_edit_in_vscode(
             .map_err(|e| S3Error::IoError(e.to_string()))?;
     }
 
-    // 2. Open in VS Code (without --wait so it returns immediately).
-    tokio::process::Command::new("code")
-        .arg(&local_path)
-        .spawn()
-        .map_err(|e| {
-            S3Error::IoError(format!(
-                "Failed to open VS Code: {e}. Is 'code' in your PATH?"
-            ))
+    // 2. Open in the chosen editor (or an auto-detected one), non-blocking.
+    let editor = editor
+        .or_else(crate::editors::resolve_default)
+        .ok_or_else(|| {
+            S3Error::IoError("No editor found. Add one in Settings → Editors.".to_string())
         })?;
+    crate::editors::launch(&editor, &local_path).map_err(S3Error::IoError)?;
 
-    crate::telemetry::capture("edit_in_vscode", serde_json::json!({ "source": "s3" }));
+    crate::telemetry::capture(
+        "edit_external",
+        serde_json::json!({ "source": "s3", "editor": editor.name }),
+    );
 
     // 3. Watch for file saves and re-upload on each save.
     let key_bg = key.clone();

--- a/src-tauri/src/scp/commands.rs
+++ b/src-tauri/src/scp/commands.rs
@@ -447,9 +447,7 @@ pub async fn scp_edit_external(
     let editor = editor
         .or_else(crate::editors::resolve_default)
         .ok_or_else(|| {
-            ScpError::LocalIoError(
-                "No editor found. Add one in Settings → Editors.".to_string(),
-            )
+            ScpError::LocalIoError("No editor found. Add one in Settings → Editors.".to_string())
         })?;
     crate::editors::launch(&editor, &local_path).map_err(ScpError::LocalIoError)?;
 

--- a/src-tauri/src/scp/commands.rs
+++ b/src-tauri/src/scp/commands.rs
@@ -415,13 +415,14 @@ pub async fn scp_cancel_transfer(
     scp_manager.cancel_transfer(&transfer_id)
 }
 
-/// Download a remote file to a temp dir, open it in VS Code, and re-upload on
-/// each save. Mirrors `sftp_edit_in_vscode` but over SCP.
+/// Download a remote file to a temp dir, open it in an external editor, and
+/// re-upload on each save. Mirrors `sftp_edit_external` but over SCP.
 #[tauri::command]
-#[instrument(skip(scp_manager, app_handle), fields(scp_session_id = %scp_session_id, remote_path = %remote_path))]
-pub async fn scp_edit_in_vscode(
+#[instrument(skip(scp_manager, app_handle, editor), fields(scp_session_id = %scp_session_id, remote_path = %remote_path))]
+pub async fn scp_edit_external(
     scp_session_id: String,
     remote_path: String,
+    editor: Option<crate::editors::EditorConfig>,
     scp_manager: State<'_, Arc<ScpManager>>,
     app_handle: AppHandle,
 ) -> Result<(), ScpError> {
@@ -442,17 +443,20 @@ pub async fn scp_edit_in_vscode(
     let token = CancellationToken::new();
     transfer::download_file(handle.clone(), &remote_path, &local_path, &token, |_| {}).await?;
 
-    // 2. Open VS Code (non-blocking).
-    tokio::process::Command::new("code")
-        .arg(&local_path)
-        .spawn()
-        .map_err(|e| {
-            ScpError::LocalIoError(format!(
-                "Failed to open VS Code: {e}. Is 'code' in your PATH?"
-            ))
+    // 2. Open in the chosen editor (or an auto-detected one), non-blocking.
+    let editor = editor
+        .or_else(crate::editors::resolve_default)
+        .ok_or_else(|| {
+            ScpError::LocalIoError(
+                "No editor found. Add one in Settings → Editors.".to_string(),
+            )
         })?;
+    crate::editors::launch(&editor, &local_path).map_err(ScpError::LocalIoError)?;
 
-    crate::telemetry::capture("edit_in_vscode", serde_json::json!({ "source": "scp" }));
+    crate::telemetry::capture(
+        "edit_external",
+        serde_json::json!({ "source": "scp", "editor": editor.name }),
+    );
 
     // 3. Watch for saves and re-upload (best-effort, 30-minute window).
     let handle_bg = handle.clone();

--- a/src-tauri/src/sftp/commands.rs
+++ b/src-tauri/src/sftp/commands.rs
@@ -817,9 +817,7 @@ pub async fn sftp_edit_external(
     let editor = editor
         .or_else(crate::editors::resolve_default)
         .ok_or_else(|| {
-            SftpError::LocalIoError(
-                "No editor found. Add one in Settings → Editors.".to_string(),
-            )
+            SftpError::LocalIoError("No editor found. Add one in Settings → Editors.".to_string())
         })?;
     crate::editors::launch(&editor, &local_path).map_err(SftpError::LocalIoError)?;
 

--- a/src-tauri/src/sftp/commands.rs
+++ b/src-tauri/src/sftp/commands.rs
@@ -762,13 +762,15 @@ pub async fn sftp_cancel_transfer(
     sftp_manager.cancel_transfer(&transfer_id)
 }
 
-/// Download a remote file to a temp directory, open it in VS Code,
-/// watch for saves, and re-upload each time the file is saved.
+/// Download a remote file to a temp directory, open it in an external editor,
+/// watch for saves, and re-upload each time the file is saved. `editor` is the
+/// editor to use; when `None`, an installed one is auto-detected.
 #[tauri::command]
-#[instrument(skip(sftp_manager, app_handle), fields(sftp_session_id = %sftp_session_id, remote_path = %remote_path))]
-pub async fn sftp_edit_in_vscode(
+#[instrument(skip(sftp_manager, app_handle, editor), fields(sftp_session_id = %sftp_session_id, remote_path = %remote_path))]
+pub async fn sftp_edit_external(
     sftp_session_id: String,
     remote_path: String,
+    editor: Option<crate::editors::EditorConfig>,
     sftp_manager: State<'_, Arc<SftpManager>>,
     app_handle: AppHandle,
 ) -> Result<(), SftpError> {
@@ -810,17 +812,21 @@ pub async fn sftp_edit_in_vscode(
             .map_err(|e| SftpError::LocalIoError(e.to_string()))?;
     }
 
-    // 2. Open in VS Code (without --wait so it returns immediately)
-    tokio::process::Command::new("code")
-        .arg(&local_path)
-        .spawn()
-        .map_err(|e| {
-            SftpError::LocalIoError(format!(
-                "Failed to open VS Code: {e}. Is 'code' in your PATH?"
-            ))
+    // 2. Open in the chosen editor (or an auto-detected one). Spawns and returns
+    //    immediately; the watcher below handles save-and-re-upload.
+    let editor = editor
+        .or_else(crate::editors::resolve_default)
+        .ok_or_else(|| {
+            SftpError::LocalIoError(
+                "No editor found. Add one in Settings → Editors.".to_string(),
+            )
         })?;
+    crate::editors::launch(&editor, &local_path).map_err(SftpError::LocalIoError)?;
 
-    crate::telemetry::capture("edit_in_vscode", serde_json::json!({ "source": "sftp" }));
+    crate::telemetry::capture(
+        "edit_external",
+        serde_json::json!({ "source": "sftp", "editor": editor.name }),
+    );
 
     // 3. Watch for file saves and re-upload on each save
     let sftp_arc_bg = sftp_arc.clone();

--- a/src/components/explorer/ExplorerFileTable.tsx
+++ b/src/components/explorer/ExplorerFileTable.tsx
@@ -23,6 +23,7 @@ import type { ExplorerEntry, ExplorerClipboard, FileSystemProvider } from "../..
 import { ContextMenu } from "../shared/ContextMenu";
 import type { ContextMenuItem } from "../shared/ContextMenu";
 import { formatBytes } from "../../utils/format";
+import { useSettingsStore, type EditorConfig } from "../../stores/settings-store";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -38,7 +39,7 @@ interface ExplorerFileTableProps {
   onDownload: (entry: ExplorerEntry) => void;
   onDelete: (entries: ExplorerEntry[]) => Promise<void>;
   onRename?: (entry: ExplorerEntry, newName: string) => Promise<void>;
-  onEditInEditor?: (entry: ExplorerEntry) => void;
+  onEditInEditor?: (entry: ExplorerEntry, editor?: EditorConfig) => void;
   onPresignUrl?: (entry: ExplorerEntry) => void;
   onGetInfo?: (entry: ExplorerEntry) => void;
   creatingFile?: boolean;
@@ -271,6 +272,8 @@ export function ExplorerFileTable({
   loading,
 }: ExplorerFileTableProps) {
   const caps = provider.capabilities;
+  const editors = useSettingsStore((s) => s.editors);
+  const defaultEditorId = useSettingsStore((s) => s.defaultEditorId);
   const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
   const [renamingId, setRenamingId] = useState<string | null>(null);
   const [confirmDelete, setConfirmDelete] = useState<ExplorerEntry[] | null>(null);
@@ -473,13 +476,28 @@ export function ExplorerFileTable({
       return items;
     }
 
-    // Single item context menu
-    if (caps.canEditInEditor && entry.entryType !== "Directory") {
+    // Single item context menu. Only offered when at least one editor is
+    // configured (auto-seeded on first run, or added in Settings → Editors).
+    if (caps.canEditInEditor && entry.entryType !== "Directory" && editors.length > 0) {
+      const defaultEditor = editors.find((e) => e.id === defaultEditorId) ?? editors[0];
+      // Primary "Edit" uses the default editor.
       items.push({
-        label: "Edit in VS Code",
+        label: `Edit in ${defaultEditor.name}`,
         icon: ExternalLink,
-        onClick: () => onEditInEditor?.(entry),
+        onClick: () => onEditInEditor?.(entry, defaultEditor),
       });
+      // "Open With ▸" lists every configured editor (only worth showing when
+      // there's a choice beyond the default).
+      if (editors.length > 1) {
+        items.push({
+          label: "Open With",
+          icon: ExternalLink,
+          submenu: editors.map((ed) => ({
+            label: ed.name,
+            onClick: () => onEditInEditor?.(entry, ed),
+          })),
+        });
+      }
     }
 
     if (caps.canDownload) {

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -23,6 +23,7 @@ import { PortForwardingPage } from "../port-forwarding";
 import { HistoryPage } from "../history";
 import { usePortForwardEvents } from "../../hooks/use-port-forward-events";
 import { UpdateDialog } from "../updater/UpdateDialog";
+import { Toaster } from "../shared/Toaster";
 
 export function AppShell() {
   const themeMode = useSettingsStore((s) => s.themeMode);
@@ -369,6 +370,9 @@ export function AppShell() {
 
       {/* Snippet command palette */}
       <SnippetPalette />
+
+      {/* Transient notifications (errors, etc.) */}
+      <Toaster />
     </div>
   );
 }

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -290,7 +290,7 @@ export function AppShell() {
       <Sidebar />
 
       {/* Main content */}
-      <div className="flex flex-col flex-1 min-w-0 rounded-xl overflow-hidden">
+      <div className="flex flex-col flex-1 min-w-0 overflow-hidden">
         {/* Unified tab bar — always shown */}
         <UnifiedTabBar />
 

--- a/src/components/layout/UnifiedTabBar.tsx
+++ b/src/components/layout/UnifiedTabBar.tsx
@@ -82,7 +82,7 @@ export function UnifiedTabBar() {
   return (
     <div className="flex items-center h-[var(--tabbar-height)] no-select px-2">
       <div
-        className="flex items-center gap-1.5 overflow-x-auto overflow-y-hidden flex-1 min-w-0"
+        className="flex items-center gap-2.5 overflow-x-auto overflow-y-hidden flex-1 min-w-0"
         role="tablist"
         aria-label="Open sessions"
       >
@@ -133,7 +133,7 @@ export function UnifiedTabBar() {
               title={tab.label + (paneCount > 1 ? ` (${paneCount} panes)` : "")}
               className={[
                 "group relative flex items-center gap-2 px-3.5 h-[30px] shrink-0 max-w-[220px]",
-                "text-[length:var(--text-sm)] leading-none rounded-lg cursor-pointer",
+                "text-[length:var(--text-sm)] leading-none rounded-md cursor-pointer",
                 "transition-[color,background-color] duration-[var(--duration-fast)]",
                 "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
                 isActive

--- a/src/components/s3/S3Browser.tsx
+++ b/src/components/s3/S3Browser.tsx
@@ -5,6 +5,9 @@ import type { S3BucketInfo, S3ListResult } from "../../types";
 import type { ExplorerEntry } from "../../types/explorer";
 import { ExplorerToolbar, ExplorerFileTable, ExplorerDropZone } from "../explorer";
 import { createS3Provider, toS3ExplorerEntry } from "../../providers/s3-provider";
+import { editorLaunchErrorMessage } from "../../lib/editor-errors";
+import { toast } from "../../stores/toast-store";
+import type { EditorConfig } from "../../stores/settings-store";
 
 interface S3BrowserProps {
   sessionId: string;
@@ -294,18 +297,19 @@ export function S3Browser({ sessionId, isActive = true }: S3BrowserProps) {
     } catch { /* best-effort */ }
   }, [sessionId, session]);
 
-  // ─── Edit in VS Code ─────────────────────────────────────────────────────
+  // ─── Edit in external editor ───────────────────────────────────────────────
 
-  const handleEditInEditor = useCallback((entry: ExplorerEntry) => {
+  const handleEditInEditor = useCallback((entry: ExplorerEntry, editor?: EditorConfig) => {
     void (async () => {
       try {
         const { invoke } = await import("@tauri-apps/api/core");
-        await invoke("s3_edit_in_vscode", {
+        await invoke("s3_edit_external", {
           s3SessionId: sessionId,
           key: entry.id,
+          editor: editor ?? null,
         });
-      } catch {
-        // VS Code may not be installed
+      } catch (err) {
+        toast.error(editorLaunchErrorMessage(err));
       }
     })();
   }, [sessionId]);

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useRef } from "react";
 import { useSettingsStore } from "../../stores/settings-store";
 import { CustomSelect, type SelectOption } from "../shared/CustomSelect";
 import { useUpdaterStore } from "../../stores/updater-store";
+import { toast } from "../../stores/toast-store";
 import { RefreshCw, CheckCircle2, AlertCircle, Palette, SquareTerminal, ArrowUpDown, Info, ExternalLink, Check, FileCode, Plus, Trash2, FolderOpen, Star, Search } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import type { CursorStyle, ThemeMode, EditorConfig } from "../../stores/settings-store";
@@ -34,6 +35,8 @@ const TEXT_INPUT_CLASS = [
   "outline-none focus:border-border-focus focus:ring-2 focus:ring-ring",
   "transition-[border-color,box-shadow] duration-[var(--duration-fast)]",
 ].join(" ");
+
+const FIELD_LABEL_CLASS = "block text-[length:var(--text-xs)] font-medium text-text-secondary mb-1.5";
 
 const REPO_URL = "https://github.com/macnev2013/anySCP";
 
@@ -619,35 +622,39 @@ function EditorsSettings() {
 
   const [detected, setDetected] = useState<DetectedEditor[] | null>(null);
   const [detecting, setDetecting] = useState(false);
+  const [customOpen, setCustomOpen] = useState(false);
+
+  const configuredPaths = new Set(editors.map((e) => e.execPath));
+  const newlyDetected = (detected ?? []).filter((e) => !configuredPaths.has(e.execPath));
 
   const scan = useCallback(async () => {
     setDetecting(true);
     try {
       const { invoke } = await import("@tauri-apps/api/core");
-      setDetected(await invoke<DetectedEditor[]>("detect_editors"));
+      const found = await invoke<DetectedEditor[]>("detect_editors");
+      setDetected(found);
+      // Feedback when the scan adds nothing new (the common case after the
+      // first-run auto-seed) so the button doesn't feel inert.
+      const configured = new Set(useSettingsStore.getState().editors.map((e) => e.execPath));
+      if (found.filter((e) => !configured.has(e.execPath)).length === 0) {
+        toast.info(found.length === 0
+          ? "No editors found on this computer."
+          : "All detected editors are already added.");
+      }
     } catch {
-      setDetected([]);
+      toast.error("Couldn't scan for editors.");
     } finally {
       setDetecting(false);
     }
   }, []);
 
-  // Auto-scan once when the user has nothing configured yet, so the section
-  // isn't empty on first visit.
-  useEffect(() => {
-    if (editors.length === 0 && detected === null) void scan();
-  }, [editors.length, detected, scan]);
-
-  const configuredPaths = new Set(editors.map((e) => e.execPath));
-  const newlyDetected = (detected ?? []).filter((e) => !configuredPaths.has(e.execPath));
-
   return (
     <>
-      <SettingsGroup label="Your editors">
+      <SettingsGroup label="Editors">
         {editors.length === 0 ? (
           <div className="px-4 py-6 rounded-xl bg-bg-surface border border-border/50 text-center">
             <p className="text-[length:var(--text-sm)] text-text-muted">
-              No editors configured yet. Add a detected one below, or set up a custom editor.
+              No editors configured. Scan for installed editors, or add one manually.
             </p>
           </div>
         ) : (
@@ -661,37 +668,33 @@ function EditorsSettings() {
                 onRemove={() => removeEditor(ed.id)}
               />
             ))}
-            <p className="px-1 text-[length:var(--text-xs)] text-text-muted">
-              The starred editor is used by “Edit” in the file browser; the rest appear under “Open With”.
-            </p>
           </div>
         )}
-      </SettingsGroup>
 
-      <SettingsGroup label="Detected on this computer">
-        <div className="flex items-center justify-between gap-4 px-4 py-3 rounded-xl bg-bg-surface border border-border/50">
-          <div>
-            <p className={LABEL_CLASS}>Scan for installed editors</p>
-            <p className={DESC_CLASS}>Looks for common editors like VS Code, Sublime Text, and more</p>
-          </div>
+        {/* Actions: the two ways to add an editor. */}
+        <div className="flex items-center gap-2 mt-3">
           <button onClick={() => void scan()} disabled={detecting} className={BTN_SECONDARY}>
             {detecting
               ? <RefreshCw size={13} strokeWidth={2} className="motion-safe:animate-spin" />
               : <Search size={13} strokeWidth={2} />}
-            {detecting ? "Scanning…" : "Scan"}
+            {detecting ? "Scanning…" : "Scan for editors"}
+          </button>
+          <button onClick={() => setCustomOpen(true)} className={BTN_SECONDARY}>
+            <Plus size={13} strokeWidth={2} /> Add custom editor
           </button>
         </div>
 
-        {detected !== null && newlyDetected.length === 0 && (
+        {editors.length > 0 && (
           <p className="px-1 mt-2 text-[length:var(--text-xs)] text-text-muted">
-            {detected.length === 0
-              ? "No editors detected. Add one manually below."
-              : "All detected editors have been added."}
+            The starred editor is used by “Edit”; the rest appear under “Open With”.
           </p>
         )}
+      </SettingsGroup>
 
-        {newlyDetected.length > 0 && (
-          <div className="flex flex-col gap-2 mt-2">
+      {/* Detected-but-not-added editors appear only after a scan turns some up. */}
+      {newlyDetected.length > 0 && (
+        <SettingsGroup label="Found on this computer">
+          <div className="flex flex-col gap-2">
             {newlyDetected.map((ed) => (
               <div
                 key={ed.execPath}
@@ -712,12 +715,10 @@ function EditorsSettings() {
               </div>
             ))}
           </div>
-        )}
-      </SettingsGroup>
+        </SettingsGroup>
+      )}
 
-      <SettingsGroup label="Add a custom editor">
-        <AddEditorForm onAdd={addEditor} />
-      </SettingsGroup>
+      <AddEditorModal open={customOpen} onClose={() => setCustomOpen(false)} onAdd={addEditor} />
     </>
   );
 }
@@ -772,89 +773,163 @@ function EditorRow({ editor, isDefault, onMakeDefault, onRemove }: {
   );
 }
 
-function AddEditorForm({ onAdd }: { onAdd: (editor: Omit<EditorConfig, "id">) => void }) {
+/** Modal form for adding a custom editor — opened from the Editors section so
+ *  the multi-field form isn't always taking up space on the page. */
+function AddEditorModal({ open, onClose, onAdd }: {
+  open: boolean;
+  onClose: () => void;
+  onAdd: (editor: Omit<EditorConfig, "id">) => void;
+}) {
   const [name, setName] = useState("");
   const [execPath, setExecPath] = useState("");
   const [args, setArgs] = useState("{path}");
+  const [visible, setVisible] = useState(false);
+
+  const backdropRef = useRef<HTMLDivElement>(null);
+  const nameRef = useRef<HTMLInputElement>(null);
+
+  // Reset fields and play the open transition each time it's shown.
+  useEffect(() => {
+    if (open) {
+      setName("");
+      setExecPath("");
+      setArgs("{path}");
+      requestAnimationFrame(() => setVisible(true));
+    } else {
+      setVisible(false);
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (visible) requestAnimationFrame(() => nameRef.current?.focus());
+  }, [visible]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
 
   const browse = useCallback(async () => {
     try {
-      const { open } = await import("@tauri-apps/plugin-dialog");
-      const picked = await open({ multiple: false, directory: false, title: "Select editor executable" });
+      const { open: openDialog } = await import("@tauri-apps/plugin-dialog");
+      const picked = await openDialog({ multiple: false, directory: false, title: "Select editor executable" });
       if (typeof picked === "string") {
         setExecPath(picked);
-        // Pre-fill the name from the file/app name if it's still blank.
-        if (!name.trim()) {
-          const base = picked.split(/[\\/]/).pop() ?? "";
-          setName(base.replace(/\.(app|exe)$/i, ""));
-        }
+        // Pre-fill the name from the file/app name when it's still blank.
+        setName((cur) => (cur.trim() ? cur : (picked.split(/[\\/]/).pop() ?? "").replace(/\.(app|exe)$/i, "")));
       }
     } catch { /* dialog cancelled / unavailable */ }
-  }, [name]);
+  }, []);
 
   const canAdd = name.trim().length > 0 && execPath.trim().length > 0;
 
-  const submit = () => {
+  const submit = (e: React.FormEvent) => {
+    e.preventDefault();
     if (!canAdd) return;
     onAdd({ name: name.trim(), execPath: execPath.trim(), args: args.trim() || "{path}" });
-    setName("");
-    setExecPath("");
-    setArgs("{path}");
+    onClose();
   };
 
+  if (!open) return null;
+
   return (
-    <div className="flex flex-col gap-3 px-4 py-4 rounded-xl bg-bg-surface border border-border/50">
-      <div className="flex flex-col gap-1.5">
-        <label htmlFor="ed-name" className={LABEL_CLASS}>Name</label>
-        <input
-          id="ed-name"
-          data-testid="ed-name"
-          type="text"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          placeholder="e.g. Sublime Text"
-          className={TEXT_INPUT_CLASS}
-        />
-      </div>
-
-      <div className="flex flex-col gap-1.5">
-        <label htmlFor="ed-path" className={LABEL_CLASS}>Executable path</label>
-        <div className="flex items-center gap-2">
-          <input
-            id="ed-path"
-            data-testid="ed-path"
-            type="text"
-            value={execPath}
-            onChange={(e) => setExecPath(e.target.value)}
-            placeholder="/path/to/editor"
-            className={TEXT_INPUT_CLASS}
-          />
-          <button type="button" onClick={() => void browse()} className={BTN_SECONDARY}>
-            <FolderOpen size={13} strokeWidth={2} /> Browse
-          </button>
+    <div
+      ref={backdropRef}
+      onClick={(e) => { if (e.target === backdropRef.current) onClose(); }}
+      className={[
+        "fixed inset-0 z-50 flex items-start justify-center pt-[12vh]",
+        "transition-[background-color,backdrop-filter] duration-[var(--duration-base)]",
+        visible ? "bg-black/50 backdrop-blur-sm" : "bg-black/0 backdrop-blur-none",
+      ].join(" ")}
+    >
+      <div
+        className={[
+          "w-full max-w-md rounded-xl bg-bg-overlay border border-border p-6 shadow-[var(--shadow-lg)]",
+          "transition-[opacity,transform] duration-[var(--duration-slow)] ease-[var(--ease-expo-out)]",
+          visible ? "opacity-100 translate-y-0" : "opacity-0 -translate-y-3",
+        ].join(" ")}
+      >
+        <div className="flex items-center gap-3 mb-5">
+          <div className="flex items-center justify-center w-10 h-10 rounded-lg shrink-0 bg-accent/15">
+            <FileCode size={20} strokeWidth={1.8} className="text-accent" aria-hidden="true" />
+          </div>
+          <h2 className="text-[length:var(--text-lg)] font-semibold text-text-primary">Add custom editor</h2>
         </div>
-      </div>
 
-      <div className="flex flex-col gap-1.5">
-        <label htmlFor="ed-args" className={LABEL_CLASS}>Arguments</label>
-        <input
-          id="ed-args"
-          data-testid="ed-args"
-          type="text"
-          value={args}
-          onChange={(e) => setArgs(e.target.value)}
-          placeholder="{path}"
-          className={TEXT_INPUT_CLASS}
-        />
-        <p className={DESC_CLASS}>
-          Use <code className="px-1 rounded bg-bg-base">{"{path}"}</code> where the file should go. If omitted, it's added at the end.
-        </p>
-      </div>
+        <form onSubmit={submit} className="flex flex-col gap-4">
+          <div>
+            <label htmlFor="ed-name" className={FIELD_LABEL_CLASS}>Name</label>
+            <input
+              ref={nameRef}
+              id="ed-name"
+              data-testid="ed-name"
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="e.g. Sublime Text"
+              className={TEXT_INPUT_CLASS}
+            />
+          </div>
 
-      <div className="flex justify-end">
-        <button type="button" onClick={submit} disabled={!canAdd} className={BTN_SECONDARY}>
-          <Plus size={13} strokeWidth={2} /> Add editor
-        </button>
+          <div>
+            <label htmlFor="ed-path" className={FIELD_LABEL_CLASS}>Executable path</label>
+            <div className="flex items-center gap-2">
+              <input
+                id="ed-path"
+                data-testid="ed-path"
+                type="text"
+                value={execPath}
+                onChange={(e) => setExecPath(e.target.value)}
+                placeholder="/path/to/editor"
+                className={TEXT_INPUT_CLASS}
+              />
+              <button type="button" onClick={() => void browse()} className={BTN_SECONDARY}>
+                <FolderOpen size={13} strokeWidth={2} /> Browse
+              </button>
+            </div>
+          </div>
+
+          <div>
+            <label htmlFor="ed-args" className={FIELD_LABEL_CLASS}>Arguments</label>
+            <input
+              id="ed-args"
+              data-testid="ed-args"
+              type="text"
+              value={args}
+              onChange={(e) => setArgs(e.target.value)}
+              placeholder="{path}"
+              className={TEXT_INPUT_CLASS}
+            />
+            <p className={DESC_CLASS}>
+              Use <code className="px-1 rounded bg-bg-base">{"{path}"}</code> where the file should go. If omitted, it's added at the end.
+            </p>
+          </div>
+
+          <div className="flex justify-end gap-2 mt-1">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2 text-[length:var(--text-sm)] text-text-secondary hover:text-text-primary rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={!canAdd}
+              className={[
+                "px-4 py-2 text-[length:var(--text-sm)] font-medium rounded-lg",
+                "text-text-inverse bg-accent hover:bg-accent-hover",
+                "disabled:opacity-50 disabled:cursor-not-allowed",
+                "transition-colors duration-[var(--duration-fast)]",
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-bg-overlay",
+              ].join(" ")}
+            >
+              Add editor
+            </button>
+          </div>
+        </form>
       </div>
     </div>
   );

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -29,14 +29,15 @@ const BTN_SECONDARY = [
   "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
 ].join(" ");
 
+// Mirrors the input/label styling used by the Host modal so dialogs feel uniform.
 const TEXT_INPUT_CLASS = [
-  "w-full px-2.5 py-1.5 rounded-lg text-[length:var(--text-sm)]",
+  "w-full px-3 py-2 rounded-lg text-[length:var(--text-sm)]",
   "bg-bg-base border border-border text-text-primary placeholder:text-text-muted",
   "outline-none focus:border-border-focus focus:ring-2 focus:ring-ring",
   "transition-[border-color,box-shadow] duration-[var(--duration-fast)]",
 ].join(" ");
 
-const FIELD_LABEL_CLASS = "block text-[length:var(--text-xs)] font-medium text-text-secondary mb-1.5";
+const FIELD_LABEL_CLASS = "block text-[length:var(--text-xs)] font-medium text-text-secondary mb-1";
 
 const REPO_URL = "https://github.com/macnev2013/anySCP";
 
@@ -839,26 +840,38 @@ function AddEditorModal({ open, onClose, onAdd }: {
       ref={backdropRef}
       onClick={(e) => { if (e.target === backdropRef.current) onClose(); }}
       className={[
-        "fixed inset-0 z-50 flex items-start justify-center pt-[12vh]",
+        "fixed inset-0 z-50 flex items-start justify-center pt-[8vh]",
         "transition-[background-color,backdrop-filter] duration-[var(--duration-base)]",
         visible ? "bg-black/50 backdrop-blur-sm" : "bg-black/0 backdrop-blur-none",
       ].join(" ")}
     >
-      <div
+      <form
+        onSubmit={submit}
+        data-testid="editor-modal"
         className={[
-          "w-full max-w-md rounded-xl bg-bg-overlay border border-border p-6 shadow-[var(--shadow-lg)]",
+          "w-full max-w-md rounded-xl bg-bg-overlay border border-border shadow-[var(--shadow-lg)]",
+          "flex flex-col max-h-[84vh]",
           "transition-[opacity,transform] duration-[var(--duration-slow)] ease-[var(--ease-expo-out)]",
           visible ? "opacity-100 translate-y-0" : "opacity-0 -translate-y-3",
         ].join(" ")}
       >
-        <div className="flex items-center gap-3 mb-5">
-          <div className="flex items-center justify-center w-10 h-10 rounded-lg shrink-0 bg-accent/15">
-            <FileCode size={20} strokeWidth={1.8} className="text-accent" aria-hidden="true" />
-          </div>
-          <h2 className="text-[length:var(--text-lg)] font-semibold text-text-primary">Add custom editor</h2>
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 pt-5 pb-4 border-b border-border shrink-0">
+          <h2 className="text-[length:var(--text-lg)] font-semibold text-text-primary">Add Editor</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="p-1.5 rounded-md text-text-muted hover:text-text-primary hover:bg-bg-subtle transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+              <path d="M1 1l12 12M13 1L1 13" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
+            </svg>
+          </button>
         </div>
 
-        <form onSubmit={submit} className="flex flex-col gap-4">
+        {/* Body */}
+        <div className="px-6 py-4 overflow-y-auto flex-1 min-h-0 flex flex-col gap-4">
           <div>
             <label htmlFor="ed-name" className={FIELD_LABEL_CLASS}>Name</label>
             <input
@@ -885,7 +898,11 @@ function AddEditorModal({ open, onClose, onAdd }: {
                 placeholder="/path/to/editor"
                 className={TEXT_INPUT_CLASS}
               />
-              <button type="button" onClick={() => void browse()} className={BTN_SECONDARY}>
+              <button
+                type="button"
+                onClick={() => void browse()}
+                className="inline-flex items-center gap-1.5 px-3 py-2 shrink-0 rounded-lg text-[length:var(--text-sm)] font-medium bg-bg-base border border-border text-text-secondary hover:text-text-primary hover:border-border-focus hover:bg-bg-overlay transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
                 <FolderOpen size={13} strokeWidth={2} /> Browse
               </button>
             </div>
@@ -906,31 +923,26 @@ function AddEditorModal({ open, onClose, onAdd }: {
               Use <code className="px-1 rounded bg-bg-base">{"{path}"}</code> where the file should go. If omitted, it's added at the end.
             </p>
           </div>
+        </div>
 
-          <div className="flex justify-end gap-2 mt-1">
-            <button
-              type="button"
-              onClick={onClose}
-              className="px-4 py-2 text-[length:var(--text-sm)] text-text-secondary hover:text-text-primary rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-            >
-              Cancel
-            </button>
-            <button
-              type="submit"
-              disabled={!canAdd}
-              className={[
-                "px-4 py-2 text-[length:var(--text-sm)] font-medium rounded-lg",
-                "text-text-inverse bg-accent hover:bg-accent-hover",
-                "disabled:opacity-50 disabled:cursor-not-allowed",
-                "transition-colors duration-[var(--duration-fast)]",
-                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-bg-overlay",
-              ].join(" ")}
-            >
-              Add editor
-            </button>
-          </div>
-        </form>
-      </div>
+        {/* Footer */}
+        <div className="px-6 pb-5 pt-3 flex items-center justify-end gap-2 border-t border-border shrink-0">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-4 py-2 text-[length:var(--text-sm)] text-text-secondary hover:text-text-primary rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={!canAdd}
+            className="px-4 py-2 text-[length:var(--text-sm)] font-medium text-text-inverse bg-accent hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-bg-overlay"
+          >
+            Add editor
+          </button>
+        </div>
+      </form>
     </div>
   );
 }

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -2,9 +2,9 @@ import { useState, useEffect, useCallback, useRef } from "react";
 import { useSettingsStore } from "../../stores/settings-store";
 import { CustomSelect, type SelectOption } from "../shared/CustomSelect";
 import { useUpdaterStore } from "../../stores/updater-store";
-import { RefreshCw, CheckCircle2, AlertCircle, Palette, SquareTerminal, ArrowUpDown, Info, ExternalLink, Check } from "lucide-react";
+import { RefreshCw, CheckCircle2, AlertCircle, Palette, SquareTerminal, ArrowUpDown, Info, ExternalLink, Check, FileCode, Plus, Trash2, FolderOpen, Star, Search } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
-import type { CursorStyle, ThemeMode } from "../../stores/settings-store";
+import type { CursorStyle, ThemeMode, EditorConfig } from "../../stores/settings-store";
 
 // ─── Shared styles ───────────────────────────────────────────────────────────
 
@@ -18,18 +18,36 @@ const INPUT_CLASS = [
   "transition-[border-color,box-shadow] duration-[var(--duration-fast)]",
 ].join(" ");
 
+const BTN_SECONDARY = [
+  "flex items-center gap-1.5 px-3 py-1.5 rounded-lg shrink-0",
+  "text-[length:var(--text-sm)] font-medium",
+  "bg-bg-base border border-border text-text-secondary",
+  "hover:text-text-primary hover:border-border-focus",
+  "disabled:opacity-50 disabled:pointer-events-none",
+  "transition-all duration-[var(--duration-fast)]",
+  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+].join(" ");
+
+const TEXT_INPUT_CLASS = [
+  "w-full px-2.5 py-1.5 rounded-lg text-[length:var(--text-sm)]",
+  "bg-bg-base border border-border text-text-primary placeholder:text-text-muted",
+  "outline-none focus:border-border-focus focus:ring-2 focus:ring-ring",
+  "transition-[border-color,box-shadow] duration-[var(--duration-fast)]",
+].join(" ");
+
 const REPO_URL = "https://github.com/macnev2013/anySCP";
 
 // ─── Sections ─────────────────────────────────────────────────────────────────
 // Each settings category is a section here. To add a new category, add an entry
 // to SECTIONS, a description, and render its content in <SectionContent />.
 
-type SectionId = "appearance" | "terminal" | "transfers" | "about";
+type SectionId = "appearance" | "terminal" | "transfers" | "editors" | "about";
 
 const SECTIONS: { id: SectionId; label: string; icon: LucideIcon }[] = [
   { id: "appearance", label: "Appearance", icon: Palette },
   { id: "terminal", label: "Terminal", icon: SquareTerminal },
   { id: "transfers", label: "Transfers", icon: ArrowUpDown },
+  { id: "editors", label: "Editors", icon: FileCode },
   { id: "about", label: "About & Updates", icon: Info },
 ];
 
@@ -37,6 +55,7 @@ const SECTION_DESCRIPTIONS: Record<SectionId, string> = {
   appearance: "Theme and interface look.",
   terminal: "Font, cursor, and scrollback history.",
   transfers: "Control how files are transferred.",
+  editors: "Editors used by “Edit” / “Open With” in the file browser.",
   about: "App information, links, and updates.",
 };
 
@@ -123,6 +142,8 @@ function SectionContent({ section }: { section: SectionId }) {
       return <TerminalSettings />;
     case "transfers":
       return <TransferSettings />;
+    case "editors":
+      return <EditorsSettings />;
     case "about":
       return <AboutSettings />;
   }
@@ -581,6 +602,261 @@ function TransferSettings() {
         <NumberSetting id="s-concurrency" value={transferConcurrency} min={1} max={10} step={1} onChange={setConcurrency} />
       </SettingRow>
     </SettingsGroup>
+  );
+}
+
+// ─── Editors ──────────────────────────────────────────────────────────────────
+
+/** A detected editor as returned by the `detect_editors` backend command. */
+type DetectedEditor = { name: string; execPath: string; args: string };
+
+function EditorsSettings() {
+  const editors = useSettingsStore((s) => s.editors);
+  const defaultEditorId = useSettingsStore((s) => s.defaultEditorId);
+  const addEditor = useSettingsStore((s) => s.addEditor);
+  const removeEditor = useSettingsStore((s) => s.removeEditor);
+  const setDefaultEditor = useSettingsStore((s) => s.setDefaultEditor);
+
+  const [detected, setDetected] = useState<DetectedEditor[] | null>(null);
+  const [detecting, setDetecting] = useState(false);
+
+  const scan = useCallback(async () => {
+    setDetecting(true);
+    try {
+      const { invoke } = await import("@tauri-apps/api/core");
+      setDetected(await invoke<DetectedEditor[]>("detect_editors"));
+    } catch {
+      setDetected([]);
+    } finally {
+      setDetecting(false);
+    }
+  }, []);
+
+  // Auto-scan once when the user has nothing configured yet, so the section
+  // isn't empty on first visit.
+  useEffect(() => {
+    if (editors.length === 0 && detected === null) void scan();
+  }, [editors.length, detected, scan]);
+
+  const configuredPaths = new Set(editors.map((e) => e.execPath));
+  const newlyDetected = (detected ?? []).filter((e) => !configuredPaths.has(e.execPath));
+
+  return (
+    <>
+      <SettingsGroup label="Your editors">
+        {editors.length === 0 ? (
+          <div className="px-4 py-6 rounded-xl bg-bg-surface border border-border/50 text-center">
+            <p className="text-[length:var(--text-sm)] text-text-muted">
+              No editors configured yet. Add a detected one below, or set up a custom editor.
+            </p>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-2">
+            {editors.map((ed) => (
+              <EditorRow
+                key={ed.id}
+                editor={ed}
+                isDefault={ed.id === defaultEditorId}
+                onMakeDefault={() => setDefaultEditor(ed.id)}
+                onRemove={() => removeEditor(ed.id)}
+              />
+            ))}
+            <p className="px-1 text-[length:var(--text-xs)] text-text-muted">
+              The starred editor is used by “Edit” in the file browser; the rest appear under “Open With”.
+            </p>
+          </div>
+        )}
+      </SettingsGroup>
+
+      <SettingsGroup label="Detected on this computer">
+        <div className="flex items-center justify-between gap-4 px-4 py-3 rounded-xl bg-bg-surface border border-border/50">
+          <div>
+            <p className={LABEL_CLASS}>Scan for installed editors</p>
+            <p className={DESC_CLASS}>Looks for common editors like VS Code, Sublime Text, and more</p>
+          </div>
+          <button onClick={() => void scan()} disabled={detecting} className={BTN_SECONDARY}>
+            {detecting
+              ? <RefreshCw size={13} strokeWidth={2} className="motion-safe:animate-spin" />
+              : <Search size={13} strokeWidth={2} />}
+            {detecting ? "Scanning…" : "Scan"}
+          </button>
+        </div>
+
+        {detected !== null && newlyDetected.length === 0 && (
+          <p className="px-1 mt-2 text-[length:var(--text-xs)] text-text-muted">
+            {detected.length === 0
+              ? "No editors detected. Add one manually below."
+              : "All detected editors have been added."}
+          </p>
+        )}
+
+        {newlyDetected.length > 0 && (
+          <div className="flex flex-col gap-2 mt-2">
+            {newlyDetected.map((ed) => (
+              <div
+                key={ed.execPath}
+                className="flex items-center justify-between gap-3 px-4 py-3 rounded-xl bg-bg-surface border border-border/50"
+              >
+                <div className="min-w-0">
+                  <p className={LABEL_CLASS}>{ed.name}</p>
+                  <p className="text-[length:var(--text-xs)] text-text-muted truncate" title={ed.execPath}>
+                    {ed.execPath}
+                  </p>
+                </div>
+                <button
+                  onClick={() => addEditor({ name: ed.name, execPath: ed.execPath, args: ed.args || "{path}" })}
+                  className={BTN_SECONDARY}
+                >
+                  <Plus size={13} strokeWidth={2} /> Add
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+      </SettingsGroup>
+
+      <SettingsGroup label="Add a custom editor">
+        <AddEditorForm onAdd={addEditor} />
+      </SettingsGroup>
+    </>
+  );
+}
+
+function EditorRow({ editor, isDefault, onMakeDefault, onRemove }: {
+  editor: EditorConfig;
+  isDefault: boolean;
+  onMakeDefault: () => void;
+  onRemove: () => void;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-3 px-4 py-3 rounded-xl bg-bg-surface border border-border/50">
+      <div className="min-w-0">
+        <p className={`${LABEL_CLASS} flex items-center gap-1.5`}>
+          {editor.name}
+          {isDefault && (
+            <span className="text-[length:var(--text-2xs)] font-medium text-accent uppercase tracking-wide">Default</span>
+          )}
+        </p>
+        <p className="text-[length:var(--text-xs)] text-text-muted truncate" title={editor.execPath}>
+          {editor.execPath} <span className="opacity-60">· {editor.args}</span>
+        </p>
+      </div>
+      <div className="flex items-center gap-1.5 shrink-0">
+        <button
+          type="button"
+          onClick={onMakeDefault}
+          disabled={isDefault}
+          title={isDefault ? "Default editor" : "Set as default"}
+          aria-label={isDefault ? "Default editor" : "Set as default"}
+          className={[
+            "p-1.5 rounded-lg border transition-colors duration-[var(--duration-fast)]",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+            isDefault
+              ? "border-transparent text-accent pointer-events-none"
+              : "border-border text-text-muted hover:text-text-primary hover:border-border-focus",
+          ].join(" ")}
+        >
+          <Star size={15} strokeWidth={2} fill={isDefault ? "currentColor" : "none"} />
+        </button>
+        <button
+          type="button"
+          onClick={onRemove}
+          title="Remove"
+          aria-label={`Remove ${editor.name}`}
+          className="p-1.5 rounded-lg border border-border text-text-muted hover:text-status-error hover:border-status-error/40 transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <Trash2 size={15} strokeWidth={2} />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function AddEditorForm({ onAdd }: { onAdd: (editor: Omit<EditorConfig, "id">) => void }) {
+  const [name, setName] = useState("");
+  const [execPath, setExecPath] = useState("");
+  const [args, setArgs] = useState("{path}");
+
+  const browse = useCallback(async () => {
+    try {
+      const { open } = await import("@tauri-apps/plugin-dialog");
+      const picked = await open({ multiple: false, directory: false, title: "Select editor executable" });
+      if (typeof picked === "string") {
+        setExecPath(picked);
+        // Pre-fill the name from the file/app name if it's still blank.
+        if (!name.trim()) {
+          const base = picked.split(/[\\/]/).pop() ?? "";
+          setName(base.replace(/\.(app|exe)$/i, ""));
+        }
+      }
+    } catch { /* dialog cancelled / unavailable */ }
+  }, [name]);
+
+  const canAdd = name.trim().length > 0 && execPath.trim().length > 0;
+
+  const submit = () => {
+    if (!canAdd) return;
+    onAdd({ name: name.trim(), execPath: execPath.trim(), args: args.trim() || "{path}" });
+    setName("");
+    setExecPath("");
+    setArgs("{path}");
+  };
+
+  return (
+    <div className="flex flex-col gap-3 px-4 py-4 rounded-xl bg-bg-surface border border-border/50">
+      <div className="flex flex-col gap-1.5">
+        <label htmlFor="ed-name" className={LABEL_CLASS}>Name</label>
+        <input
+          id="ed-name"
+          data-testid="ed-name"
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="e.g. Sublime Text"
+          className={TEXT_INPUT_CLASS}
+        />
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <label htmlFor="ed-path" className={LABEL_CLASS}>Executable path</label>
+        <div className="flex items-center gap-2">
+          <input
+            id="ed-path"
+            data-testid="ed-path"
+            type="text"
+            value={execPath}
+            onChange={(e) => setExecPath(e.target.value)}
+            placeholder="/path/to/editor"
+            className={TEXT_INPUT_CLASS}
+          />
+          <button type="button" onClick={() => void browse()} className={BTN_SECONDARY}>
+            <FolderOpen size={13} strokeWidth={2} /> Browse
+          </button>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <label htmlFor="ed-args" className={LABEL_CLASS}>Arguments</label>
+        <input
+          id="ed-args"
+          data-testid="ed-args"
+          type="text"
+          value={args}
+          onChange={(e) => setArgs(e.target.value)}
+          placeholder="{path}"
+          className={TEXT_INPUT_CLASS}
+        />
+        <p className={DESC_CLASS}>
+          Use <code className="px-1 rounded bg-bg-base">{"{path}"}</code> where the file should go. If omitted, it's added at the end.
+        </p>
+      </div>
+
+      <div className="flex justify-end">
+        <button type="button" onClick={submit} disabled={!canAdd} className={BTN_SECONDARY}>
+          <Plus size={13} strokeWidth={2} /> Add editor
+        </button>
+      </div>
+    </div>
   );
 }
 

--- a/src/components/sftp/ExplorerView.tsx
+++ b/src/components/sftp/ExplorerView.tsx
@@ -8,6 +8,9 @@ import type { ExplorerEntry, ExplorerClipboard } from "../../types/explorer";
 import { ExplorerToolbar, ExplorerFileTable, ExplorerDropZone } from "../explorer";
 import { createSftpProvider, toExplorerEntry } from "../../providers/sftp-provider";
 import { explorerInvoke, transferEventName, type Transport } from "../../lib/explorer-transport";
+import { editorLaunchErrorMessage } from "../../lib/editor-errors";
+import { toast } from "../../stores/toast-store";
+import type { EditorConfig } from "../../stores/settings-store";
 
 interface ExplorerViewProps {
   /** The transport session id (sftp_session_id or scp_session_id). */
@@ -420,14 +423,17 @@ export function ExplorerView({ sessionId, transport = "sftp", isActive = true }:
     }
   }, [sessionId, transport, session, loadDirectory]);
 
-  // ─── Edit in VS Code ─────────────────────────────────────────────────────
+  // ─── Edit in external editor ───────────────────────────────────────────────
 
-  const handleEditInEditor = useCallback((entry: ExplorerEntry) => {
+  const handleEditInEditor = useCallback((entry: ExplorerEntry, editor?: EditorConfig) => {
     void (async () => {
       try {
-        await explorerInvoke(transport, "edit_in_vscode", sessionId, { remotePath: entry.id });
-      } catch {
-        // VS Code may not be installed
+        await explorerInvoke(transport, "edit_external", sessionId, {
+          remotePath: entry.id,
+          editor: editor ?? null,
+        });
+      } catch (err) {
+        toast.error(editorLaunchErrorMessage(err));
       }
     })();
   }, [sessionId, transport]);

--- a/src/components/shared/ContextMenu.tsx
+++ b/src/components/shared/ContextMenu.tsx
@@ -1,13 +1,17 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
+import { ChevronRight } from "lucide-react";
 
 export interface ContextMenuItem {
   label: string;
   icon?: React.ElementType;
-  onClick: () => void;
+  /** Leaf action. Omitted for items that only open a `submenu`. */
+  onClick?: () => void;
   danger?: boolean;
   disabled?: boolean;
   /** Render a separator line above this item */
   separator?: boolean;
+  /** Nested items — turns this row into a flyout submenu. */
+  submenu?: ContextMenuItem[];
 }
 
 interface ContextMenuProps {
@@ -35,6 +39,89 @@ function clampPosition(
   const clampedY = y + menuHeight > vh ? vh - menuHeight - 8 : y;
 
   return { x: Math.max(8, clampedX), y: Math.max(8, clampedY) };
+}
+
+// ─── Item ──────────────────────────────────────────────────────────────────────
+
+function MenuRow({ item, onClose }: { item: ContextMenuItem; onClose: () => void }) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [open, setOpen] = useState(false);
+  const [flip, setFlip] = useState(false);
+  const hasSubmenu = !!item.submenu && item.submenu.length > 0;
+  const Icon = item.icon;
+
+  // Open the flyout to the left when it would overflow the right viewport edge.
+  useEffect(() => {
+    if (open && ref.current) {
+      const rect = ref.current.getBoundingClientRect();
+      setFlip(rect.right + MENU_WIDTH > window.innerWidth);
+    }
+  }, [open]);
+
+  return (
+    <div
+      ref={ref}
+      className="relative"
+      onMouseEnter={() => hasSubmenu && setOpen(true)}
+      onMouseLeave={() => hasSubmenu && setOpen(false)}
+    >
+      {item.separator && <div className="h-px bg-border my-1" role="separator" />}
+      <button
+        role="menuitem"
+        aria-haspopup={hasSubmenu || undefined}
+        aria-expanded={hasSubmenu ? open : undefined}
+        disabled={item.disabled}
+        onClick={() => {
+          if (item.disabled) return;
+          if (hasSubmenu) {
+            setOpen((o) => !o);
+            return;
+          }
+          item.onClick?.();
+          onClose();
+        }}
+        className={[
+          "w-full px-3 py-1.5 flex items-center gap-2",
+          "text-[length:var(--text-sm)] text-left cursor-pointer",
+          "transition-colors duration-[var(--duration-fast)]",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset",
+          item.disabled
+            ? "opacity-40 pointer-events-none"
+            : item.danger
+              ? "text-status-error hover:bg-status-error/10"
+              : "text-text-primary hover:bg-bg-subtle",
+        ].join(" ")}
+      >
+        {Icon && (
+          <Icon
+            size={15}
+            strokeWidth={1.8}
+            aria-hidden="true"
+            className={item.danger ? "text-status-error" : "text-text-muted"}
+          />
+        )}
+        <span className="flex-1 truncate">{item.label}</span>
+        {hasSubmenu && <ChevronRight size={14} strokeWidth={1.8} aria-hidden="true" className="-mr-1 text-text-muted" />}
+      </button>
+
+      {hasSubmenu && open && (
+        <div
+          role="menu"
+          className={[
+            "absolute top-0 z-10 py-1 min-w-[160px]",
+            flip ? "right-full mr-0.5" : "left-full ml-0.5",
+            "bg-bg-overlay border border-border rounded-lg",
+            "shadow-[var(--shadow-lg)]",
+            "animate-in fade-in-0 zoom-in-95 duration-[var(--duration-fast)]",
+          ].join(" ")}
+        >
+          {item.submenu!.map((sub, i) => (
+            <MenuRow key={i} item={sub} onClose={onClose} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
 }
 
 // ─── Component ────────────────────────────────────────────────────────────────
@@ -81,48 +168,9 @@ export function ContextMenu({ items, position, onClose }: ContextMenuProps) {
         "animate-in fade-in-0 zoom-in-95 duration-[var(--duration-fast)]",
       ].join(" ")}
     >
-      {items.map((item, index) => {
-        const Icon = item.icon;
-
-        return (
-          <div key={index}>
-            {item.separator && (
-              <div className="h-px bg-border my-1" role="separator" />
-            )}
-            <button
-              role="menuitem"
-              disabled={item.disabled}
-              onClick={() => {
-                if (!item.disabled) {
-                  item.onClick();
-                  onClose();
-                }
-              }}
-              className={[
-                "w-full px-3 py-1.5 flex items-center gap-2",
-                "text-[length:var(--text-sm)] text-left cursor-pointer",
-                "transition-colors duration-[var(--duration-fast)]",
-                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset",
-                item.disabled
-                  ? "opacity-40 pointer-events-none"
-                  : item.danger
-                    ? "text-status-error hover:bg-status-error/10"
-                    : "text-text-primary hover:bg-bg-subtle",
-              ].join(" ")}
-            >
-              {Icon && (
-                <Icon
-                  size={15}
-                  strokeWidth={1.8}
-                  aria-hidden="true"
-                  className={item.danger ? "text-status-error" : "text-text-muted"}
-                />
-              )}
-              {item.label}
-            </button>
-          </div>
-        );
-      })}
+      {items.map((item, index) => (
+        <MenuRow key={index} item={item} onClose={onClose} />
+      ))}
     </div>
   );
 }

--- a/src/components/shared/Toaster.tsx
+++ b/src/components/shared/Toaster.tsx
@@ -1,0 +1,50 @@
+import { AlertCircle, CheckCircle2, Info, X } from "lucide-react";
+import { useToastStore, type ToastKind } from "../../stores/toast-store";
+
+const ICONS: Record<ToastKind, React.ElementType> = {
+  error: AlertCircle,
+  success: CheckCircle2,
+  info: Info,
+};
+
+const ACCENTS: Record<ToastKind, string> = {
+  error: "text-status-error",
+  success: "text-status-connected",
+  info: "text-accent",
+};
+
+/** Renders the stack of active toasts. Mount once at the app root. */
+export function Toaster() {
+  const toasts = useToastStore((s) => s.toasts);
+  const dismiss = useToastStore((s) => s.dismiss);
+
+  if (toasts.length === 0) return null;
+
+  return (
+    <div className="fixed bottom-4 right-4 z-[100] flex flex-col gap-2 max-w-sm w-[22rem] pointer-events-none">
+      {toasts.map((t) => {
+        const Icon = ICONS[t.kind];
+        return (
+          <div
+            key={t.id}
+            role="alert"
+            className="pointer-events-auto flex items-start gap-2.5 px-3.5 py-3 rounded-xl bg-bg-overlay border border-border shadow-[var(--shadow-lg)] animate-in fade-in-0 slide-in-from-bottom-2 duration-[var(--duration-fast)]"
+          >
+            <Icon size={16} strokeWidth={2} aria-hidden="true" className={`shrink-0 mt-0.5 ${ACCENTS[t.kind]}`} />
+            <p className="flex-1 min-w-0 text-[length:var(--text-sm)] text-text-primary break-words">
+              {t.message}
+            </p>
+            <button
+              type="button"
+              onClick={() => dismiss(t.id)}
+              aria-label="Dismiss"
+              className="shrink-0 -mr-1 -mt-0.5 p-1 rounded-md text-text-muted hover:text-text-primary hover:bg-bg-subtle transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              <X size={14} strokeWidth={2} />
+            </button>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/lib/editor-errors.ts
+++ b/src/lib/editor-errors.ts
@@ -1,0 +1,15 @@
+// Shared formatting for editor-launch failures surfaced to the user.
+//
+// Backend edit commands reject with a serialized error of the shape
+// `{ kind, message }` (see SftpError / ScpError / S3Error). We previously
+// swallowed these entirely, so launch failures looked like "nothing happened"
+// (issues #12, #45, #56). This pulls out a message worth showing in a toast.
+
+export function editorLaunchErrorMessage(err: unknown): string {
+  if (err && typeof err === "object" && "message" in err) {
+    const msg = String((err as { message: unknown }).message).trim();
+    if (msg) return msg;
+  }
+  if (typeof err === "string" && err.trim()) return err;
+  return "Couldn't open the editor. Configure one in Settings → Editors.";
+}

--- a/src/stores/settings-store.ts
+++ b/src/stores/settings-store.ts
@@ -6,6 +6,19 @@ export type ThemeMode = "dark" | "light";
 /** Full custom accent colour in oklch components (lightness, chroma, hue). */
 export interface AccentCustom { l: number; c: number; h: number }
 
+/**
+ * A configured external editor. `args` is a command template where `{path}` is
+ * replaced with the file to open (the file is appended if `{path}` is absent).
+ * `id` is a UI-only stable key; the backend ignores it. `execPath` is the
+ * absolute path to the binary, or a macOS .app bundle.
+ */
+export interface EditorConfig {
+  id: string;
+  name: string;
+  execPath: string;
+  args: string;
+}
+
 interface SettingsState {
   // Appearance
   themeMode: ThemeMode;
@@ -28,6 +41,10 @@ interface SettingsState {
   // Transfers
   transferConcurrency: number;
 
+  // External editors
+  editors: EditorConfig[];
+  defaultEditorId: string | null;
+
   // State
   loaded: boolean;
 
@@ -45,6 +62,10 @@ interface SettingsState {
   setTerminalLineHeight: (height: number) => void;
   setTerminalScrollback: (lines: number) => void;
   setTransferConcurrency: (n: number) => void;
+  addEditor: (editor: Omit<EditorConfig, "id">) => void;
+  updateEditor: (id: string, patch: Partial<Omit<EditorConfig, "id">>) => void;
+  removeEditor: (id: string) => void;
+  setDefaultEditor: (id: string | null) => void;
   loadSettings: () => Promise<void>;
 }
 
@@ -63,6 +84,8 @@ const DEFAULTS = {
   terminalLineHeight: 1.2,
   terminalScrollback: 5000,
   transferConcurrency: 3,
+  editors: [] as EditorConfig[],
+  defaultEditorId: null as string | null,
 };
 
 /**
@@ -127,6 +150,25 @@ function persist(key: string, value: string) {
       await invoke("save_setting", { key, value });
     } catch { /* best-effort */ }
   })();
+}
+
+/** Persist the whole editor config as one JSON blob (it's a list, not a scalar). */
+function persistEditors(editors: EditorConfig[], defaultEditorId: string | null) {
+  persist("editors_config", JSON.stringify({ editors, defaultEditorId }));
+}
+
+/** Editors that make the best out-of-the-box default, most-preferred first.
+ *  Names must match the backend registry display names (see editors/mod.rs). */
+const PREFERRED_DEFAULT_EDITORS = ["Visual Studio Code", "VSCodium", "Cursor", "Windsurf", "Sublime Text", "Zed"];
+
+/** Choose which seeded editor should be the default — a popular IDE if present,
+ *  otherwise just the first one detected. */
+function pickDefaultEditorId(editors: EditorConfig[]): string | null {
+  for (const name of PREFERRED_DEFAULT_EDITORS) {
+    const match = editors.find((e) => e.name === name);
+    if (match) return match.id;
+  }
+  return editors[0]?.id ?? null;
 }
 
 let accentPersistTimer: ReturnType<typeof setTimeout> | undefined;
@@ -220,12 +262,40 @@ export const useSettingsStore = create<SettingsState>((set) => ({
     })();
   },
 
+  addEditor: (editor) => set((s) => {
+    const next = [...s.editors, { ...editor, id: crypto.randomUUID() }];
+    // The first editor added becomes the default automatically.
+    const defaultEditorId = s.defaultEditorId ?? next[next.length - 1].id;
+    persistEditors(next, defaultEditorId);
+    return { editors: next, defaultEditorId };
+  }),
+
+  updateEditor: (id, patch) => set((s) => {
+    const next = s.editors.map((e) => (e.id === id ? { ...e, ...patch } : e));
+    persistEditors(next, s.defaultEditorId);
+    return { editors: next };
+  }),
+
+  removeEditor: (id) => set((s) => {
+    const next = s.editors.filter((e) => e.id !== id);
+    // If the default was removed, fall back to the first remaining editor.
+    const defaultEditorId = s.defaultEditorId === id ? (next[0]?.id ?? null) : s.defaultEditorId;
+    persistEditors(next, defaultEditorId);
+    return { editors: next, defaultEditorId };
+  }),
+
+  setDefaultEditor: (id) => set((s) => {
+    persistEditors(s.editors, id);
+    return { defaultEditorId: id };
+  }),
+
   loadSettings: async () => {
     try {
       const { invoke } = await import("@tauri-apps/api/core");
       const pairs = await invoke<[string, string][]>("load_all_settings");
 
       const updates: Partial<SettingsState> = {};
+      let editorsSeeded = false;
       for (const [key, value] of pairs) {
         switch (key) {
           case "app_theme": updates.themeMode = value === "light" ? "light" : DEFAULTS.themeMode; break;
@@ -247,6 +317,45 @@ export const useSettingsStore = create<SettingsState>((set) => ({
           case "app_interface_font": updates.interfaceFont = value || DEFAULTS.interfaceFont; break;
           case "app_auto_update": updates.autoUpdate = value !== "false"; break;
           case "app_skipped_update": updates.skippedUpdateVersion = value || null; break;
+          case "editors_config": {
+            try {
+              const parsed = JSON.parse(value) as { editors?: EditorConfig[]; defaultEditorId?: string | null };
+              if (Array.isArray(parsed.editors)) updates.editors = parsed.editors;
+              updates.defaultEditorId = parsed.defaultEditorId ?? null;
+            } catch { /* ignore malformed config */ }
+            break;
+          }
+          case "editors_seeded": editorsSeeded = value === "true"; break;
+        }
+      }
+
+      // First run: auto-detect installed editors and add them so "Edit" / "Open
+      // With" work out of the box. Tracked by a dedicated `editors_seeded` flag
+      // (NOT the mere presence of editors_config) so that a user who later
+      // deletes every editor won't have them silently re-added.
+      if (!editorsSeeded) {
+        const current = updates.editors ?? [];
+        if (current.length > 0) {
+          // A real config already exists (e.g. manually added) — respect it.
+          persist("editors_seeded", "true");
+        } else {
+          try {
+            const detected = await invoke<{ name: string; execPath: string; args: string }[]>("detect_editors");
+            if (detected.length > 0) {
+              const editors: EditorConfig[] = detected.map((d) => ({
+                id: crypto.randomUUID(),
+                name: d.name,
+                execPath: d.execPath,
+                args: d.args || "{path}",
+              }));
+              const defaultEditorId = pickDefaultEditorId(editors);
+              updates.editors = editors;
+              updates.defaultEditorId = defaultEditorId;
+              persistEditors(editors, defaultEditorId);
+              persist("editors_seeded", "true");
+            }
+            // Nothing detected → leave unseeded so we retry on the next launch.
+          } catch { /* detection unavailable — leave unseeded to retry next launch */ }
         }
       }
 

--- a/src/stores/settings-store.ts
+++ b/src/stores/settings-store.ts
@@ -159,7 +159,11 @@ function persistEditors(editors: EditorConfig[], defaultEditorId: string | null)
 
 /** Editors that make the best out-of-the-box default, most-preferred first.
  *  Names must match the backend registry display names (see editors/mod.rs). */
-const PREFERRED_DEFAULT_EDITORS = ["Visual Studio Code", "VSCodium", "Cursor", "Windsurf", "Sublime Text", "Zed"];
+const PREFERRED_DEFAULT_EDITORS = ["VS Code", "VSCodium", "Cursor", "Windsurf", "Sublime Text", "Zed"];
+
+/** Old → new display names for editors renamed in the backend registry, applied
+ *  to already-saved configs on load so existing users see the canonical name. */
+const RENAMED_EDITORS: Record<string, string> = { "Visual Studio Code": "VS Code" };
 
 /** Choose which seeded editor should be the default — a popular IDE if present,
  *  otherwise just the first one detected. */
@@ -320,8 +324,18 @@ export const useSettingsStore = create<SettingsState>((set) => ({
           case "editors_config": {
             try {
               const parsed = JSON.parse(value) as { editors?: EditorConfig[]; defaultEditorId?: string | null };
-              if (Array.isArray(parsed.editors)) updates.editors = parsed.editors;
-              updates.defaultEditorId = parsed.defaultEditorId ?? null;
+              const defaultEditorId = parsed.defaultEditorId ?? null;
+              if (Array.isArray(parsed.editors)) {
+                let renamed = false;
+                const migrated = parsed.editors.map((e) => {
+                  const next = RENAMED_EDITORS[e.name];
+                  if (next && next !== e.name) { renamed = true; return { ...e, name: next }; }
+                  return e;
+                });
+                updates.editors = migrated;
+                if (renamed) persistEditors(migrated, defaultEditorId); // keep the rename
+              }
+              updates.defaultEditorId = defaultEditorId;
             } catch { /* ignore malformed config */ }
             break;
           }

--- a/src/stores/toast-store.ts
+++ b/src/stores/toast-store.ts
@@ -1,0 +1,40 @@
+import { create } from "zustand";
+
+// A minimal transient-notification store. Used to surface action failures that
+// would otherwise be invisible — most importantly editor-launch errors, which
+// used to be swallowed silently (issues #12, #45, #56).
+
+export type ToastKind = "error" | "success" | "info";
+
+export interface Toast {
+  id: string;
+  kind: ToastKind;
+  message: string;
+}
+
+interface ToastState {
+  toasts: Toast[];
+  show: (kind: ToastKind, message: string) => void;
+  dismiss: (id: string) => void;
+}
+
+const AUTO_DISMISS_MS = 6000;
+
+export const useToastStore = create<ToastState>((set) => ({
+  toasts: [],
+  show: (kind, message) => {
+    const id = crypto.randomUUID();
+    set((s) => ({ toasts: [...s.toasts, { id, kind, message }] }));
+    setTimeout(() => {
+      set((s) => ({ toasts: s.toasts.filter((t) => t.id !== id) }));
+    }, AUTO_DISMISS_MS);
+  },
+  dismiss: (id) => set((s) => ({ toasts: s.toasts.filter((t) => t.id !== id) })),
+}));
+
+/** Convenience facade for firing toasts from anywhere (incl. non-React code). */
+export const toast = {
+  error: (message: string) => useToastStore.getState().show("error", message),
+  success: (message: string) => useToastStore.getState().show("success", message),
+  info: (message: string) => useToastStore.getState().show("info", message),
+};


### PR DESCRIPTION
## Summary

Fixes the broken **"Edit in VS Code"** action and adds support for **any editor** (Sublime, JetBrains, Zed, Notepad++, …) via an **Open With** menu and an auto-configured, scannable editor list in Settings.

Closes #12, closes #45, closes #56.

### The bug
The backend spawned `code` from `PATH`. macOS GUI apps launched from Finder/Dock don't inherit the shell `PATH`, so the spawn failed — and the frontend swallowed the error, so **nothing happened**.

## Backend
- **New `editors` module** — a registry-driven, per-OS scanner covering **54 editors**:
  - **macOS:** scans `.app` bundles across the standard app dirs (launches via `open -a`).
  - **Linux:** searches `$PATH` + common dirs **plus flatpak/snap export-bins** and JetBrains Toolbox shims.
  - **Windows:** resolves install paths (with `%ENV%` expansion and `*` globs for versioned dirs) + `PATH`.
  - Launching resolves **absolute paths**, sidestepping `PATH` entirely.
- Generalized `*_edit_in_vscode` → `*_edit_external` (sftp/scp/s3): takes an optional editor and falls back to an auto-detected default. The download → watch → re-upload-on-save flow is unchanged.
- New `detect_editors` command. Unit tests for arg-template parsing, glob/wildcard resolution, and registry invariants.

## Frontend
- **Settings → Editors:** the configured list (set-default / remove) plus two actions — **Scan for editors** and **Add custom editor**. Detected-but-not-added editors appear only after a scan finds some; an empty scan shows a toast instead of a permanent card.
- **Add Editor dialog:** a modal matching the **Add Host** modal chrome (header bar + ✕ close, bordered body, bordered footer with Cancel + primary action), instead of an always-open form.
- **Auto-seed on first run:** detected editors are added automatically (tracked by an `editors_seeded` flag, so user deletions stick); old saved names are migrated to the canonical ones on load.
- **Context menu:** "Edit in *{default}*" + an **Open With** submenu — shown only when an editor is configured. Submenu support added to the shared `ContextMenu`.
- **Toasts:** a small notification store/`Toaster`; launch failures are surfaced instead of failing silently.

## Misc
- Detected stable VS Code is labelled **"VS Code"** (consistent with "VS Code Insiders").
- **Layout:** the main content panel's corner radius now matches the sidebar (`rounded-lg`), and tab spacing/radius were nudged for a tidier tab bar.

## Notes
- Auto-detection is limited to GUI editors (terminal editors like vim/nano are in the registry but skipped, since the app launches editors as detached GUI processes).
- Editor identifiers (`.app` names, Windows paths, Linux bins, flatpak ids) were researched cross-platform and fact-checked. The macOS (`open -a`) and Windows (`%ENV%`/glob) detection paths compile but were only exercised on Linux — worth a smoke test on those OSes before merge.

## Testing
- `cargo test editors::` — 7/7 pass.
- `cargo check` — clean (no warnings).
- `tsc --noEmit` — clean.
- Live smoke test on Linux: detected VS Code + Sublime Text; terminal editors correctly skipped.