### PR TITLE
fix(terminal): preserve pane history when splitting

### DIFF
--- a/src/components/terminal/Terminal.tsx
+++ b/src/components/terminal/Terminal.tsx
@@ -1,98 +1,27 @@
 import { useEffect, useRef } from "react";
-import { Terminal as XTerm } from "@xterm/xterm";
-import { FitAddon } from "@xterm/addon-fit";
 import "@xterm/xterm/css/xterm.css";
 import { useSshOutput } from "../../hooks/use-ssh-events";
-import { useDebouncedCallback } from "../../hooks/use-debounce";
-import { registerSearchAddon, unregisterSearchAddon } from "../../stores/terminal-registry";
+import {
+  ensureTerminal,
+  getTerminal,
+  getTerminalTheme,
+} from "../../stores/terminal-instances";
 import { useSettingsStore } from "../../stores/settings-store";
 import type { SessionId } from "../../types";
-
-/**
- * ANSI 16-color palettes. xterm.js falls back to its built-in palette when these
- * are unset, and that default green (#0DBC79) is nearly illegible on a light
- * background — so we ship palettes tuned for each background's contrast.
- */
-const ANSI_PALETTE_DARK = {
-  black: "#2e3436",
-  red: "#cd3131",
-  green: "#0dbc79",
-  yellow: "#e5e510",
-  blue: "#2472c8",
-  magenta: "#bc3fbc",
-  cyan: "#11a8cd",
-  white: "#e5e5e5",
-  brightBlack: "#666666",
-  brightRed: "#f14c4c",
-  brightGreen: "#23d18b",
-  brightYellow: "#f5f543",
-  brightBlue: "#3b8eea",
-  brightMagenta: "#d670d6",
-  brightCyan: "#29b8db",
-  brightWhite: "#ffffff",
-};
-
-const ANSI_PALETTE_LIGHT = {
-  black: "#24292e",
-  red: "#cf222e",
-  green: "#116329",
-  yellow: "#953800",
-  blue: "#0969da",
-  magenta: "#8250df",
-  cyan: "#1b7c83",
-  white: "#6e7781",
-  brightBlack: "#57606a",
-  brightRed: "#a40e26",
-  brightGreen: "#1a7f37",
-  brightYellow: "#633c01",
-  brightBlue: "#0550ae",
-  brightMagenta: "#8250df",
-  brightCyan: "#3192aa",
-  brightWhite: "#8c959f",
-};
-
-/**
- * Read OKLCH CSS custom properties and convert to hex for xterm.js.
- */
-function getTerminalTheme(): Record<string, string> {
-  const styles = getComputedStyle(document.documentElement);
-  const canvas = document.createElement("canvas");
-  canvas.width = 1;
-  canvas.height = 1;
-  const ctx = canvas.getContext("2d");
-  if (!ctx) return {};
-
-  function toHex(cssVar: string): string {
-    const value = styles.getPropertyValue(cssVar).trim();
-    if (!value) return "#000000";
-    ctx!.fillStyle = value;
-    ctx!.fillRect(0, 0, 1, 1);
-    const [r, g, b] = ctx!.getImageData(0, 0, 1, 1).data;
-    return `#${r.toString(16).padStart(2, "0")}${g.toString(16).padStart(2, "0")}${b.toString(16).padStart(2, "0")}`;
-  }
-
-  const ansi =
-    document.documentElement.dataset.theme === "light" ? ANSI_PALETTE_LIGHT : ANSI_PALETTE_DARK;
-
-  return {
-    background: toHex("--color-bg-base"),
-    foreground: toHex("--color-text-primary"),
-    cursor: toHex("--color-accent"),
-    cursorAccent: toHex("--color-bg-base"),
-    selectionBackground: toHex("--color-accent-muted"),
-    selectionForeground: toHex("--color-text-primary"),
-    ...ansi,
-  };
-}
 
 interface TerminalProps {
   sessionId: SessionId;
 }
 
+/**
+ * Renders a session's terminal. The xterm.js instance itself is owned by the
+ * terminal-instances registry, not this component — see that module for why.
+ * This component only mounts the cached host element into the DOM and forwards
+ * resize/appearance changes, so the scrollback buffer survives the remounts
+ * that happen whenever the surrounding layout changes shape (e.g. on split).
+ */
 export function Terminal({ sessionId }: TerminalProps) {
   const containerRef = useRef<HTMLDivElement>(null);
-  const terminalRef = useRef<XTerm | null>(null);
-  const fitAddonRef = useRef<FitAddon | null>(null);
   const themeMode = useSettingsStore((s) => s.themeMode);
   const fontFamily = useSettingsStore((s) => s.terminalFontFamily);
   const fontSize = useSettingsStore((s) => s.terminalFontSize);
@@ -101,20 +30,12 @@ export function Terminal({ sessionId }: TerminalProps) {
   const cursorBlink = useSettingsStore((s) => s.terminalCursorBlink);
   const scrollback = useSettingsStore((s) => s.terminalScrollback);
 
-  const settings = useSettingsStore.getState();
-
-  const debouncedResize = useDebouncedCallback(
-    (cols: number, rows: number) => {
-      (async () => {
-        const { invoke } = await import("@tauri-apps/api/core");
-        await invoke("ssh_resize_pty", { sessionId, cols, rows });
-      })();
-    },
-    150,
-  );
-
+  // Create the instance eagerly on the first byte so early output (banner /
+  // MOTD / initial prompt) that lands before the mount effect runs is written
+  // into the scrollback rather than dropped. createEntry opens into a detached
+  // element; the mount effect later attaches that same cached element.
   useSshOutput(sessionId, (data) => {
-    terminalRef.current?.write(data);
+    ensureTerminal(sessionId).term.write(data);
   });
 
   useEffect(() => {
@@ -123,125 +44,55 @@ export function Terminal({ sessionId }: TerminalProps) {
     let disposed = false;
     let observer: ResizeObserver | null = null;
 
-    // Wait for fonts to load so xterm measures glyphs correctly
+    // Wait for fonts to load so xterm measures glyphs correctly.
     document.fonts.ready.then(() => {
-      if (disposed || !containerRef.current) return;
+      const container = containerRef.current;
+      if (disposed || !container) return;
 
-      const theme = getTerminalTheme();
+      const { element, fitAddon } = ensureTerminal(sessionId);
+      container.appendChild(element);
 
-      const terminal = new XTerm({
-        cursorBlink: settings.terminalCursorBlink,
-        cursorStyle: settings.terminalCursorStyle,
-        fontSize: settings.terminalFontSize,
-        fontFamily: settings.terminalFontFamily,
-        fontWeight: "400",
-        fontWeightBold: "600",
-        lineHeight: settings.terminalLineHeight,
-        letterSpacing: 0,
-        scrollback: settings.terminalScrollback,
-        theme,
-        allowProposedApi: true,
-      });
-
-      const fitAddon = new FitAddon();
-      terminal.loadAddon(fitAddon);
-
-      terminal.open(containerRef.current);
-
-      terminalRef.current = terminal;
-      fitAddonRef.current = fitAddon;
-
-      // E2E test hook — exposes the xterm instance so tests can read the buffer
-      // without poking at canvas/DOM internals. Stripped trivially by minifiers
-      // if anyone ever cares about prod bundle size.
-      if (typeof window !== "undefined") {
-        const reg = ((window as unknown as { __e2eTerminals?: Map<string, XTerm> }).__e2eTerminals ??=
-          new Map<string, XTerm>());
-        reg.set(sessionId, terminal);
-      }
-
-      // Load search addon
-      import("@xterm/addon-search")
-        .then(({ SearchAddon }) => {
-          if (!disposed) {
-            const searchAddon = new SearchAddon();
-            terminal.loadAddon(searchAddon);
-            registerSearchAddon(sessionId, searchAddon);
-          }
-        })
-        .catch(() => { /* Search unavailable */ });
-
-      // Initial fit after layout settles
+      // Fit after layout settles, then again whenever the container resizes.
       requestAnimationFrame(() => {
         if (!disposed) fitAddon.fit();
       });
 
-      terminal.attachCustomKeyEventHandler((e) => {
-        if (e.metaKey && e.shiftKey && e.key === "s") return false;
-        if (e.metaKey && !e.shiftKey && e.key === "t") return false;
-        if (e.metaKey && !e.shiftKey && e.key === "b") return false;
-        if (e.metaKey && !e.shiftKey && e.key === "w") return false;
-        if (e.metaKey && !e.shiftKey && e.key >= "1" && e.key <= "9") return false;
-        if (e.metaKey && (e.key === "[" || e.key === "]")) return false;
-        if (e.metaKey && !e.shiftKey && e.key === "f") return false;
-        // Cmd+K — snippet palette
-        if (e.metaKey && !e.shiftKey && e.key === "k") return false;
-        if (e.metaKey && e.key.toLowerCase() === "d") return false;
-        if (e.metaKey && e.shiftKey && e.key === "Enter") return false;
-        if (e.metaKey && e.altKey && ["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight"].includes(e.key)) return false;
-        return true;
-      });
-
-      terminal.onData((data) => {
-        (async () => {
-          const { invoke } = await import("@tauri-apps/api/core");
-          const bytes = Array.from(new TextEncoder().encode(data));
-          await invoke("ssh_send_input", { sessionId, data: bytes });
-        })();
-      });
-
-      terminal.onResize(({ cols, rows }) => {
-        debouncedResize(cols, rows);
-      });
-
-      // ResizeObserver for container size changes
       observer = new ResizeObserver(() => {
         requestAnimationFrame(() => {
-          if (fitAddonRef.current && containerRef.current &&
-              containerRef.current.clientWidth > 0 && containerRef.current.clientHeight > 0) {
-            fitAddonRef.current.fit();
+          if (
+            !disposed &&
+            container.clientWidth > 0 &&
+            container.clientHeight > 0
+          ) {
+            fitAddon.fit();
           }
         });
       });
-      observer.observe(containerRef.current);
+      observer.observe(container);
     });
 
     return () => {
       disposed = true;
       observer?.disconnect();
-      unregisterSearchAddon(sessionId);
-      if (typeof window !== "undefined") {
-        (window as unknown as { __e2eTerminals?: Map<string, XTerm> })
-          .__e2eTerminals?.delete(sessionId);
-      }
-      if (terminalRef.current) {
-        terminalRef.current.dispose();
-        terminalRef.current = null;
-        fitAddonRef.current = null;
+      // Detach the cached element but keep the xterm instance (and its
+      // scrollback) alive — the registry disposes it when the session ends.
+      const entry = getTerminal(sessionId);
+      if (entry?.element.parentElement) {
+        entry.element.parentElement.removeChild(entry.element);
       }
     };
-  }, [sessionId, debouncedResize]);
+  }, [sessionId]);
 
   useEffect(() => {
-    if (terminalRef.current) {
-      terminalRef.current.options.theme = getTerminalTheme();
-    }
-  }, [themeMode]);
+    const term = getTerminal(sessionId)?.term;
+    if (term) term.options.theme = getTerminalTheme();
+  }, [sessionId, themeMode]);
 
   // Apply appearance changes to the already-open terminal (not just new ones).
   useEffect(() => {
-    const term = terminalRef.current;
-    if (!term) return;
+    const entry = getTerminal(sessionId);
+    if (!entry) return;
+    const { term, fitAddon } = entry;
     term.options.fontFamily = fontFamily;
     term.options.fontSize = fontSize;
     term.options.lineHeight = lineHeight;
@@ -249,9 +100,9 @@ export function Terminal({ sessionId }: TerminalProps) {
     term.options.cursorBlink = cursorBlink;
     term.options.scrollback = scrollback;
     // Re-fit so the new glyph metrics recompute rows/cols, then repaint.
-    fitAddonRef.current?.fit();
+    fitAddon.fit();
     term.refresh(0, term.rows - 1);
-  }, [fontFamily, fontSize, lineHeight, cursorStyle, cursorBlink, scrollback]);
+  }, [sessionId, fontFamily, fontSize, lineHeight, cursorStyle, cursorBlink, scrollback]);
 
   return (
     <div

--- a/src/stores/terminal-instances.ts
+++ b/src/stores/terminal-instances.ts
@@ -1,0 +1,248 @@
+import { Terminal as XTerm } from "@xterm/xterm";
+import { FitAddon } from "@xterm/addon-fit";
+import { registerSearchAddon, unregisterSearchAddon } from "./terminal-registry";
+import { useSettingsStore } from "./settings-store";
+import { useSessionStore } from "./session-store";
+
+/**
+ * Module-level registry of live xterm.js instances, keyed by sessionId.
+ *
+ * xterm holds the scrollback buffer (the user's commands + output history) in
+ * memory. React unmounts/remounts the <Terminal> component whenever the layout
+ * tree changes shape — e.g. a single pane becoming a split — because the
+ * component type at that tree position changes. If the xterm instance were
+ * owned by the component's effect, that remount would dispose the buffer and
+ * the user would lose their history on every split.
+ *
+ * So the instance and its host DOM element live here instead, decoupled from
+ * the component lifecycle. The component only attaches/detaches the cached
+ * element. The instance is disposed only when the session itself is removed.
+ */
+export interface TerminalEntry {
+  term: XTerm;
+  /** The element xterm renders into; reparented as the component remounts. */
+  element: HTMLDivElement;
+  fitAddon: FitAddon;
+  /** Pending debounced PTY-resize timer, cleared on dispose. */
+  resizeTimer: ReturnType<typeof setTimeout> | null;
+}
+
+const instances = new Map<string, TerminalEntry>();
+
+/**
+ * ANSI 16-color palettes. xterm.js falls back to its built-in palette when
+ * these are unset, and that default green (#0DBC79) is nearly illegible on a
+ * light background — so we ship palettes tuned for each background's contrast.
+ */
+const ANSI_PALETTE_DARK = {
+  black: "#2e3436",
+  red: "#cd3131",
+  green: "#0dbc79",
+  yellow: "#e5e510",
+  blue: "#2472c8",
+  magenta: "#bc3fbc",
+  cyan: "#11a8cd",
+  white: "#e5e5e5",
+  brightBlack: "#666666",
+  brightRed: "#f14c4c",
+  brightGreen: "#23d18b",
+  brightYellow: "#f5f543",
+  brightBlue: "#3b8eea",
+  brightMagenta: "#d670d6",
+  brightCyan: "#29b8db",
+  brightWhite: "#ffffff",
+};
+
+const ANSI_PALETTE_LIGHT = {
+  black: "#24292e",
+  red: "#cf222e",
+  green: "#116329",
+  yellow: "#953800",
+  blue: "#0969da",
+  magenta: "#8250df",
+  cyan: "#1b7c83",
+  white: "#6e7781",
+  brightBlack: "#57606a",
+  brightRed: "#a40e26",
+  brightGreen: "#1a7f37",
+  brightYellow: "#633c01",
+  brightBlue: "#0550ae",
+  brightMagenta: "#8250df",
+  brightCyan: "#3192aa",
+  brightWhite: "#8c959f",
+};
+
+/** Read OKLCH CSS custom properties and convert to hex for xterm.js. */
+export function getTerminalTheme(): Record<string, string> {
+  const styles = getComputedStyle(document.documentElement);
+  const canvas = document.createElement("canvas");
+  canvas.width = 1;
+  canvas.height = 1;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return {};
+
+  function toHex(cssVar: string): string {
+    const value = styles.getPropertyValue(cssVar).trim();
+    if (!value) return "#000000";
+    ctx!.fillStyle = value;
+    ctx!.fillRect(0, 0, 1, 1);
+    const [r, g, b] = ctx!.getImageData(0, 0, 1, 1).data;
+    return `#${r.toString(16).padStart(2, "0")}${g.toString(16).padStart(2, "0")}${b.toString(16).padStart(2, "0")}`;
+  }
+
+  const ansi =
+    document.documentElement.dataset.theme === "light" ? ANSI_PALETTE_LIGHT : ANSI_PALETTE_DARK;
+
+  return {
+    background: toHex("--color-bg-base"),
+    foreground: toHex("--color-text-primary"),
+    cursor: toHex("--color-accent"),
+    cursorAccent: toHex("--color-bg-base"),
+    selectionBackground: toHex("--color-accent-muted"),
+    selectionForeground: toHex("--color-text-primary"),
+    ...ansi,
+  };
+}
+
+function createEntry(sessionId: string): TerminalEntry {
+  const settings = useSettingsStore.getState();
+
+  const element = document.createElement("div");
+  element.className = "h-full w-full";
+
+  const term = new XTerm({
+    cursorBlink: settings.terminalCursorBlink,
+    cursorStyle: settings.terminalCursorStyle,
+    fontSize: settings.terminalFontSize,
+    fontFamily: settings.terminalFontFamily,
+    fontWeight: "400",
+    fontWeightBold: "600",
+    lineHeight: settings.terminalLineHeight,
+    letterSpacing: 0,
+    scrollback: settings.terminalScrollback,
+    theme: getTerminalTheme(),
+    allowProposedApi: true,
+  });
+
+  const fitAddon = new FitAddon();
+  term.loadAddon(fitAddon);
+  term.open(element);
+
+  const entry: TerminalEntry = { term, element, fitAddon, resizeTimer: null };
+
+  // Load search addon asynchronously.
+  import("@xterm/addon-search")
+    .then(({ SearchAddon }) => {
+      // Guard against disposal while the dynamic import was in flight.
+      if (!instances.has(sessionId)) return;
+      const searchAddon = new SearchAddon();
+      term.loadAddon(searchAddon);
+      registerSearchAddon(sessionId, searchAddon);
+    })
+    .catch(() => {
+      /* Search unavailable */
+    });
+
+  term.attachCustomKeyEventHandler((e) => {
+    if (e.metaKey && e.shiftKey && e.key === "s") return false;
+    if (e.metaKey && !e.shiftKey && e.key === "t") return false;
+    if (e.metaKey && !e.shiftKey && e.key === "b") return false;
+    if (e.metaKey && !e.shiftKey && e.key === "w") return false;
+    if (e.metaKey && !e.shiftKey && e.key >= "1" && e.key <= "9") return false;
+    if (e.metaKey && (e.key === "[" || e.key === "]")) return false;
+    if (e.metaKey && !e.shiftKey && e.key === "f") return false;
+    // Cmd+K — snippet palette
+    if (e.metaKey && !e.shiftKey && e.key === "k") return false;
+    if (e.metaKey && e.key.toLowerCase() === "d") return false;
+    if (e.metaKey && e.shiftKey && e.key === "Enter") return false;
+    if (e.metaKey && e.altKey && ["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight"].includes(e.key))
+      return false;
+    return true;
+  });
+
+  term.onData((data) => {
+    (async () => {
+      const { invoke } = await import("@tauri-apps/api/core");
+      const bytes = Array.from(new TextEncoder().encode(data));
+      await invoke("ssh_send_input", { sessionId, data: bytes });
+    })();
+  });
+
+  // Debounce PTY resize requests; the timer lives on the entry (not a closure
+  // local) so disposeTerminal can cancel a pending resize that would otherwise
+  // fire ssh_resize_pty against an already-removed session.
+  term.onResize(({ cols, rows }) => {
+    if (entry.resizeTimer) clearTimeout(entry.resizeTimer);
+    entry.resizeTimer = setTimeout(() => {
+      entry.resizeTimer = null;
+      (async () => {
+        const { invoke } = await import("@tauri-apps/api/core");
+        await invoke("ssh_resize_pty", { sessionId, cols, rows });
+      })().catch(() => {
+        /* session may have been torn down between schedule and fire */
+      });
+    }, 150);
+  });
+
+  // E2E test hook — exposes the xterm instance so tests can read the buffer
+  // without poking at canvas/DOM internals.
+  if (typeof window !== "undefined") {
+    const reg = ((window as unknown as { __e2eTerminals?: Map<string, XTerm> }).__e2eTerminals ??=
+      new Map<string, XTerm>());
+    reg.set(sessionId, term);
+  }
+
+  return entry;
+}
+
+/** Get the cached terminal for a session, creating it on first request. */
+export function ensureTerminal(sessionId: string): TerminalEntry {
+  let entry = instances.get(sessionId);
+  if (!entry) {
+    entry = createEntry(sessionId);
+    instances.set(sessionId, entry);
+  }
+  return entry;
+}
+
+/** Get the cached terminal for a session without creating one. */
+export function getTerminal(sessionId: string): TerminalEntry | undefined {
+  return instances.get(sessionId);
+}
+
+/** Dispose a terminal instance and release all associated resources. */
+export function disposeTerminal(sessionId: string): void {
+  const entry = instances.get(sessionId);
+  if (!entry) return;
+  instances.delete(sessionId);
+  unregisterSearchAddon(sessionId);
+  if (typeof window !== "undefined") {
+    (window as unknown as { __e2eTerminals?: Map<string, XTerm> }).__e2eTerminals?.delete(sessionId);
+  }
+  if (entry.resizeTimer) clearTimeout(entry.resizeTimer);
+  entry.element.parentElement?.removeChild(entry.element);
+  entry.term.dispose();
+}
+
+// Garbage-collect xterm instances when their session is removed from the store.
+// The instance must outlive React component remounts (splits, tab switches), so
+// the store — the source of truth for which sessions exist — drives disposal.
+const unsubscribe = useSessionStore.subscribe((state) => {
+  for (const sessionId of instances.keys()) {
+    if (!state.sessions.has(sessionId)) {
+      disposeTerminal(sessionId);
+    }
+  }
+});
+
+// On HMR, tear down the old subscription and dispose live instances so the
+// re-evaluated module starts from a clean Map instead of leaking a stale
+// subscription that keeps mutating an orphaned one. No-op in production.
+if (import.meta.hot) {
+  import.meta.hot.dispose(() => {
+    unsubscribe();
+    for (const sessionId of [...instances.keys()]) {
+      disposeTerminal(sessionId);
+    }
+  });
+}

--- a/tests/e2e/specs/26-split-pane.spec.ts
+++ b/tests/e2e/specs/26-split-pane.spec.ts
@@ -10,7 +10,11 @@ import {
     openNewHostModal,
     waitForModalClosed,
 } from "../helpers/host.js";
-import { waitForAnyTerminal, waitForTerminalText } from "../helpers/terminal.js";
+import {
+    runCommand,
+    waitForAnyTerminal,
+    waitForTerminalText,
+} from "../helpers/terminal.js";
 import { cmd } from "../helpers/keyboard.js";
 
 const SSHD_PASS_HOST = process.env.SSHD_PASS_HOST ?? "sshd-pass";
@@ -53,5 +57,56 @@ describe("terminal split pane", () => {
         const direction = await split.getAttribute("data-split-direction");
         expect(direction).to.equal("horizontal");
         expect((await $$("[data-testid^='terminal-']")).length).to.equal(2);
+    });
+
+    it("preserves the original pane's history across a split", async () => {
+        await openNewHostModal();
+        await fillPasswordHostForm({
+            label: "split-history",
+            host: SSHD_PASS_HOST,
+            port: SSHD_PASS_PORT,
+            username: SSH_USER,
+            password: SSH_PASS,
+        });
+        await clickConnect();
+        await waitForModalClosed();
+        const sessionId = await waitForAnyTerminal();
+        await waitForTerminalText(sessionId, ":~$");
+
+        // Leave a unique marker in the original terminal's scrollback.
+        const marker = "split_history_marker_42";
+        await runCommand(sessionId, `echo ${marker}`, marker);
+
+        await cmd("d");
+
+        await browser.waitUntil(
+            async () => (await $$("[data-testid^='terminal-']")).length >= 2,
+            { timeout: 10_000, timeoutMsg: "second pane never opened" },
+        );
+
+        // The split remounts the layout (pane -> SplitContainer). The original
+        // pane's cached xterm element must be re-parented under the new split
+        // and laid out — not left detached as a blank pane. The [data-session-id]
+        // node is the Terminal wrapper; the real xterm element is its child.
+        await browser.waitUntil(
+            async () =>
+                browser.execute((sid: string) => {
+                    const split = document.querySelector('[data-testid="split-container"]');
+                    if (!split) return false;
+                    const wrapper = split.querySelector(`[data-session-id="${sid}"]`);
+                    if (!wrapper) return false;
+                    const xtermEl =
+                        (wrapper.querySelector(".xterm") as HTMLElement | null) ??
+                        (wrapper.firstElementChild as HTMLElement | null);
+                    return !!xtermEl && xtermEl.isConnected && xtermEl.clientHeight > 0;
+                }, sessionId),
+            {
+                timeout: 10_000,
+                timeoutMsg: "original pane's xterm element was not re-attached under the split layout",
+            },
+        );
+
+        // And its scrollback must still hold the pre-split marker.
+        await waitForTerminalText(sessionId, marker);
     });
 });


### PR DESCRIPTION
## Problem

Opening a terminal, running commands, then splitting the pane wiped the **original** terminal's scrollback — all commands and history were lost.

## Root cause

Splitting changes the tab's layout node from `pane` to `split` (`session-store.ts` `splitPane`). That layout is rendered directly at `AppShell.tsx` via `<TerminalArea node={termTab.layout}>`. When the node type flips, the child component at that tree position changes from `TerminalPane` → `SplitContainer`, so React **unmounts the original `Terminal`** and mounts a fresh one. The old component's cleanup called `terminal.dispose()`, destroying the xterm.js scrollback buffer.

## Fix

Decouple the xterm.js instance lifecycle from React mount/unmount:

- **New `src/stores/terminal-instances.ts`** — a module-level registry that owns each session's `XTerm` instance plus its host DOM element, keyed by `sessionId`. Input/resize/key handlers and the search addon are wired once at creation. A zustand store subscription disposes an instance only when its session actually leaves the store.
- **`src/components/terminal/Terminal.tsx`** is now a thin wrapper: it `appendChild`s the cached element on mount and only *detaches* it on unmount (never disposes). On a split, the original session's `Terminal` remounts but gets the **same** cached instance reparented into the new pane, so its buffer (history) is preserved. The new pane gets its own fresh instance.

This mirrors the existing "render all tabs, toggle visibility — no remount" pattern already used in `AppShell` to preserve state across tab switches.

### Also addressed (found via adversarial self-review)

- **Early output capture**: the instance is now created on the first SSH byte, so the banner / MOTD / initial prompt are written to scrollback instead of being dropped during the async mount window.
- **Resize timer cleanup**: the debounced PTY-resize timer lives on the entry and is cancelled on dispose, so it can't fire `ssh_resize_pty` against a removed session (also adds a `.catch` to avoid an unhandled rejection).
- **HMR hygiene**: the store subscription is torn down and live instances disposed on hot-reload, avoiding duplicate dev-only subscriptions.

## Testing

- `tsc --noEmit` passes.
- Adds an e2e regression test (`tests/e2e/specs/26-split-pane.spec.ts`) that runs a marker command, splits with Cmd+D, and asserts both that the original pane's xterm element is **re-attached under the split layout** (not left detached/blank) and that its scrollback still contains the pre-split marker. The e2e suite itself was not run locally (left for CI / manual run).

## Notes

The **new** pane still starts a fresh shell with no shared history — that's separate backend behavior (a new PTY/shell in `ssh/session.rs`), not part of this bug.