### PR TITLE
feat(settings): Data management — clear all data + encrypted backup/restore

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -99,9 +99,14 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 name = "anyscp"
 version = "0.0.0-dev"
 dependencies = [
+ "aes-gcm",
+ "argon2",
  "async-trait",
+ "base64 0.22.1",
  "dashmap",
  "dirs",
+ "flate2",
+ "getrandom 0.2.17",
  "keyring",
  "notify",
  "reqwest 0.12.28",
@@ -135,6 +140,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 dependencies = [
  "derive_arbitrary",
+]
+
+[[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures",
+ "password-hash",
 ]
 
 [[package]]
@@ -430,6 +447,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
 ]
 
 [[package]]
@@ -3494,6 +3520,17 @@ dependencies = [
  "redox_syscall 0.5.18",
  "smallvec",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -102,7 +102,6 @@ dependencies = [
  "aes-gcm",
  "argon2",
  "async-trait",
- "base64 0.22.1",
  "dashmap",
  "dirs",
  "flate2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -72,6 +72,18 @@ tauri-plugin-process = "2"
 ssh2-config = "0.7.0"
 rust-s3 = { version = "0.37.1", default-features = false, features = ["tokio-rustls-tls"] }
 
+# Encrypted backup/restore: Argon2id key derivation + AES-256-GCM, with the
+# secret material kept out of the plaintext export file. `getrandom` provides
+# the OS CSPRNG for the per-backup salt and nonce; `base64` encodes the binary
+# blobs into the JSON envelope.
+argon2 = "0.5"
+aes-gcm = "0.10"
+getrandom = "0.2"
+base64 = "0.22"
+# Compress the backup payload before encrypting — a raw SQLite snapshot is
+# mostly zero-filled pages, so this shrinks the file ~10-50x. Pure-Rust backend.
+flate2 = "1"
+
 # Telemetry
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 dirs = "6"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -72,14 +72,12 @@ tauri-plugin-process = "2"
 ssh2-config = "0.7.0"
 rust-s3 = { version = "0.37.1", default-features = false, features = ["tokio-rustls-tls"] }
 
-# Encrypted backup/restore: Argon2id key derivation + AES-256-GCM, with the
-# secret material kept out of the plaintext export file. `getrandom` provides
-# the OS CSPRNG for the per-backup salt and nonce; `base64` encodes the binary
-# blobs into the JSON envelope.
+# Encrypted backup/restore: Argon2id key derivation + AES-256-GCM, written as a
+# compact binary container (no JSON/base64). `getrandom` provides the OS CSPRNG
+# for the per-backup salt and nonce.
 argon2 = "0.5"
 aes-gcm = "0.10"
 getrandom = "0.2"
-base64 = "0.22"
 # Compress the backup payload before encrypting — a raw SQLite snapshot is
 # mostly zero-filled pages, so this shrinks the file ~10-50x. Pure-Rust backend.
 flate2 = "1"

--- a/src-tauri/src/backup/commands.rs
+++ b/src-tauri/src/backup/commands.rs
@@ -27,8 +27,8 @@ pub async fn backup_export(
     }
     let db = Arc::clone(&state);
     task::spawn_blocking(move || {
-        let json = build_backup(&db, &password)?;
-        std::fs::write(&path, json).map_err(|e| BackupError::Io(e.to_string()))?;
+        let bytes = build_backup(&db, &password)?;
+        std::fs::write(&path, bytes).map_err(|e| BackupError::Io(e.to_string()))?;
         crate::telemetry::capture("backup_exported", serde_json::json!({}));
         Ok::<(), BackupError>(())
     })
@@ -50,8 +50,8 @@ pub async fn backup_import(
     }
     let db = Arc::clone(&state);
     task::spawn_blocking(move || {
-        let json = std::fs::read_to_string(&path).map_err(|e| BackupError::Io(e.to_string()))?;
-        restore_backup(&db, &password, &json)?;
+        let bytes = std::fs::read(&path).map_err(|e| BackupError::Io(e.to_string()))?;
+        restore_backup(&db, &password, &bytes)?;
         crate::telemetry::capture("backup_imported", serde_json::json!({}));
         Ok::<(), BackupError>(())
     })

--- a/src-tauri/src/backup/commands.rs
+++ b/src-tauri/src/backup/commands.rs
@@ -1,0 +1,60 @@
+//! Tauri commands for encrypted backup export / import.
+//!
+//! Both run the crypto + DB work on a blocking thread (Argon2 is deliberately
+//! CPU-heavy, and the keychain/SQLite calls are synchronous). The frontend
+//! picks the file path via the dialog plugin and supplies the passphrase.
+
+use std::sync::Arc;
+
+use tauri::State;
+use tokio::task;
+use tracing::instrument;
+
+use crate::db::HostDb;
+
+use super::{build_backup, restore_backup, BackupError};
+
+/// Encrypt all app data with `password` and write the backup to `path`.
+#[tauri::command]
+#[instrument(skip(password, state), fields(path = %path))]
+pub async fn backup_export(
+    password: String,
+    path: String,
+    state: State<'_, Arc<HostDb>>,
+) -> Result<(), BackupError> {
+    if password.is_empty() {
+        return Err(BackupError::Crypto("password must not be empty".into()));
+    }
+    let db = Arc::clone(&state);
+    task::spawn_blocking(move || {
+        let json = build_backup(&db, &password)?;
+        std::fs::write(&path, json).map_err(|e| BackupError::Io(e.to_string()))?;
+        crate::telemetry::capture("backup_exported", serde_json::json!({}));
+        Ok::<(), BackupError>(())
+    })
+    .await
+    .map_err(|e| BackupError::Io(format!("task panicked: {e}")))?
+}
+
+/// Decrypt the backup at `path` with `password` and restore it, replacing all
+/// current data and credentials. The frontend relaunches the app afterwards.
+#[tauri::command]
+#[instrument(skip(password, state), fields(path = %path))]
+pub async fn backup_import(
+    password: String,
+    path: String,
+    state: State<'_, Arc<HostDb>>,
+) -> Result<(), BackupError> {
+    if password.is_empty() {
+        return Err(BackupError::Crypto("password must not be empty".into()));
+    }
+    let db = Arc::clone(&state);
+    task::spawn_blocking(move || {
+        let json = std::fs::read_to_string(&path).map_err(|e| BackupError::Io(e.to_string()))?;
+        restore_backup(&db, &password, &json)?;
+        crate::telemetry::capture("backup_imported", serde_json::json!({}));
+        Ok::<(), BackupError>(())
+    })
+    .await
+    .map_err(|e| BackupError::Io(format!("task panicked: {e}")))?
+}

--- a/src-tauri/src/backup/mod.rs
+++ b/src-tauri/src/backup/mod.rs
@@ -1,17 +1,27 @@
 //! Encrypted backup / restore of all anySCP data.
 //!
-//! A backup is a single JSON *envelope* written to a file the user chooses. Its
-//! payload — a raw SQLite snapshot of the whole database plus every stored
-//! credential — is encrypted with a key derived from the user's passphrase via
-//! **Argon2id**, using **AES-256-GCM**. Secrets therefore never touch disk in
-//! plaintext, and a backup is useless without the passphrase.
+//! A backup is a compact **binary container** (not JSON): a small plaintext
+//! header — magic, KDF parameters, salt, nonce — followed directly by the raw
+//! **AES-256-GCM** ciphertext. The header is the AEAD associated data, so any
+//! tampering with the parameters is detected. The key is derived from the
+//! user's passphrase with **Argon2id**; the payload (a raw SQLite snapshot of
+//! the whole database plus every stored credential) is gzip-compressed before
+//! encryption. Secrets never touch disk in plaintext, and a backup is useless
+//! without the passphrase.
 //!
 //! - Export: snapshot the DB ([`crate::db::HostDb::export_db_snapshot`]) +
-//!   gather credentials from the OS keychain → encrypt → write the envelope.
-//! - Import: decrypt with the passphrase → restore the DB snapshot
-//!   ([`crate::db::HostDb::import_db_snapshot`]) + write credentials back to the
-//!   keychain. A wrong password fails the AEAD tag check and is reported as
-//!   such; nothing is modified.
+//!   gather credentials from the OS keychain → frame + gzip → seal → write the
+//!   container bytes.
+//! - Import: open the container with the passphrase → gunzip → restore the DB
+//!   snapshot ([`crate::db::HostDb::import_db_snapshot`]) + write credentials
+//!   back to the keychain. A wrong password fails the AEAD tag check and is
+//!   reported as such; nothing is modified.
+//!
+//! ## Container layout (little-endian)
+//! ```text
+//! magic "ASCPBAK\x01" (8) | kdf_id u8 | m_kib u32 | t u32 | p u32 |
+//! compression u8 | salt_len u8 | salt | nonce_len u8 | nonce | ciphertext…
+//! ```
 
 pub mod commands;
 
@@ -20,22 +30,21 @@ use std::collections::BTreeMap;
 use aes_gcm::aead::{Aead, KeyInit, Payload};
 use aes_gcm::{Aes256Gcm, Key, Nonce};
 use argon2::{Algorithm, Argon2, Params, Version};
-use base64::engine::general_purpose::STANDARD;
-use base64::Engine as _;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
 use crate::db::HostDb;
 use crate::vault::{self, StoredCredential};
 
 // ─── Constants ─────────────────────────────────────────────────────────────────
 
-const FORMAT_TAG: &str = "anyscp.backup";
-const ENVELOPE_VERSION: u32 = 1;
-/// AEAD associated data — binds the ciphertext to this format/version so a blob
-/// can't be transplanted into a different context.
-const AAD: &[u8] = b"anyscp.backup.v1";
+/// Container magic + format version (last byte). Bumping the version byte lets
+/// future formats be told apart and rejected cleanly.
+const MAGIC: &[u8; 8] = b"ASCPBAK\x01";
+const KDF_ARGON2ID: u8 = 1;
+const COMPRESSION_NONE: u8 = 0;
+const COMPRESSION_GZIP: u8 = 1;
 // Argon2id parameters: m = 64 MiB, t = 3, p = 1 — strong, well under a second on
-// modern hardware. Stored in the envelope so import derives the same key.
+// modern hardware. Written into the header so import derives the same key.
 const ARGON2_M_KIB: u32 = 64 * 1024;
 const ARGON2_T: u32 = 3;
 const ARGON2_P: u32 = 1;
@@ -88,32 +97,47 @@ impl From<crate::db::DbError> for BackupError {
 
 // ─── On-disk format ──────────────────────────────────────────────────────────
 
-#[derive(Debug, Serialize, Deserialize)]
+/// KDF parameters carried in the header (algorithm is fixed to Argon2id).
 struct KdfParams {
-    algorithm: String,
+    algorithm: &'static str,
     m_kib: u32,
     t: u32,
     p: u32,
 }
 
-/// The JSON written to the backup file. Only `ciphertext` holds user data; the
-/// rest are the public parameters needed to derive the key and decrypt.
-#[derive(Debug, Serialize, Deserialize)]
-struct Envelope {
-    format: String,
-    version: u32,
-    kdf: KdfParams,
-    /// How the plaintext was compressed before encryption: `"gzip"` or `"none"`.
-    #[serde(default = "compression_none")]
-    compression: String,
-    salt: String,
-    nonce: String,
-    ciphertext: String,
-    created_at_unix: u64,
+/// Bounds-checked sequential reader over the (untrusted) container bytes. Every
+/// accessor returns a `Format` error rather than panicking on a short read.
+struct Reader<'a> {
+    data: &'a [u8],
+    pos: usize,
 }
 
-fn compression_none() -> String {
-    "none".into()
+impl<'a> Reader<'a> {
+    fn new(data: &'a [u8]) -> Self {
+        Self { data, pos: 0 }
+    }
+
+    fn take(&mut self, n: usize) -> Result<&'a [u8], BackupError> {
+        let end = self
+            .pos
+            .checked_add(n)
+            .ok_or_else(|| BackupError::Format("backup header overflow".into()))?;
+        if end > self.data.len() {
+            return Err(BackupError::Format("truncated backup file".into()));
+        }
+        let out = &self.data[self.pos..end];
+        self.pos = end;
+        Ok(out)
+    }
+
+    fn u8(&mut self) -> Result<u8, BackupError> {
+        Ok(self.take(1)?[0])
+    }
+
+    fn u32_le(&mut self) -> Result<u32, BackupError> {
+        let b = self.take(4)?;
+        Ok(u32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+    }
 }
 
 // ─── Crypto ─────────────────────────────────────────────────────────────────────
@@ -144,14 +168,29 @@ fn derive_key(password: &str, salt: &[u8], p: &KdfParams) -> Result<[u8; KEY_LEN
     Ok(key)
 }
 
-fn encrypt(password: &str, plaintext: &[u8], compression: &str) -> Result<Envelope, BackupError> {
+/// Encrypt `plaintext` into a self-describing binary container. The header
+/// (magic + KDF params + compression + salt + nonce) is both written verbatim
+/// and used as the AEAD associated data, so any edit to it fails decryption.
+fn seal(password: &str, plaintext: &[u8], compression: u8) -> Result<Vec<u8>, BackupError> {
     let mut salt = [0u8; SALT_LEN];
     let mut nonce = [0u8; NONCE_LEN];
     getrandom::getrandom(&mut salt).map_err(|e| BackupError::Crypto(e.to_string()))?;
     getrandom::getrandom(&mut nonce).map_err(|e| BackupError::Crypto(e.to_string()))?;
 
+    let mut header = Vec::with_capacity(MAGIC.len() + 14 + SALT_LEN + NONCE_LEN);
+    header.extend_from_slice(MAGIC);
+    header.push(KDF_ARGON2ID);
+    header.extend_from_slice(&ARGON2_M_KIB.to_le_bytes());
+    header.extend_from_slice(&ARGON2_T.to_le_bytes());
+    header.extend_from_slice(&ARGON2_P.to_le_bytes());
+    header.push(compression);
+    header.push(SALT_LEN as u8);
+    header.extend_from_slice(&salt);
+    header.push(NONCE_LEN as u8);
+    header.extend_from_slice(&nonce);
+
     let kdf = KdfParams {
-        algorithm: "argon2id".into(),
+        algorithm: "argon2id",
         m_kib: ARGON2_M_KIB,
         t: ARGON2_T,
         p: ARGON2_P,
@@ -163,21 +202,14 @@ fn encrypt(password: &str, plaintext: &[u8], compression: &str) -> Result<Envelo
             Nonce::from_slice(&nonce),
             Payload {
                 msg: plaintext,
-                aad: AAD,
+                aad: &header,
             },
         )
         .map_err(|e| BackupError::Crypto(e.to_string()))?;
 
-    Ok(Envelope {
-        format: FORMAT_TAG.into(),
-        version: ENVELOPE_VERSION,
-        kdf,
-        compression: compression.to_string(),
-        salt: STANDARD.encode(salt),
-        nonce: STANDARD.encode(nonce),
-        ciphertext: STANDARD.encode(ciphertext),
-        created_at_unix: now_unix(),
-    })
+    let mut out = header;
+    out.extend_from_slice(&ciphertext);
+    Ok(out)
 }
 
 // ─── Compression + binary framing ──────────────────────────────────────────────
@@ -229,57 +261,59 @@ fn decode_frame(frame: &[u8]) -> Result<(&[u8], &[u8]), BackupError> {
     Ok((&rest[..len], &rest[len..]))
 }
 
-fn decrypt(password: &str, env: &Envelope) -> Result<Vec<u8>, BackupError> {
-    if env.format != FORMAT_TAG {
-        return Err(BackupError::Format(format!(
-            "unexpected format tag {:?}",
-            env.format
-        )));
+/// Parse a binary container, derive the key, and decrypt. Returns the decrypted
+/// plaintext and the compression byte. Every malformed/truncated input yields a
+/// `Format` error; a wrong password (or any tampering, including the header)
+/// yields `Decrypt` via the GCM tag check.
+fn open(password: &str, data: &[u8]) -> Result<(Vec<u8>, u8), BackupError> {
+    let mut r = Reader::new(data);
+    if r.take(MAGIC.len())? != MAGIC {
+        return Err(BackupError::Format("not an anySCP backup file".into()));
     }
-    if env.version > ENVELOPE_VERSION {
-        return Err(BackupError::Format(format!(
-            "backup format v{} is newer than this app supports (v{ENVELOPE_VERSION})",
-            env.version
-        )));
+    let kdf_id = r.u8()?;
+    if kdf_id != KDF_ARGON2ID {
+        return Err(BackupError::Format(format!("unsupported KDF id {kdf_id}")));
     }
-    let salt = STANDARD
-        .decode(env.salt.as_bytes())
-        .map_err(|e| BackupError::Format(e.to_string()))?;
-    let nonce = STANDARD
-        .decode(env.nonce.as_bytes())
-        .map_err(|e| BackupError::Format(e.to_string()))?;
-    let ciphertext = STANDARD
-        .decode(env.ciphertext.as_bytes())
-        .map_err(|e| BackupError::Format(e.to_string()))?;
+    let m_kib = r.u32_le()?;
+    let t = r.u32_le()?;
+    let p = r.u32_le()?;
+    let compression = r.u8()?;
+    let salt_len = r.u8()? as usize;
+    let salt = r.take(salt_len)?.to_vec();
+    let nonce_len = r.u8()? as usize;
+    let nonce = r.take(nonce_len)?;
     if nonce.len() != NONCE_LEN {
         return Err(BackupError::Format("invalid nonce length".into()));
     }
+    // Everything consumed so far is the header; it is the AEAD associated data.
+    let header = &data[..r.pos];
+    let ciphertext = &data[r.pos..];
 
-    let key = derive_key(password, &salt, &env.kdf)?;
+    let kdf = KdfParams {
+        algorithm: "argon2id",
+        m_kib,
+        t,
+        p,
+    };
+    // derive_key clamps the (untrusted) KDF parameters before use.
+    let key = derive_key(password, &salt, &kdf)?;
     let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(&key));
-    cipher
+    let plaintext = cipher
         .decrypt(
-            Nonce::from_slice(&nonce),
+            Nonce::from_slice(nonce),
             Payload {
-                msg: &ciphertext,
-                aad: AAD,
+                msg: ciphertext,
+                aad: header,
             },
         )
-        // A wrong password (or any tampering) fails the GCM tag check here.
-        .map_err(|_| BackupError::Decrypt)
-}
-
-fn now_unix() -> u64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0)
+        .map_err(|_| BackupError::Decrypt)?;
+    Ok((plaintext, compression))
 }
 
 // ─── Orchestration (sync — callers use spawn_blocking) ──────────────────────────
 
-/// Build the encrypted backup envelope (as a JSON string) for the whole app.
-pub fn build_backup(db: &HostDb, password: &str) -> Result<String, BackupError> {
+/// Build the encrypted backup container (raw bytes) for the whole app.
+pub fn build_backup(db: &HostDb, password: &str) -> Result<Vec<u8>, BackupError> {
     let db_bytes = db.export_db_snapshot()?;
 
     // Gather every stored secret keyed by its vault key. Missing entries are
@@ -301,21 +335,19 @@ pub fn build_backup(db: &HostDb, password: &str) -> Result<String, BackupError> 
         serde_json::to_vec(&credentials).map_err(|e| BackupError::Crypto(e.to_string()))?;
     let frame = encode_frame(&creds_json, &db_bytes);
     let compressed = gzip(&frame)?;
-    let envelope = encrypt(password, &compressed, "gzip")?;
-    serde_json::to_string_pretty(&envelope).map_err(|e| BackupError::Crypto(e.to_string()))
+    seal(password, &compressed, COMPRESSION_GZIP)
 }
 
-/// Decrypt and restore a backup, replacing all current data and credentials.
-pub fn restore_backup(db: &HostDb, password: &str, envelope_json: &str) -> Result<(), BackupError> {
-    let envelope: Envelope = serde_json::from_str(envelope_json)
-        .map_err(|_| BackupError::Format("not an anySCP backup file".into()))?;
-    let plaintext = decrypt(password, &envelope)?;
-    let frame = match envelope.compression.as_str() {
-        "gzip" => gunzip(&plaintext)?,
-        "none" => plaintext,
+/// Decrypt and restore a backup container, replacing all current data and
+/// credentials.
+pub fn restore_backup(db: &HostDb, password: &str, container: &[u8]) -> Result<(), BackupError> {
+    let (plaintext, compression) = open(password, container)?;
+    let frame = match compression {
+        COMPRESSION_GZIP => gunzip(&plaintext)?,
+        COMPRESSION_NONE => plaintext,
         other => {
             return Err(BackupError::Format(format!(
-                "unsupported backup compression {other:?}"
+                "unsupported backup compression id {other}"
             )))
         }
     };
@@ -342,58 +374,80 @@ mod tests {
     use super::*;
 
     fn roundtrip(password: &str, msg: &[u8]) -> Vec<u8> {
-        let env = encrypt(password, msg, "none").expect("encrypt");
-        decrypt(password, &env).expect("decrypt")
+        let container = seal(password, msg, COMPRESSION_NONE).expect("seal");
+        let (plaintext, comp) = open(password, &container).expect("open");
+        assert_eq!(comp, COMPRESSION_NONE);
+        plaintext
     }
 
     #[test]
-    fn encrypt_decrypt_roundtrip() {
+    fn seal_open_roundtrip() {
         let msg = br#"{"hello":"world"}"#;
         assert_eq!(roundtrip("correct horse battery staple", msg), msg);
     }
 
     #[test]
+    fn container_starts_with_magic_and_hides_plaintext() {
+        let container = seal("pw", b"TOP-SECRET-MARKER", COMPRESSION_NONE).unwrap();
+        assert!(container.starts_with(MAGIC));
+        // The plaintext marker must not appear anywhere in the container.
+        assert!(!container
+            .windows(b"TOP-SECRET-MARKER".len())
+            .any(|w| w == b"TOP-SECRET-MARKER"));
+    }
+
+    #[test]
     fn wrong_password_fails() {
-        let env = encrypt("right-password", b"secret data", "none").expect("encrypt");
-        let err = decrypt("wrong-password", &env).expect_err("must fail");
+        let container = seal("right-password", b"secret data", COMPRESSION_NONE).expect("seal");
+        let err = open("wrong-password", &container).expect_err("must fail");
         assert!(matches!(err, BackupError::Decrypt), "got {err:?}");
     }
 
     #[test]
     fn tampered_ciphertext_fails() {
-        let mut env = encrypt("pw", b"secret data", "none").expect("encrypt");
-        // Flip a byte in the (base64) ciphertext.
-        let mut ct = STANDARD.decode(env.ciphertext.as_bytes()).unwrap();
-        ct[0] ^= 0xff;
-        env.ciphertext = STANDARD.encode(ct);
-        assert!(matches!(decrypt("pw", &env), Err(BackupError::Decrypt)));
+        let mut container = seal("pw", b"secret data", COMPRESSION_NONE).expect("seal");
+        // Flip the last byte (inside the ciphertext/tag).
+        *container.last_mut().unwrap() ^= 0xff;
+        assert!(matches!(open("pw", &container), Err(BackupError::Decrypt)));
     }
 
     #[test]
-    fn each_backup_uses_fresh_salt_and_nonce() {
-        let a = encrypt("pw", b"data", "none").unwrap();
-        let b = encrypt("pw", b"data", "none").unwrap();
-        // Same password + plaintext must still yield different salt/nonce/ct.
-        assert_ne!(a.salt, b.salt);
-        assert_ne!(a.nonce, b.nonce);
-        assert_ne!(a.ciphertext, b.ciphertext);
+    fn tampered_header_fails() {
+        let mut container = seal("pw", b"secret data", COMPRESSION_NONE).expect("seal");
+        // Flip the compression byte in the header — it's part of the AEAD AAD,
+        // so the tag check must fail.
+        let comp_off = MAGIC.len() + 1 + 4 + 4 + 4; // after magic+kdf_id+m+t+p
+        container[comp_off] ^= 0xff;
+        assert!(matches!(open("pw", &container), Err(BackupError::Decrypt)));
     }
 
     #[test]
-    fn envelope_serializes_with_expected_fields() {
-        let env = encrypt("pw", b"x", "none").unwrap();
-        let json = serde_json::to_string(&env).unwrap();
-        assert!(json.contains("\"format\":\"anyscp.backup\""));
-        assert!(json.contains("\"argon2id\""));
-        // The plaintext must not leak into the envelope.
-        assert!(!json.contains("\"x\""));
+    fn each_backup_is_unique() {
+        let a = seal("pw", b"data", COMPRESSION_NONE).unwrap();
+        let b = seal("pw", b"data", COMPRESSION_NONE).unwrap();
+        // Fresh salt + nonce per backup → different bytes despite same input.
+        assert_ne!(a, b);
     }
 
     #[test]
-    fn rejects_foreign_format_tag() {
-        let mut env = encrypt("pw", b"x", "none").unwrap();
-        env.format = "something.else".into();
-        assert!(matches!(decrypt("pw", &env), Err(BackupError::Format(_))));
+    fn rejects_bad_magic() {
+        let mut container = seal("pw", b"x", COMPRESSION_NONE).unwrap();
+        container[0] ^= 0xff;
+        assert!(matches!(
+            open("pw", &container),
+            Err(BackupError::Format(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_truncated_container() {
+        let container = seal("pw", b"x", COMPRESSION_NONE).unwrap();
+        // Cut into the header — the reader must error, not panic.
+        assert!(matches!(
+            open("pw", &container[..5]),
+            Err(BackupError::Format(_))
+        ));
+        assert!(matches!(open("pw", &[]), Err(BackupError::Format(_))));
     }
 
     #[test]
@@ -448,9 +502,9 @@ mod tests {
 
         let backup = build_backup(&src, "hunter2-strong-pw").expect("build_backup");
 
-        // Compression + framing: the encrypted backup is smaller than the raw
-        // SQLite snapshot, despite base64 + the GCM tag (the old double-base64
-        // format was ~1.8x the snapshot).
+        // Compression + framing + binary container: the encrypted backup is far
+        // smaller than the raw SQLite snapshot (the old JSON+double-base64 format
+        // was ~1.8x the snapshot).
         let raw = src.export_db_snapshot().expect("snapshot");
         assert!(
             backup.len() < raw.len(),

--- a/src-tauri/src/backup/mod.rs
+++ b/src-tauri/src/backup/mod.rs
@@ -1,0 +1,476 @@
+//! Encrypted backup / restore of all anySCP data.
+//!
+//! A backup is a single JSON *envelope* written to a file the user chooses. Its
+//! payload — a raw SQLite snapshot of the whole database plus every stored
+//! credential — is encrypted with a key derived from the user's passphrase via
+//! **Argon2id**, using **AES-256-GCM**. Secrets therefore never touch disk in
+//! plaintext, and a backup is useless without the passphrase.
+//!
+//! - Export: snapshot the DB ([`crate::db::HostDb::export_db_snapshot`]) +
+//!   gather credentials from the OS keychain → encrypt → write the envelope.
+//! - Import: decrypt with the passphrase → restore the DB snapshot
+//!   ([`crate::db::HostDb::import_db_snapshot`]) + write credentials back to the
+//!   keychain. A wrong password fails the AEAD tag check and is reported as
+//!   such; nothing is modified.
+
+pub mod commands;
+
+use std::collections::BTreeMap;
+
+use aes_gcm::aead::{Aead, KeyInit, Payload};
+use aes_gcm::{Aes256Gcm, Key, Nonce};
+use argon2::{Algorithm, Argon2, Params, Version};
+use base64::engine::general_purpose::STANDARD;
+use base64::Engine as _;
+use serde::{Deserialize, Serialize};
+
+use crate::db::HostDb;
+use crate::vault::{self, StoredCredential};
+
+// ─── Constants ─────────────────────────────────────────────────────────────────
+
+const FORMAT_TAG: &str = "anyscp.backup";
+const ENVELOPE_VERSION: u32 = 1;
+/// AEAD associated data — binds the ciphertext to this format/version so a blob
+/// can't be transplanted into a different context.
+const AAD: &[u8] = b"anyscp.backup.v1";
+// Argon2id parameters: m = 64 MiB, t = 3, p = 1 — strong, well under a second on
+// modern hardware. Stored in the envelope so import derives the same key.
+const ARGON2_M_KIB: u32 = 64 * 1024;
+const ARGON2_T: u32 = 3;
+const ARGON2_P: u32 = 1;
+const SALT_LEN: usize = 16;
+const NONCE_LEN: usize = 12;
+const KEY_LEN: usize = 32;
+
+// ─── Error ─────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, thiserror::Error)]
+pub enum BackupError {
+    #[error("Database error: {0}")]
+    Db(String),
+    #[error("Incorrect password, or the backup file is corrupt")]
+    Decrypt,
+    #[error("Crypto error: {0}")]
+    Crypto(String),
+    #[error("Not a valid anySCP backup file: {0}")]
+    Format(String),
+    #[error("I/O error: {0}")]
+    Io(String),
+}
+
+/// Serialize as `{ kind, message }` — same convention as the other error types.
+impl Serialize for BackupError {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut state = serializer.serialize_struct("BackupError", 2)?;
+        let kind = match self {
+            BackupError::Db(_) => "db",
+            BackupError::Decrypt => "decrypt",
+            BackupError::Crypto(_) => "crypto",
+            BackupError::Format(_) => "format",
+            BackupError::Io(_) => "io",
+        };
+        state.serialize_field("kind", kind)?;
+        state.serialize_field("message", &self.to_string())?;
+        state.end()
+    }
+}
+
+impl From<crate::db::DbError> for BackupError {
+    fn from(e: crate::db::DbError) -> Self {
+        BackupError::Db(e.to_string())
+    }
+}
+
+// ─── On-disk format ──────────────────────────────────────────────────────────
+
+#[derive(Debug, Serialize, Deserialize)]
+struct KdfParams {
+    algorithm: String,
+    m_kib: u32,
+    t: u32,
+    p: u32,
+}
+
+/// The JSON written to the backup file. Only `ciphertext` holds user data; the
+/// rest are the public parameters needed to derive the key and decrypt.
+#[derive(Debug, Serialize, Deserialize)]
+struct Envelope {
+    format: String,
+    version: u32,
+    kdf: KdfParams,
+    /// How the plaintext was compressed before encryption: `"gzip"` or `"none"`.
+    #[serde(default = "compression_none")]
+    compression: String,
+    salt: String,
+    nonce: String,
+    ciphertext: String,
+    created_at_unix: u64,
+}
+
+fn compression_none() -> String {
+    "none".into()
+}
+
+// ─── Crypto ─────────────────────────────────────────────────────────────────────
+
+fn derive_key(password: &str, salt: &[u8], p: &KdfParams) -> Result<[u8; KEY_LEN], BackupError> {
+    if p.algorithm != "argon2id" {
+        return Err(BackupError::Format(format!(
+            "unsupported KDF {:?}",
+            p.algorithm
+        )));
+    }
+    // The KDF parameters come from the (untrusted) envelope on import. Reject
+    // out-of-range values so a malicious file can't request, say, a 16 GiB
+    // Argon2 allocation and OOM-kill the app before the tag check. The ceilings
+    // sit well above our own export parameters (64 MiB / t=3 / p=1).
+    if p.m_kib < 8 || p.m_kib > 1 << 20 || p.t < 1 || p.t > 16 || p.p < 1 || p.p > 16 {
+        return Err(BackupError::Format(
+            "backup KDF parameters are out of the supported range".into(),
+        ));
+    }
+    let params = Params::new(p.m_kib, p.t, p.p, Some(KEY_LEN))
+        .map_err(|e| BackupError::Crypto(e.to_string()))?;
+    let argon2 = Argon2::new(Algorithm::Argon2id, Version::V0x13, params);
+    let mut key = [0u8; KEY_LEN];
+    argon2
+        .hash_password_into(password.as_bytes(), salt, &mut key)
+        .map_err(|e| BackupError::Crypto(e.to_string()))?;
+    Ok(key)
+}
+
+fn encrypt(password: &str, plaintext: &[u8], compression: &str) -> Result<Envelope, BackupError> {
+    let mut salt = [0u8; SALT_LEN];
+    let mut nonce = [0u8; NONCE_LEN];
+    getrandom::getrandom(&mut salt).map_err(|e| BackupError::Crypto(e.to_string()))?;
+    getrandom::getrandom(&mut nonce).map_err(|e| BackupError::Crypto(e.to_string()))?;
+
+    let kdf = KdfParams {
+        algorithm: "argon2id".into(),
+        m_kib: ARGON2_M_KIB,
+        t: ARGON2_T,
+        p: ARGON2_P,
+    };
+    let key = derive_key(password, &salt, &kdf)?;
+    let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(&key));
+    let ciphertext = cipher
+        .encrypt(
+            Nonce::from_slice(&nonce),
+            Payload {
+                msg: plaintext,
+                aad: AAD,
+            },
+        )
+        .map_err(|e| BackupError::Crypto(e.to_string()))?;
+
+    Ok(Envelope {
+        format: FORMAT_TAG.into(),
+        version: ENVELOPE_VERSION,
+        kdf,
+        compression: compression.to_string(),
+        salt: STANDARD.encode(salt),
+        nonce: STANDARD.encode(nonce),
+        ciphertext: STANDARD.encode(ciphertext),
+        created_at_unix: now_unix(),
+    })
+}
+
+// ─── Compression + binary framing ──────────────────────────────────────────────
+//
+// The plaintext is a compact binary frame — `[u32-LE creds_json_len | creds_json
+// | raw db bytes]` — then gzip-compressed before encryption. Framing keeps the
+// SQLite snapshot as raw bytes (no base64 bloat inside the payload), and gzip
+// crushes the snapshot's zero-filled pages, so the backup file is a fraction of
+// the raw DB size instead of ~1.8x it.
+
+fn gzip(data: &[u8]) -> Result<Vec<u8>, BackupError> {
+    use flate2::write::GzEncoder;
+    use flate2::Compression;
+    use std::io::Write;
+    let mut enc = GzEncoder::new(Vec::new(), Compression::default());
+    enc.write_all(data)
+        .map_err(|e| BackupError::Crypto(e.to_string()))?;
+    enc.finish().map_err(|e| BackupError::Crypto(e.to_string()))
+}
+
+fn gunzip(data: &[u8]) -> Result<Vec<u8>, BackupError> {
+    use flate2::read::GzDecoder;
+    use std::io::Read;
+    let mut out = Vec::new();
+    GzDecoder::new(data)
+        .read_to_end(&mut out)
+        .map_err(|_| BackupError::Format("backup payload is corrupt".into()))?;
+    Ok(out)
+}
+
+fn encode_frame(creds_json: &[u8], db: &[u8]) -> Vec<u8> {
+    let mut frame = Vec::with_capacity(4 + creds_json.len() + db.len());
+    frame.extend_from_slice(&(creds_json.len() as u32).to_le_bytes());
+    frame.extend_from_slice(creds_json);
+    frame.extend_from_slice(db);
+    frame
+}
+
+/// Split a frame back into `(creds_json, db_bytes)`.
+fn decode_frame(frame: &[u8]) -> Result<(&[u8], &[u8]), BackupError> {
+    if frame.len() < 4 {
+        return Err(BackupError::Format("truncated backup payload".into()));
+    }
+    let len = u32::from_le_bytes([frame[0], frame[1], frame[2], frame[3]]) as usize;
+    let rest = &frame[4..];
+    if len > rest.len() {
+        return Err(BackupError::Format("corrupt backup payload framing".into()));
+    }
+    Ok((&rest[..len], &rest[len..]))
+}
+
+fn decrypt(password: &str, env: &Envelope) -> Result<Vec<u8>, BackupError> {
+    if env.format != FORMAT_TAG {
+        return Err(BackupError::Format(format!(
+            "unexpected format tag {:?}",
+            env.format
+        )));
+    }
+    if env.version > ENVELOPE_VERSION {
+        return Err(BackupError::Format(format!(
+            "backup format v{} is newer than this app supports (v{ENVELOPE_VERSION})",
+            env.version
+        )));
+    }
+    let salt = STANDARD
+        .decode(env.salt.as_bytes())
+        .map_err(|e| BackupError::Format(e.to_string()))?;
+    let nonce = STANDARD
+        .decode(env.nonce.as_bytes())
+        .map_err(|e| BackupError::Format(e.to_string()))?;
+    let ciphertext = STANDARD
+        .decode(env.ciphertext.as_bytes())
+        .map_err(|e| BackupError::Format(e.to_string()))?;
+    if nonce.len() != NONCE_LEN {
+        return Err(BackupError::Format("invalid nonce length".into()));
+    }
+
+    let key = derive_key(password, &salt, &env.kdf)?;
+    let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(&key));
+    cipher
+        .decrypt(
+            Nonce::from_slice(&nonce),
+            Payload {
+                msg: &ciphertext,
+                aad: AAD,
+            },
+        )
+        // A wrong password (or any tampering) fails the GCM tag check here.
+        .map_err(|_| BackupError::Decrypt)
+}
+
+fn now_unix() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+// ─── Orchestration (sync — callers use spawn_blocking) ──────────────────────────
+
+/// Build the encrypted backup envelope (as a JSON string) for the whole app.
+pub fn build_backup(db: &HostDb, password: &str) -> Result<String, BackupError> {
+    let db_bytes = db.export_db_snapshot()?;
+
+    // Gather every stored secret keyed by its vault key. Missing entries are
+    // simply skipped (a host may have no saved credential).
+    let mut credentials: BTreeMap<String, StoredCredential> = BTreeMap::new();
+    for h in db.list_hosts()? {
+        if let Ok(c) = vault::get_credential(&h.id) {
+            credentials.insert(h.id, c);
+        }
+    }
+    for s in db.list_s3_connections()? {
+        let key = format!("s3:{}", s.id);
+        if let Ok(c) = vault::get_credential(&key) {
+            credentials.insert(key, c);
+        }
+    }
+
+    let creds_json =
+        serde_json::to_vec(&credentials).map_err(|e| BackupError::Crypto(e.to_string()))?;
+    let frame = encode_frame(&creds_json, &db_bytes);
+    let compressed = gzip(&frame)?;
+    let envelope = encrypt(password, &compressed, "gzip")?;
+    serde_json::to_string_pretty(&envelope).map_err(|e| BackupError::Crypto(e.to_string()))
+}
+
+/// Decrypt and restore a backup, replacing all current data and credentials.
+pub fn restore_backup(db: &HostDb, password: &str, envelope_json: &str) -> Result<(), BackupError> {
+    let envelope: Envelope = serde_json::from_str(envelope_json)
+        .map_err(|_| BackupError::Format("not an anySCP backup file".into()))?;
+    let plaintext = decrypt(password, &envelope)?;
+    let frame = match envelope.compression.as_str() {
+        "gzip" => gunzip(&plaintext)?,
+        "none" => plaintext,
+        other => {
+            return Err(BackupError::Format(format!(
+                "unsupported backup compression {other:?}"
+            )))
+        }
+    };
+    let (creds_json, db_bytes) = decode_frame(&frame)?;
+    let credentials: BTreeMap<String, StoredCredential> = serde_json::from_slice(creds_json)
+        .map_err(|e| BackupError::Crypto(format!("payload parse failed: {e}")))?;
+
+    // 1. Replace the database (validated + migrated + transactional inside).
+    db.import_db_snapshot(db_bytes)?;
+    // 2. Restore secrets to the OS keychain. Best-effort per entry so one bad
+    //    write doesn't abort the rest; the DB is already restored.
+    for (key, cred) in &credentials {
+        if let Err(e) = vault::save_credential(key, cred) {
+            tracing::warn!(key = %key, error = %e, "restore: failed to write credential to keychain");
+        }
+    }
+    Ok(())
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn roundtrip(password: &str, msg: &[u8]) -> Vec<u8> {
+        let env = encrypt(password, msg, "none").expect("encrypt");
+        decrypt(password, &env).expect("decrypt")
+    }
+
+    #[test]
+    fn encrypt_decrypt_roundtrip() {
+        let msg = br#"{"hello":"world"}"#;
+        assert_eq!(roundtrip("correct horse battery staple", msg), msg);
+    }
+
+    #[test]
+    fn wrong_password_fails() {
+        let env = encrypt("right-password", b"secret data", "none").expect("encrypt");
+        let err = decrypt("wrong-password", &env).expect_err("must fail");
+        assert!(matches!(err, BackupError::Decrypt), "got {err:?}");
+    }
+
+    #[test]
+    fn tampered_ciphertext_fails() {
+        let mut env = encrypt("pw", b"secret data", "none").expect("encrypt");
+        // Flip a byte in the (base64) ciphertext.
+        let mut ct = STANDARD.decode(env.ciphertext.as_bytes()).unwrap();
+        ct[0] ^= 0xff;
+        env.ciphertext = STANDARD.encode(ct);
+        assert!(matches!(decrypt("pw", &env), Err(BackupError::Decrypt)));
+    }
+
+    #[test]
+    fn each_backup_uses_fresh_salt_and_nonce() {
+        let a = encrypt("pw", b"data", "none").unwrap();
+        let b = encrypt("pw", b"data", "none").unwrap();
+        // Same password + plaintext must still yield different salt/nonce/ct.
+        assert_ne!(a.salt, b.salt);
+        assert_ne!(a.nonce, b.nonce);
+        assert_ne!(a.ciphertext, b.ciphertext);
+    }
+
+    #[test]
+    fn envelope_serializes_with_expected_fields() {
+        let env = encrypt("pw", b"x", "none").unwrap();
+        let json = serde_json::to_string(&env).unwrap();
+        assert!(json.contains("\"format\":\"anyscp.backup\""));
+        assert!(json.contains("\"argon2id\""));
+        // The plaintext must not leak into the envelope.
+        assert!(!json.contains("\"x\""));
+    }
+
+    #[test]
+    fn rejects_foreign_format_tag() {
+        let mut env = encrypt("pw", b"x", "none").unwrap();
+        env.format = "something.else".into();
+        assert!(matches!(decrypt("pw", &env), Err(BackupError::Format(_))));
+    }
+
+    #[test]
+    fn frame_roundtrips() {
+        let creds = br#"{"host-1":{"type":"Password","password":"x"}}"#;
+        let db = &[0u8, 1, 2, 3, 255, 254];
+        let frame = encode_frame(creds, db);
+        let (c, d) = decode_frame(&frame).expect("decode");
+        assert_eq!(c, creds);
+        assert_eq!(d, db);
+    }
+
+    #[test]
+    fn frame_empty_db() {
+        let frame = encode_frame(b"{}", &[]);
+        let (c, d) = decode_frame(&frame).expect("decode");
+        assert_eq!(c, b"{}");
+        assert!(d.is_empty());
+    }
+
+    #[test]
+    fn decode_frame_rejects_truncated() {
+        assert!(decode_frame(&[1, 2]).is_err()); // < 4 bytes
+                                                 // Length header claims more creds bytes than exist.
+        assert!(decode_frame(&[10, 0, 0, 0, b'x']).is_err());
+    }
+
+    #[test]
+    fn gzip_roundtrips_and_shrinks_zeros() {
+        let data = vec![0u8; 64 * 1024]; // mimics SQLite's zero-filled pages
+        let z = gzip(&data).expect("gzip");
+        assert!(z.len() < data.len() / 10, "zeros should compress hugely");
+        assert_eq!(gunzip(&z).expect("gunzip"), data);
+    }
+
+    #[test]
+    fn gunzip_rejects_garbage() {
+        assert!(matches!(
+            gunzip(b"not gzip data"),
+            Err(BackupError::Format(_))
+        ));
+    }
+
+    #[test]
+    fn build_and_restore_roundtrip_is_compact() {
+        use crate::db::HostDb;
+        let dir1 = std::env::temp_dir().join(format!("anyscp-bk-src-{}", uuid::Uuid::new_v4()));
+        let dir2 = std::env::temp_dir().join(format!("anyscp-bk-dst-{}", uuid::Uuid::new_v4()));
+        let src = HostDb::new(&dir1).expect("src db");
+        src.save_setting("app_theme", "light")
+            .expect("seed setting");
+
+        let backup = build_backup(&src, "hunter2-strong-pw").expect("build_backup");
+
+        // Compression + framing: the encrypted backup is smaller than the raw
+        // SQLite snapshot, despite base64 + the GCM tag (the old double-base64
+        // format was ~1.8x the snapshot).
+        let raw = src.export_db_snapshot().expect("snapshot");
+        assert!(
+            backup.len() < raw.len(),
+            "backup {} should be smaller than raw snapshot {}",
+            backup.len(),
+            raw.len()
+        );
+
+        let dst = HostDb::new(&dir2).expect("dst db");
+        // Wrong password must fail (and the GCM tag check means nothing restores).
+        assert!(restore_backup(&dst, "wrong-pw", &backup).is_err());
+        // Correct password restores the data.
+        restore_backup(&dst, "hunter2-strong-pw", &backup).expect("restore_backup");
+        assert!(dst
+            .load_all_settings()
+            .expect("settings")
+            .iter()
+            .any(|(k, v)| k == "app_theme" && v == "light"));
+
+        let _ = std::fs::remove_dir_all(&dir1);
+        let _ = std::fs::remove_dir_all(&dir2);
+    }
+}

--- a/src-tauri/src/db/commands.rs
+++ b/src-tauri/src/db/commands.rs
@@ -175,3 +175,36 @@ pub async fn load_all_settings(
         .await
         .map_err(|e| DbError::InitError(format!("task panicked: {e}")))?
 }
+
+// ─── Factory reset ─────────────────────────────────────────────────────────────
+
+/// Permanently wipe ALL local data — saved hosts, groups, connection history,
+/// snippets, port-forward rules, S3 connections, and app settings — plus their
+/// stored credentials in the OS keychain. Returns anySCP to first-launch state.
+///
+/// This is irreversible; the frontend gates it behind a typed confirmation and
+/// relaunches the app afterwards.
+#[tauri::command]
+#[instrument(skip(state))]
+pub async fn factory_reset(state: State<'_, Arc<HostDb>>) -> Result<(), DbError> {
+    let db = Arc::clone(&state);
+    task::spawn_blocking(move || {
+        let keys = db.factory_reset()?;
+        // Purge secrets from the keychain. Best-effort: a missing entry is fine,
+        // and one bad key shouldn't abort the rest — the rows are already gone.
+        for host_id in &keys.host_ids {
+            if let Err(e) = crate::vault::delete_credential(host_id) {
+                tracing::warn!(host_id = %host_id, error = %e, "factory reset: keychain purge failed");
+            }
+        }
+        for s3_id in &keys.s3_ids {
+            let key = format!("s3:{s3_id}");
+            if let Err(e) = crate::vault::delete_credential(&key) {
+                tracing::warn!(key = %key, error = %e, "factory reset: keychain purge failed");
+            }
+        }
+        Ok::<(), DbError>(())
+    })
+    .await
+    .map_err(|e| DbError::InitError(format!("task panicked: {e}")))?
+}

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -1664,6 +1664,146 @@ impl HostDb {
         );
         Ok(ResetKeys { host_ids, s3_ids })
     }
+
+    // -----------------------------------------------------------------------
+    // Backup snapshot (raw SQLite, full fidelity)
+    // -----------------------------------------------------------------------
+
+    /// Produce a consistent single-file SQLite snapshot of the entire database
+    /// (every table, current schema) as raw bytes. `VACUUM INTO` is safe on a
+    /// live WAL connection and yields a clean copy with no `-wal`/`-shm`
+    /// sidecars. Used by the encrypted backup export.
+    #[instrument(skip(self))]
+    pub fn export_db_snapshot(&self) -> Result<Vec<u8>, DbError> {
+        // The snapshot is plaintext on disk until the caller encrypts it, so it
+        // lives inside an owner-only (0700) temp dir and is removed on every
+        // path, including read failures.
+        let dir = private_temp_dir("anyscp-export")?;
+        let tmp = dir.join("snapshot.db");
+        let result = (|| -> Result<Vec<u8>, DbError> {
+            {
+                let conn = self
+                    .conn
+                    .lock()
+                    .map_err(|e| DbError::InitError(format!("db lock poisoned: {e}")))?;
+                // VACUUM INTO doesn't accept bound parameters; the path is our own
+                // uuid temp path, single-quote-escaped defensively.
+                let escaped = tmp.to_string_lossy().replace('\'', "''");
+                conn.execute_batch(&format!("VACUUM INTO '{escaped}'"))?;
+            }
+            std::fs::read(&tmp).map_err(|e| DbError::InitError(format!("read snapshot: {e}")))
+        })();
+        let _ = std::fs::remove_dir_all(&dir);
+        result
+    }
+
+    /// Replace ALL data with the contents of a raw SQLite snapshot (as produced
+    /// by [`export_db_snapshot`]). The incoming snapshot is migrated up to the
+    /// current schema first, so older backups restore cleanly; a snapshot from
+    /// a newer app version is rejected. The copy runs in one transaction with
+    /// deferred FK checks; the snippets FTS index is rebuilt by the table
+    /// triggers as rows are inserted.
+    #[instrument(skip(self, bytes))]
+    pub fn import_db_snapshot(&self, bytes: &[u8]) -> Result<(), DbError> {
+        // The app's current schema version (main was migrated on startup).
+        let current: i64 = {
+            let conn = self
+                .conn
+                .lock()
+                .map_err(|e| DbError::InitError(format!("db lock poisoned: {e}")))?;
+            conn.query_row(
+                "SELECT CAST(value AS INTEGER) FROM _meta WHERE key = 'schema_version'",
+                [],
+                |r| r.get(0),
+            )
+            .optional()?
+            .unwrap_or(0)
+        };
+
+        // Owner-only temp dir for the (plaintext) snapshot during restore.
+        let tmp_dir = private_temp_dir("anyscp-restore")?;
+        let tmp_db = tmp_dir.join("anyscp.db");
+
+        let result = (|| -> Result<(), DbError> {
+            std::fs::write(&tmp_db, bytes)
+                .map_err(|e| DbError::InitError(format!("write snapshot: {e}")))?;
+
+            // Validate the snapshot and migrate it up to the current schema.
+            {
+                let bak = Connection::open(&tmp_db)?;
+                let bak_ver: i64 = bak
+                    .query_row(
+                        "SELECT CAST(value AS INTEGER) FROM _meta WHERE key = 'schema_version'",
+                        [],
+                        |r| r.get(0),
+                    )
+                    .optional()
+                    .map_err(|_| {
+                        DbError::Validation(
+                            "this file is not a valid anySCP backup (no schema marker)".into(),
+                        )
+                    })?
+                    .ok_or_else(|| {
+                        DbError::Validation(
+                            "this file is not a valid anySCP backup (no schema marker)".into(),
+                        )
+                    })?;
+                if bak_ver > current {
+                    return Err(DbError::Validation(format!(
+                        "backup is from a newer version of anySCP (schema {bak_ver} > {current}); update anySCP first"
+                    )));
+                }
+                bak.execute_batch("PRAGMA foreign_keys = ON;")?;
+                Self::run_migrations(&bak)?;
+                bak.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);")?;
+            } // bak connection dropped (and checkpointed) here
+
+            // Copy every table into the live database, replacing current data.
+            let mut conn = self
+                .conn
+                .lock()
+                .map_err(|e| DbError::InitError(format!("db lock poisoned: {e}")))?;
+            conn.execute(
+                "ATTACH DATABASE ?1 AS bak",
+                params![tmp_db.to_string_lossy()],
+            )?;
+            let copy = (|| -> Result<(), DbError> {
+                let tx = conn.transaction()?;
+                tx.execute_batch("PRAGMA defer_foreign_keys = TRUE;")?;
+                // Replace every table. Deferred FK checks mean delete/insert
+                // order doesn't matter; the snippets FTS index is maintained by
+                // its triggers as rows are inserted.
+                //
+                // Columns are listed explicitly, by NAME, read from the live
+                // schema — `INSERT ... SELECT *` would map by position and could
+                // silently mis-map if a future migration ever reordered columns.
+                for table in COPYABLE_TABLES {
+                    tx.execute(&format!("DELETE FROM main.{table}"), [])?;
+                }
+                for table in COPYABLE_TABLES {
+                    let cols = table_columns(&tx, table)?;
+                    if cols.is_empty() {
+                        continue;
+                    }
+                    let list = cols.join(", ");
+                    tx.execute(
+                        &format!(
+                            "INSERT INTO main.{table} ({list}) SELECT {list} FROM bak.{table}"
+                        ),
+                        [],
+                    )?;
+                }
+                tx.commit()?;
+                Ok(())
+            })();
+            // Always detach, even if the copy failed.
+            let _ = conn.execute("DETACH DATABASE bak", []);
+            copy
+        })();
+
+        let _ = std::fs::remove_dir_all(&tmp_dir);
+        result
+    }
 }
 
 /// Keychain keys whose secrets must be purged after a [`HostDb::factory_reset`].
@@ -1672,6 +1812,44 @@ impl HostDb {
 pub struct ResetKeys {
     pub host_ids: Vec<String>,
     pub s3_ids: Vec<String>,
+}
+
+/// Tables copied wholesale during a snapshot restore. `_meta` (schema marker)
+/// is intentionally kept, and `snippets_fts*` shadow tables are excluded — they
+/// are rebuilt by the snippets triggers as rows are inserted.
+const COPYABLE_TABLES: &[&str] = &[
+    "host_groups",
+    "saved_hosts",
+    "connection_history",
+    "snippet_folders",
+    "snippets",
+    "port_forwarding_rules",
+    "s3_connections",
+    "app_settings",
+];
+
+/// Column names of `table` in declaration order, read from the live schema.
+/// `table` is always a trusted constant from [`COPYABLE_TABLES`].
+fn table_columns(conn: &Connection, table: &str) -> Result<Vec<String>, DbError> {
+    let mut stmt = conn.prepare(&format!("PRAGMA table_info({table})"))?;
+    let cols = stmt
+        .query_map([], |row| row.get::<_, String>(1))?
+        .collect::<Result<Vec<String>, _>>()?;
+    Ok(cols)
+}
+
+/// Create an owner-only (0700 on Unix) temp directory for a short-lived,
+/// *plaintext* SQLite snapshot. The caller removes it when done.
+fn private_temp_dir(prefix: &str) -> Result<std::path::PathBuf, DbError> {
+    let dir = std::env::temp_dir().join(format!("{prefix}-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&dir).map_err(|e| DbError::InitError(format!("temp dir: {e}")))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700))
+            .map_err(|e| DbError::InitError(format!("temp dir perms: {e}")))?;
+    }
+    Ok(dir)
 }
 
 // ---------------------------------------------------------------------------
@@ -1770,6 +1948,81 @@ mod tests {
         db.save_host(&sample_host("host-2"))
             .expect("save after reset");
         assert_eq!(db.list_hosts().expect("list").len(), 1);
+    }
+
+    #[test]
+    fn db_snapshot_export_import_roundtrip() {
+        // Seed a source DB with a group + host (FK) + a setting, snapshot it.
+        let (src, _d1) = test_db();
+        src.create_group(&sample_group("g1")).expect("create_group");
+        let mut h = sample_host("h1");
+        h.group_id = Some("g1".to_string());
+        src.save_host(&h).expect("save_host");
+        src.save_setting("app_theme", "light")
+            .expect("save_setting");
+        src.save_snippet_folder(&sample_snippet_folder("sf1"))
+            .expect("save_snippet_folder");
+        src.save_snippet(&sample_snippet("s1"))
+            .expect("save_snippet");
+        let snapshot = src.export_db_snapshot().expect("export_db_snapshot");
+
+        // Import into a separate, initially-empty DB.
+        let (dst, _d2) = test_db();
+        assert!(dst.list_hosts().expect("list").is_empty());
+        dst.import_db_snapshot(&snapshot)
+            .expect("import_db_snapshot");
+
+        let hosts = dst.list_hosts().expect("list_hosts");
+        assert_eq!(hosts.len(), 1);
+        assert_eq!(hosts[0].id, "h1");
+        assert_eq!(hosts[0].group_id.as_deref(), Some("g1"));
+        assert_eq!(dst.list_groups().expect("list_groups").len(), 1);
+        assert!(dst
+            .load_all_settings()
+            .expect("settings")
+            .iter()
+            .any(|(k, v)| k == "app_theme" && v == "light"));
+        // Snippets copy over, and the FTS index is rebuilt by the table triggers
+        // during the ATTACH copy (search must find the snippet afterwards).
+        assert_eq!(dst.list_snippets(None).expect("list_snippets").len(), 1);
+        assert_eq!(dst.list_snippet_folders().expect("folders").len(), 1);
+        assert!(
+            !dst.search_snippets("shell", 10).expect("search").is_empty(),
+            "FTS index should be populated after import"
+        );
+    }
+
+    #[test]
+    fn db_snapshot_import_replaces_existing() {
+        let (src, _d1) = test_db();
+        src.save_host(&sample_host("from-backup")).expect("save");
+        let snapshot = src.export_db_snapshot().expect("export");
+
+        // Destination already has unrelated data; import must replace it.
+        let (dst, _d2) = test_db();
+        dst.save_host(&sample_host("pre-existing")).expect("save");
+        dst.import_db_snapshot(&snapshot).expect("import");
+
+        let ids: Vec<String> = dst
+            .list_hosts()
+            .unwrap()
+            .into_iter()
+            .map(|h| h.id)
+            .collect();
+        assert_eq!(ids, vec!["from-backup".to_string()]);
+    }
+
+    #[test]
+    fn db_snapshot_import_rejects_non_backup() {
+        let (dst, _d) = test_db();
+        let err = dst
+            .import_db_snapshot(b"this is not a sqlite database")
+            .expect_err("must reject");
+        // Either a validation message or a sqlite "not a database" error; both
+        // mean the import refused garbage rather than corrupting the live DB.
+        assert!(matches!(err, DbError::Validation(_) | DbError::Sqlite(_)));
+        // Live DB is untouched / usable.
+        assert!(dst.list_hosts().expect("list").is_empty());
     }
 
     #[test]

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -1608,6 +1608,70 @@ impl HostDb {
         }
         Ok(result)
     }
+
+    // -----------------------------------------------------------------------
+    // Factory reset
+    // -----------------------------------------------------------------------
+
+    /// Wipe ALL user data for a factory reset: every data table plus app
+    /// settings. The schema (`_meta`/`schema_version`) and table structures are
+    /// kept intact, so the database ends up identical to a fresh install — the
+    /// next launch re-seeds first-run defaults (e.g. `editors_seeded`).
+    ///
+    /// Returns the host ids and S3 connection ids whose rows were removed so the
+    /// caller can purge their secrets from the OS keychain — the `keyring` crate
+    /// can't enumerate entries, so they must be deleted by key (see
+    /// [`ResetKeys`]).
+    #[instrument(skip(self))]
+    pub fn factory_reset(&self) -> Result<ResetKeys, DbError> {
+        let mut conn = self
+            .conn
+            .lock()
+            .map_err(|e| DbError::InitError(format!("db lock poisoned: {e}")))?;
+
+        // Collect the keychain keys before deleting the rows that reference them.
+        let host_ids = conn
+            .prepare("SELECT id FROM saved_hosts")?
+            .query_map([], |r| r.get::<_, String>(0))?
+            .collect::<Result<Vec<String>, _>>()?;
+        let s3_ids = conn
+            .prepare("SELECT id FROM s3_connections")?
+            .query_map([], |r| r.get::<_, String>(0))?
+            .collect::<Result<Vec<String>, _>>()?;
+
+        // One transaction. `defer_foreign_keys` postpones FK checks to commit, so
+        // we don't have to order deletes around the self-referential
+        // `saved_hosts.proxy_jump_host_id` or the cross-table FKs. Deleting from
+        // `snippets` fires the FTS triggers that keep `snippets_fts` consistent.
+        let tx = conn.transaction()?;
+        tx.execute_batch(
+            "PRAGMA defer_foreign_keys = TRUE;
+             DELETE FROM connection_history;
+             DELETE FROM port_forwarding_rules;
+             DELETE FROM s3_connections;
+             DELETE FROM snippets;
+             DELETE FROM snippet_folders;
+             DELETE FROM saved_hosts;
+             DELETE FROM host_groups;
+             DELETE FROM app_settings;",
+        )?;
+        tx.commit()?;
+
+        tracing::info!(
+            hosts = host_ids.len(),
+            s3 = s3_ids.len(),
+            "factory reset: cleared all data and settings"
+        );
+        Ok(ResetKeys { host_ids, s3_ids })
+    }
+}
+
+/// Keychain keys whose secrets must be purged after a [`HostDb::factory_reset`].
+/// Host credentials are keyed by `host_id`; S3 credentials by `s3:{id}`.
+#[derive(Debug, Default)]
+pub struct ResetKeys {
+    pub host_ids: Vec<String>,
+    pub s3_ids: Vec<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -1678,6 +1742,34 @@ mod tests {
         assert_eq!(all[0].id, "host-1");
         assert_eq!(all[0].port, 22);
         assert!(all[0].group_id.is_none());
+    }
+
+    #[test]
+    fn factory_reset_wipes_everything_and_returns_keys() {
+        let (db, _dir) = test_db();
+        db.create_group(&sample_group("grp-1"))
+            .expect("create_group");
+        let mut h = sample_host("host-1");
+        h.group_id = Some("grp-1".to_string());
+        db.save_host(&h).expect("save_host");
+        db.record_connection("host-1").expect("record_connection");
+        db.save_setting("app_theme", "light").expect("save_setting");
+
+        let keys = db.factory_reset().expect("factory_reset");
+        assert_eq!(keys.host_ids, vec!["host-1".to_string()]);
+        assert!(keys.s3_ids.is_empty());
+
+        // Every data table and app settings are now empty.
+        assert!(db.list_hosts().expect("list_hosts").is_empty());
+        assert!(db.list_groups().expect("list_groups").is_empty());
+        assert!(db.list_recent_connections(50).expect("recent").is_empty());
+        assert!(db.load_all_settings().expect("settings").is_empty());
+
+        // The schema survives the wipe — a fresh insert still works (i.e. the
+        // DB is reset to first-launch state, not corrupted/dropped).
+        db.save_host(&sample_host("host-2"))
+            .expect("save after reset");
+        assert_eq!(db.list_hosts().expect("list").len(), 1);
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 mod ai;
+mod backup;
 mod db;
 mod editors;
 mod import;
@@ -246,6 +247,9 @@ pub fn run() {
             db::commands::load_all_settings,
             // Factory reset (wipe all data + credentials)
             db::commands::factory_reset,
+            // Encrypted backup / restore
+            backup::commands::backup_export,
+            backup::commands::backup_import,
             // External editors
             editors::detect_editors,
             // Credential vault

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -244,6 +244,8 @@ pub fn run() {
             // App settings
             db::commands::save_setting,
             db::commands::load_all_settings,
+            // Factory reset (wipe all data + credentials)
+            db::commands::factory_reset,
             // External editors
             editors::detect_editors,
             // Credential vault

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -3,7 +3,7 @@ import { useSettingsStore } from "../../stores/settings-store";
 import { CustomSelect, type SelectOption } from "../shared/CustomSelect";
 import { useUpdaterStore } from "../../stores/updater-store";
 import { toast } from "../../stores/toast-store";
-import { RefreshCw, CheckCircle2, AlertCircle, Palette, SquareTerminal, ArrowUpDown, Info, ExternalLink, Check, FileCode, Plus, Trash2, FolderOpen, Star, Search } from "lucide-react";
+import { RefreshCw, CheckCircle2, AlertCircle, Palette, SquareTerminal, ArrowUpDown, Info, ExternalLink, Check, FileCode, Plus, Trash2, FolderOpen, Star, Search, Database } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import type { CursorStyle, ThemeMode, EditorConfig } from "../../stores/settings-store";
 
@@ -45,13 +45,14 @@ const REPO_URL = "https://github.com/macnev2013/anySCP";
 // Each settings category is a section here. To add a new category, add an entry
 // to SECTIONS, a description, and render its content in <SectionContent />.
 
-type SectionId = "appearance" | "terminal" | "transfers" | "editors" | "about";
+type SectionId = "appearance" | "terminal" | "transfers" | "editors" | "data" | "about";
 
 const SECTIONS: { id: SectionId; label: string; icon: LucideIcon }[] = [
   { id: "appearance", label: "Appearance", icon: Palette },
   { id: "terminal", label: "Terminal", icon: SquareTerminal },
   { id: "transfers", label: "Transfers", icon: ArrowUpDown },
   { id: "editors", label: "Editors", icon: FileCode },
+  { id: "data", label: "Data", icon: Database },
   { id: "about", label: "About & Updates", icon: Info },
 ];
 
@@ -60,6 +61,7 @@ const SECTION_DESCRIPTIONS: Record<SectionId, string> = {
   terminal: "Font, cursor, and scrollback history.",
   transfers: "Control how files are transferred.",
   editors: "Editors used by “Edit” / “Open With” in the file browser.",
+  data: "Stored data and resetting the app.",
   about: "App information, links, and updates.",
 };
 
@@ -148,6 +150,8 @@ function SectionContent({ section }: { section: SectionId }) {
       return <TransferSettings />;
     case "editors":
       return <EditorsSettings />;
+    case "data":
+      return <DataSettings />;
     case "about":
       return <AboutSettings />;
   }
@@ -606,6 +610,187 @@ function TransferSettings() {
         <NumberSetting id="s-concurrency" value={transferConcurrency} min={1} max={10} step={1} onChange={setConcurrency} />
       </SettingRow>
     </SettingsGroup>
+  );
+}
+
+// ─── Data ───────────────────────────────────────────────────────────────────────
+
+function DataSettings() {
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  return (
+    <>
+      <SettingsGroup label="Danger zone">
+        <div className="flex items-center justify-between gap-4 px-4 py-3 rounded-xl bg-bg-surface border border-status-error/30">
+          <div>
+            <p className={LABEL_CLASS}>Clear all data</p>
+            <p className={DESC_CLASS}>
+              Permanently delete every saved host, group, connection history entry,
+              snippet, port-forward rule, and S3 connection — along with their stored
+              credentials and all app preferences. anySCP restarts at first-launch state.
+              This can’t be undone.
+            </p>
+          </div>
+          <button
+            type="button"
+            data-testid="s-clear-data"
+            onClick={() => setConfirmOpen(true)}
+            className={[
+              "flex items-center gap-1.5 px-3 py-1.5 rounded-lg shrink-0",
+              "text-[length:var(--text-sm)] font-medium",
+              "bg-status-error/10 border border-status-error/40 text-status-error",
+              "hover:bg-status-error/15",
+              "transition-colors duration-[var(--duration-fast)]",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+            ].join(" ")}
+          >
+            <Trash2 size={13} strokeWidth={2} /> Clear all data…
+          </button>
+        </div>
+      </SettingsGroup>
+
+      <ConfirmResetModal open={confirmOpen} onClose={() => setConfirmOpen(false)} />
+    </>
+  );
+}
+
+/** Typed-confirmation dialog for the irreversible factory reset. The user must
+ *  type the confirm word, then we wipe the backend and relaunch the app. */
+function ConfirmResetModal({ open, onClose }: { open: boolean; onClose: () => void }) {
+  const CONFIRM_WORD = "DELETE";
+  const [text, setText] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [visible, setVisible] = useState(false);
+
+  const backdropRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const canReset = text.trim() === CONFIRM_WORD && !busy;
+
+  useEffect(() => {
+    if (open) {
+      setText("");
+      setBusy(false);
+      requestAnimationFrame(() => setVisible(true));
+    } else {
+      setVisible(false);
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (visible) requestAnimationFrame(() => inputRef.current?.focus());
+  }, [visible]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape" && !busy) onClose(); };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open, onClose, busy]);
+
+  const doReset = useCallback(async () => {
+    setBusy(true);
+    try {
+      const { invoke } = await import("@tauri-apps/api/core");
+      await invoke("factory_reset");
+      // Relaunch so all in-memory state — frontend stores AND backend sessions —
+      // restarts from the now-empty database, a true first-launch state.
+      try {
+        const { relaunch } = await import("@tauri-apps/plugin-process");
+        await relaunch();
+      } catch {
+        // Relaunch unavailable (dev/web) — reload the webview as a fallback.
+        window.location.reload();
+      }
+    } catch {
+      setBusy(false);
+      toast.error("Couldn’t clear data. Please try again.");
+    }
+  }, []);
+
+  if (!open) return null;
+
+  return (
+    <div
+      ref={backdropRef}
+      onClick={(e) => { if (e.target === backdropRef.current && !busy) onClose(); }}
+      className={[
+        "fixed inset-0 z-50 flex items-start justify-center pt-[12vh]",
+        "transition-[background-color,backdrop-filter] duration-[var(--duration-base)]",
+        visible ? "bg-black/50 backdrop-blur-sm" : "bg-black/0 backdrop-blur-none",
+      ].join(" ")}
+    >
+      <div
+        role="alertdialog"
+        aria-modal="true"
+        aria-labelledby="reset-title"
+        data-testid="reset-modal"
+        className={[
+          "w-full max-w-md rounded-xl bg-bg-overlay border border-border shadow-[var(--shadow-lg)]",
+          "flex flex-col",
+          "transition-[opacity,transform] duration-[var(--duration-slow)] ease-[var(--ease-expo-out)]",
+          visible ? "opacity-100 translate-y-0" : "opacity-0 -translate-y-3",
+        ].join(" ")}
+      >
+        {/* Header */}
+        <div className="flex items-center gap-2.5 px-6 pt-5 pb-4 border-b border-border shrink-0">
+          <AlertCircle size={18} strokeWidth={2} className="text-status-error shrink-0" />
+          <h2 id="reset-title" className="text-[length:var(--text-lg)] font-semibold text-text-primary">
+            Clear all data?
+          </h2>
+        </div>
+
+        {/* Body */}
+        <div className="px-6 py-4 flex flex-col gap-4">
+          <p className="text-[length:var(--text-sm)] text-text-secondary">
+            This permanently deletes <strong className="text-text-primary">all</strong> saved
+            hosts, groups, history, snippets, port-forward rules, S3 connections, stored
+            credentials, and preferences. anySCP will restart fresh. This action cannot be undone.
+          </p>
+          <div>
+            <label htmlFor="reset-confirm" className={FIELD_LABEL_CLASS}>
+              Type <code className="px-1 rounded bg-bg-base text-status-error">{CONFIRM_WORD}</code> to confirm
+            </label>
+            <input
+              ref={inputRef}
+              id="reset-confirm"
+              data-testid="reset-confirm-input"
+              type="text"
+              autoComplete="off"
+              spellCheck={false}
+              value={text}
+              disabled={busy}
+              onChange={(e) => setText(e.target.value)}
+              onKeyDown={(e) => { if (e.key === "Enter" && canReset) void doReset(); }}
+              placeholder={CONFIRM_WORD}
+              className={TEXT_INPUT_CLASS}
+            />
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="px-6 pb-5 pt-3 flex items-center justify-end gap-2 border-t border-border shrink-0">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={busy}
+            className="px-4 py-2 text-[length:var(--text-sm)] text-text-secondary hover:text-text-primary rounded-lg transition-colors duration-[var(--duration-fast)] disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            data-testid="reset-confirm-submit"
+            onClick={() => void doReset()}
+            disabled={!canReset}
+            className="flex items-center gap-1.5 px-4 py-2 text-[length:var(--text-sm)] font-medium text-text-inverse bg-status-error hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed rounded-lg transition-[opacity] duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-bg-overlay"
+          >
+            {busy && <RefreshCw size={13} strokeWidth={2} className="motion-safe:animate-spin" />}
+            {busy ? "Clearing…" : "Clear all data"}
+          </button>
+        </div>
+      </div>
+    </div>
   );
 }
 

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -3,7 +3,7 @@ import { useSettingsStore } from "../../stores/settings-store";
 import { CustomSelect, type SelectOption } from "../shared/CustomSelect";
 import { useUpdaterStore } from "../../stores/updater-store";
 import { toast } from "../../stores/toast-store";
-import { RefreshCw, CheckCircle2, AlertCircle, Palette, SquareTerminal, ArrowUpDown, Info, ExternalLink, Check, FileCode, Plus, Trash2, FolderOpen, Star, Search, Database } from "lucide-react";
+import { RefreshCw, CheckCircle2, AlertCircle, Palette, SquareTerminal, ArrowUpDown, Info, ExternalLink, Check, FileCode, Plus, Trash2, FolderOpen, Star, Search, Database, Download, Upload, ShieldCheck } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import type { CursorStyle, ThemeMode, EditorConfig } from "../../stores/settings-store";
 
@@ -61,7 +61,7 @@ const SECTION_DESCRIPTIONS: Record<SectionId, string> = {
   terminal: "Font, cursor, and scrollback history.",
   transfers: "Control how files are transferred.",
   editors: "Editors used by “Edit” / “Open With” in the file browser.",
-  data: "Stored data and resetting the app.",
+  data: "Back up, restore, and reset your data.",
   about: "App information, links, and updates.",
 };
 
@@ -617,9 +617,51 @@ function TransferSettings() {
 
 function DataSettings() {
   const [confirmOpen, setConfirmOpen] = useState(false);
+  const [exportOpen, setExportOpen] = useState(false);
+  // Import is two-step: pick a file, then prompt for its password.
+  const [importPath, setImportPath] = useState<string | null>(null);
+
+  const pickImportFile = useCallback(async () => {
+    try {
+      const { open } = await import("@tauri-apps/plugin-dialog");
+      const picked = await open({
+        multiple: false,
+        directory: false,
+        title: "Select anySCP backup",
+        filters: [{ name: "anySCP backup", extensions: ["json"] }],
+      });
+      if (typeof picked === "string") setImportPath(picked);
+    } catch { /* dialog cancelled / unavailable */ }
+  }, []);
 
   return (
     <>
+      <SettingsGroup label="Backup">
+        <SettingRow>
+          <div>
+            <p className={LABEL_CLASS}>Export encrypted backup</p>
+            <p className={DESC_CLASS}>
+              Save all hosts, groups, snippets, settings, and stored credentials to a
+              single password-protected file.
+            </p>
+          </div>
+          <button type="button" data-testid="s-export-backup" onClick={() => setExportOpen(true)} className={BTN_SECONDARY}>
+            <Download size={13} strokeWidth={2} /> Export…
+          </button>
+        </SettingRow>
+        <SettingRow>
+          <div>
+            <p className={LABEL_CLASS}>Import backup</p>
+            <p className={DESC_CLASS}>
+              Restore from a backup file. This replaces all current data and restarts anySCP.
+            </p>
+          </div>
+          <button type="button" data-testid="s-import-backup" onClick={() => void pickImportFile()} className={BTN_SECONDARY}>
+            <Upload size={13} strokeWidth={2} /> Import…
+          </button>
+        </SettingRow>
+      </SettingsGroup>
+
       <SettingsGroup label="Danger zone">
         <div className="flex items-center justify-between gap-4 px-4 py-3 rounded-xl bg-bg-surface border border-status-error/30">
           <div>
@@ -649,8 +691,213 @@ function DataSettings() {
         </div>
       </SettingsGroup>
 
+      <BackupPasswordModal mode="export" open={exportOpen} onClose={() => setExportOpen(false)} />
+      <BackupPasswordModal
+        mode="import"
+        open={importPath !== null}
+        path={importPath ?? undefined}
+        onClose={() => setImportPath(null)}
+      />
       <ConfirmResetModal open={confirmOpen} onClose={() => setConfirmOpen(false)} />
     </>
+  );
+}
+
+/** Passphrase dialog for encrypted backup export/import.
+ *  - export: set + confirm a password, then a save-file dialog picks the path.
+ *  - import: enter the file's password; on success the app relaunches so the
+ *    restored data loads cleanly. */
+function BackupPasswordModal({ mode, open, path, onClose }: {
+  mode: "export" | "import";
+  open: boolean;
+  path?: string;
+  onClose: () => void;
+}) {
+  const isExport = mode === "export";
+  const MIN_LEN = 8;
+  const [pw, setPw] = useState("");
+  const [confirm, setConfirm] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [visible, setVisible] = useState(false);
+
+  const backdropRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const valid = isExport ? pw.length >= MIN_LEN && pw === confirm : pw.length > 0;
+  const canSubmit = valid && !busy;
+
+  useEffect(() => {
+    if (open) {
+      setPw("");
+      setConfirm("");
+      setBusy(false);
+      requestAnimationFrame(() => setVisible(true));
+    } else {
+      setVisible(false);
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (visible) requestAnimationFrame(() => inputRef.current?.focus());
+  }, [visible]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape" && !busy) onClose(); };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open, onClose, busy]);
+
+  const submit = useCallback(async () => {
+    if (!canSubmit) return;
+    setBusy(true);
+    try {
+      const { invoke } = await import("@tauri-apps/api/core");
+      if (isExport) {
+        const { save } = await import("@tauri-apps/plugin-dialog");
+        const d = new Date();
+        const stamp = `${d.getFullYear()}${String(d.getMonth() + 1).padStart(2, "0")}${String(d.getDate()).padStart(2, "0")}`;
+        const dest = await save({
+          title: "Save anySCP backup",
+          defaultPath: `anyscp-backup-${stamp}.json`,
+          filters: [{ name: "anySCP backup", extensions: ["json"] }],
+        });
+        if (!dest) { setBusy(false); return; } // dialog cancelled — keep the modal open
+        await invoke("backup_export", { password: pw, path: dest });
+        toast.success("Encrypted backup saved.");
+        onClose();
+      } else {
+        await invoke("backup_import", { password: pw, path });
+        // Relaunch so all in-memory state reloads from the restored database.
+        try {
+          const { relaunch } = await import("@tauri-apps/plugin-process");
+          await relaunch();
+        } catch {
+          window.location.reload();
+        }
+      }
+    } catch (e: unknown) {
+      setBusy(false);
+      const msg = e && typeof e === "object" && "message" in e
+        ? String((e as { message: unknown }).message)
+        : null;
+      toast.error(msg ?? (isExport ? "Couldn’t export backup." : "Import failed."));
+    }
+  }, [canSubmit, isExport, pw, path, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      ref={backdropRef}
+      onClick={(e) => { if (e.target === backdropRef.current && !busy) onClose(); }}
+      className={[
+        "fixed inset-0 z-50 flex items-start justify-center pt-[10vh]",
+        "transition-[background-color,backdrop-filter] duration-[var(--duration-base)]",
+        visible ? "bg-black/50 backdrop-blur-sm" : "bg-black/0 backdrop-blur-none",
+      ].join(" ")}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="backup-title"
+        data-testid={`backup-modal-${mode}`}
+        className={[
+          "w-full max-w-md rounded-xl bg-bg-overlay border border-border shadow-[var(--shadow-lg)]",
+          "flex flex-col",
+          "transition-[opacity,transform] duration-[var(--duration-slow)] ease-[var(--ease-expo-out)]",
+          visible ? "opacity-100 translate-y-0" : "opacity-0 -translate-y-3",
+        ].join(" ")}
+      >
+        {/* Header */}
+        <div className="flex items-center gap-2.5 px-6 pt-5 pb-4 border-b border-border shrink-0">
+          {isExport
+            ? <ShieldCheck size={18} strokeWidth={2} className="text-accent shrink-0" />
+            : <AlertCircle size={18} strokeWidth={2} className="text-status-error shrink-0" />}
+          <h2 id="backup-title" className="text-[length:var(--text-lg)] font-semibold text-text-primary">
+            {isExport ? "Export encrypted backup" : "Import backup"}
+          </h2>
+        </div>
+
+        {/* Body */}
+        <form
+          onSubmit={(e) => { e.preventDefault(); void submit(); }}
+          className="px-6 py-4 flex flex-col gap-4"
+        >
+          <p className="text-[length:var(--text-sm)] text-text-secondary">
+            {isExport
+              ? "Choose a password to encrypt the backup. You’ll need it to restore — there’s no way to recover the data without it."
+              : "Enter the password this backup was created with. Importing replaces all current data and restarts anySCP."}
+          </p>
+
+          <div>
+            <label htmlFor="backup-pw" className={FIELD_LABEL_CLASS}>Password</label>
+            <input
+              ref={inputRef}
+              id="backup-pw"
+              data-testid="backup-password"
+              type="password"
+              autoComplete={isExport ? "new-password" : "current-password"}
+              value={pw}
+              disabled={busy}
+              onChange={(e) => setPw(e.target.value)}
+              placeholder={isExport ? `At least ${MIN_LEN} characters` : "Backup password"}
+              className={TEXT_INPUT_CLASS}
+            />
+          </div>
+
+          {isExport && (
+            <div>
+              <label htmlFor="backup-pw2" className={FIELD_LABEL_CLASS}>Confirm password</label>
+              <input
+                id="backup-pw2"
+                data-testid="backup-password-confirm"
+                type="password"
+                autoComplete="new-password"
+                value={confirm}
+                disabled={busy}
+                onChange={(e) => setConfirm(e.target.value)}
+                placeholder="Re-enter password"
+                className={TEXT_INPUT_CLASS}
+              />
+              {confirm.length > 0 && pw !== confirm && (
+                <p className="mt-1 text-[length:var(--text-xs)] text-status-error">Passwords don’t match.</p>
+              )}
+            </div>
+          )}
+
+          {/* Footer */}
+          <div className="flex items-center justify-end gap-2 pt-1">
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={busy}
+              className="px-4 py-2 text-[length:var(--text-sm)] text-text-secondary hover:text-text-primary rounded-lg transition-colors duration-[var(--duration-fast)] disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              data-testid="backup-submit"
+              disabled={!canSubmit}
+              className={[
+                "flex items-center gap-1.5 px-4 py-2 rounded-lg",
+                "text-[length:var(--text-sm)] font-medium text-text-inverse",
+                isExport ? "bg-accent hover:bg-accent-hover" : "bg-status-error hover:opacity-90",
+                "disabled:opacity-50 disabled:cursor-not-allowed",
+                "transition-[opacity,background-color] duration-[var(--duration-fast)]",
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-bg-overlay",
+              ].join(" ")}
+            >
+              {busy && <RefreshCw size={13} strokeWidth={2} className="motion-safe:animate-spin" />}
+              {isExport
+                ? (busy ? "Exporting…" : "Choose file & export")
+                : (busy ? "Restoring…" : "Import & restart")}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
   );
 }
 

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -628,7 +628,7 @@ function DataSettings() {
         multiple: false,
         directory: false,
         title: "Select anySCP backup",
-        filters: [{ name: "anySCP backup", extensions: ["json"] }],
+        filters: [{ name: "anySCP backup", extensions: ["ascpbak"] }],
       });
       if (typeof picked === "string") setImportPath(picked);
     } catch { /* dialog cancelled / unavailable */ }
@@ -759,8 +759,8 @@ function BackupPasswordModal({ mode, open, path, onClose }: {
         const stamp = `${d.getFullYear()}${String(d.getMonth() + 1).padStart(2, "0")}${String(d.getDate()).padStart(2, "0")}`;
         const dest = await save({
           title: "Save anySCP backup",
-          defaultPath: `anyscp-backup-${stamp}.json`,
-          filters: [{ name: "anySCP backup", extensions: ["json"] }],
+          defaultPath: `anyscp-backup-${stamp}.ascpbak`,
+          filters: [{ name: "anySCP backup", extensions: ["ascpbak"] }],
         });
         if (!dest) { setBusy(false); return; } // dialog cancelled — keep the modal open
         await invoke("backup_export", { password: pw, path: dest });

--- a/src/stores/hosts-store.ts
+++ b/src/stores/hosts-store.ts
@@ -101,10 +101,37 @@ export const useHostsStore = create<HostsState>((set) => ({
   },
 }));
 
-// E2E test hook — lets WebDriver tests invoke duplicate without driving the
-// right-click context menu (which is flaky in WebKitWebDriver). No production
-// code reads this.
+// E2E test hooks. Defined in bundled source (not in injected browser.execute
+// callbacks) so the dynamic Tauri-API import resolves — a bare module specifier
+// can't be resolved in code injected at runtime. No production code reads these.
 if (typeof window !== "undefined") {
-  (window as unknown as { __e2eDuplicateHost?: (id: string) => Promise<void> })
-    .__e2eDuplicateHost = (id) => useHostsStore.getState().duplicateHost(id);
+  const w = window as unknown as {
+    __e2eDuplicateHost?: (id: string) => Promise<void>;
+    __e2eBackupExport?: (password: string, path: string) => Promise<void>;
+    __e2eBackupImport?: (password: string, path: string) => Promise<void>;
+    __e2eFactoryReset?: () => Promise<void>;
+    __e2eDataCounts?: () => Promise<{ hosts: number; groups: number; snippets: number }>;
+  };
+  w.__e2eDuplicateHost = (id) => useHostsStore.getState().duplicateHost(id);
+  w.__e2eBackupExport = async (password, path) => {
+    const { invoke } = await import("@tauri-apps/api/core");
+    await invoke("backup_export", { password, path });
+  };
+  w.__e2eBackupImport = async (password, path) => {
+    const { invoke } = await import("@tauri-apps/api/core");
+    await invoke("backup_import", { password, path });
+  };
+  w.__e2eFactoryReset = async () => {
+    const { invoke } = await import("@tauri-apps/api/core");
+    await invoke("factory_reset");
+  };
+  w.__e2eDataCounts = async () => {
+    const { invoke } = await import("@tauri-apps/api/core");
+    const [hosts, groups, snippets] = await Promise.all([
+      invoke<unknown[]>("list_hosts"),
+      invoke<unknown[]>("list_groups"),
+      invoke<unknown[]>("list_snippets", { folderId: null }),
+    ]);
+    return { hosts: hosts.length, groups: groups.length, snippets: snippets.length };
+  };
 }

--- a/tests/e2e/helpers/backup.ts
+++ b/tests/e2e/helpers/backup.ts
@@ -1,19 +1,22 @@
 // Encrypted backup / restore helpers.
 //
-// The export/import UI uses native file dialogs (and the import relaunches the
+// The export/import UI uses native file dialogs (and import relaunches the
 // app), neither of which WebDriver can drive. So — exactly like the transfer
-// helpers — these invoke the backend commands directly via the in-page Tauri
-// IPC with explicit file paths. The real passphrase modal and the typed-DELETE
-// confirmation are exercised against the UI in the spec; the relaunch is
-// reproduced with `relaunchApp()` (a fresh session re-reads the DB), which is
-// what the production flow does.
+// helpers — these call window hooks registered in bundled source
+// (hosts-store.ts) that invoke the backend commands directly with explicit
+// paths. The injected callbacks must NOT `import("@tauri-apps/...")` themselves:
+// a bare specifier can't be resolved in code injected at runtime, so the hook
+// (which Vite bundled) does the import instead.
 
 /** Encrypt all app data with `password` and write the backup to `path`. */
 export async function backupExport(password: string, path: string): Promise<void> {
     await browser.execute(
         async (pw: string, p: string) => {
-            const { invoke } = await import("@tauri-apps/api/core");
-            await invoke("backup_export", { password: pw, path: p });
+            const fn = (window as unknown as {
+                __e2eBackupExport?: (a: string, b: string) => Promise<void>;
+            }).__e2eBackupExport;
+            if (!fn) throw new Error("__e2eBackupExport not registered");
+            await fn(pw, p);
         },
         password,
         path,
@@ -25,8 +28,11 @@ export async function backupExport(password: string, path: string): Promise<void
 export async function backupImport(password: string, path: string): Promise<void> {
     await browser.execute(
         async (pw: string, p: string) => {
-            const { invoke } = await import("@tauri-apps/api/core");
-            await invoke("backup_import", { password: pw, path: p });
+            const fn = (window as unknown as {
+                __e2eBackupImport?: (a: string, b: string) => Promise<void>;
+            }).__e2eBackupImport;
+            if (!fn) throw new Error("__e2eBackupImport not registered");
+            await fn(pw, p);
         },
         password,
         path,
@@ -36,7 +42,21 @@ export async function backupImport(password: string, path: string): Promise<void
 /** Wipe all data + credentials (factory reset), without the UI relaunch. */
 export async function factoryReset(): Promise<void> {
     await browser.execute(async () => {
-        const { invoke } = await import("@tauri-apps/api/core");
-        await invoke("factory_reset");
+        const fn = (window as unknown as { __e2eFactoryReset?: () => Promise<void> })
+            .__e2eFactoryReset;
+        if (!fn) throw new Error("__e2eFactoryReset not registered");
+        await fn();
+    });
+}
+
+/** Row counts straight from the backend, across entity types — so a restore can
+ *  be verified at the data layer, not just via the dashboard. */
+export async function dataCounts(): Promise<{ hosts: number; groups: number; snippets: number }> {
+    return await browser.execute(async () => {
+        const fn = (window as unknown as {
+            __e2eDataCounts?: () => Promise<{ hosts: number; groups: number; snippets: number }>;
+        }).__e2eDataCounts;
+        if (!fn) throw new Error("__e2eDataCounts not registered");
+        return await fn();
     });
 }

--- a/tests/e2e/helpers/backup.ts
+++ b/tests/e2e/helpers/backup.ts
@@ -1,0 +1,42 @@
+// Encrypted backup / restore helpers.
+//
+// The export/import UI uses native file dialogs (and the import relaunches the
+// app), neither of which WebDriver can drive. So — exactly like the transfer
+// helpers — these invoke the backend commands directly via the in-page Tauri
+// IPC with explicit file paths. The real passphrase modal and the typed-DELETE
+// confirmation are exercised against the UI in the spec; the relaunch is
+// reproduced with `relaunchApp()` (a fresh session re-reads the DB), which is
+// what the production flow does.
+
+/** Encrypt all app data with `password` and write the backup to `path`. */
+export async function backupExport(password: string, path: string): Promise<void> {
+    await browser.execute(
+        async (pw: string, p: string) => {
+            const { invoke } = await import("@tauri-apps/api/core");
+            await invoke("backup_export", { password: pw, path: p });
+        },
+        password,
+        path,
+    );
+}
+
+/** Decrypt the backup at `path` with `password` and restore it (replaces all
+ *  current data). Rejects on a wrong password or an invalid file. */
+export async function backupImport(password: string, path: string): Promise<void> {
+    await browser.execute(
+        async (pw: string, p: string) => {
+            const { invoke } = await import("@tauri-apps/api/core");
+            await invoke("backup_import", { password: pw, path: p });
+        },
+        password,
+        path,
+    );
+}
+
+/** Wipe all data + credentials (factory reset), without the UI relaunch. */
+export async function factoryReset(): Promise<void> {
+    await browser.execute(async () => {
+        const { invoke } = await import("@tauri-apps/api/core");
+        await invoke("factory_reset");
+    });
+}

--- a/tests/e2e/specs/62-data-backup-restore.spec.ts
+++ b/tests/e2e/specs/62-data-backup-restore.spec.ts
@@ -29,7 +29,7 @@ import {
 } from "../helpers/host.js";
 import { openNewGroupModal, fillGroupAndSave } from "../helpers/groups.js";
 import { gotoSnippetsPage, openNewSnippetModal, fillSnippetAndSave } from "../helpers/snippets.js";
-import { backupExport, backupImport, factoryReset } from "../helpers/backup.js";
+import { backupExport, backupImport, factoryReset, dataCounts } from "../helpers/backup.js";
 
 const PASSWORD = "e2e-backup-pass-123";
 const createdFiles: string[] = [];
@@ -53,18 +53,6 @@ async function seedHost(label: string): Promise<void> {
     await clickSave();
     await waitForModalClosed();
     await findHostCardByLabel(label); // confirm it landed on the dashboard
-}
-
-/** Row counts straight from the backend, so "everything is back" is verified at
- *  the data layer across entity types, not just via the dashboard. */
-async function dataCounts(): Promise<{ hosts: number; groups: number; snippets: number }> {
-    return await browser.execute(async () => {
-        const { invoke } = await import("@tauri-apps/api/core");
-        const hosts = (await invoke("list_hosts")) as unknown[];
-        const groups = (await invoke("list_groups")) as unknown[];
-        const snippets = (await invoke("list_snippets", { folderId: null })) as unknown[];
-        return { hosts: hosts.length, groups: groups.length, snippets: snippets.length };
-    });
 }
 
 async function openSettingsData(): Promise<void> {

--- a/tests/e2e/specs/62-data-backup-restore.spec.ts
+++ b/tests/e2e/specs/62-data-backup-restore.spec.ts
@@ -1,0 +1,219 @@
+// Settings → Data: encrypted backup / restore + factory reset.
+//
+// The native save/open file dialogs and the post-import app relaunch can't be
+// driven through WebDriver, so the data-mutating steps invoke the backend
+// commands directly (helpers/backup.ts) with explicit temp paths — the same
+// approach the transfer specs use for the file picker. End-to-end behaviour is
+// then verified through the REAL UI: relaunch the app (which re-reads the DB,
+// exactly as the production import/reset flow does) and assert the dashboard.
+// The passphrase modal and the typed-DELETE confirmation gating are exercised
+// against the real UI separately.
+//
+// Because the WDIO process runs in the same container as the app, the spec can
+// also read the written backup file off disk and assert it's a binary container
+// (magic header), not the old JSON+base64 envelope.
+
+import { expect } from "chai";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { readFile, writeFile, rm } from "node:fs/promises";
+import { resetApp, relaunchApp } from "../helpers/reset.js";
+import { waitForDashboard, hostCardCount } from "../helpers/dashboard.js";
+import {
+    clickSave,
+    fillPasswordHostForm,
+    findHostCardByLabel,
+    assertHostAbsent,
+    openNewHostModal,
+    waitForModalClosed,
+} from "../helpers/host.js";
+import { openNewGroupModal, fillGroupAndSave } from "../helpers/groups.js";
+import { gotoSnippetsPage, openNewSnippetModal, fillSnippetAndSave } from "../helpers/snippets.js";
+import { backupExport, backupImport, factoryReset } from "../helpers/backup.js";
+
+const PASSWORD = "e2e-backup-pass-123";
+const createdFiles: string[] = [];
+
+function tmpBackupPath(): string {
+    const name = `anyscp-e2e-backup-${Date.now()}-${Math.random().toString(36).slice(2)}.ascpbak`;
+    const p = join(tmpdir(), name);
+    createdFiles.push(p);
+    return p;
+}
+
+async function seedHost(label: string): Promise<void> {
+    await openNewHostModal();
+    await fillPasswordHostForm({
+        label,
+        host: "192.0.2.10",
+        port: 22,
+        username: "tester",
+        password: "hunter2",
+    });
+    await clickSave();
+    await waitForModalClosed();
+    await findHostCardByLabel(label); // confirm it landed on the dashboard
+}
+
+/** Row counts straight from the backend, so "everything is back" is verified at
+ *  the data layer across entity types, not just via the dashboard. */
+async function dataCounts(): Promise<{ hosts: number; groups: number; snippets: number }> {
+    return await browser.execute(async () => {
+        const { invoke } = await import("@tauri-apps/api/core");
+        const hosts = (await invoke("list_hosts")) as unknown[];
+        const groups = (await invoke("list_groups")) as unknown[];
+        const snippets = (await invoke("list_snippets", { folderId: null })) as unknown[];
+        return { hosts: hosts.length, groups: groups.length, snippets: snippets.length };
+    });
+}
+
+async function openSettingsData(): Promise<void> {
+    const nav = await $("[aria-label='Settings']");
+    await nav.waitForClickable({ timeout: 10_000 });
+    await nav.click();
+    const tab = await $("[data-testid='settings-nav-data']");
+    await tab.waitForClickable({ timeout: 10_000 });
+    await tab.click();
+}
+
+describe("Settings → Data: backup & restore", () => {
+    beforeEach(async () => {
+        await resetApp();
+        await waitForDashboard();
+    });
+
+    after(async () => {
+        for (const f of createdFiles) await rm(f, { force: true });
+    });
+
+    it("adds data, backs it up, clears it, then restores everything from the backup", async () => {
+        const hostLabel = "Backup Target";
+        const groupName = "Backup Group";
+        const snippetName = "Backup Snippet";
+
+        // 1. Add data of several kinds (host + group on the dashboard, then a snippet).
+        await seedHost(hostLabel);
+        await openNewGroupModal();
+        await fillGroupAndSave(groupName);
+        await gotoSnippetsPage();
+        await openNewSnippetModal();
+        await fillSnippetAndSave({ name: snippetName, command: "echo hello" });
+
+        expect(await dataCounts()).to.deep.equal({ hosts: 1, groups: 1, snippets: 1 });
+
+        // 2. Take an encrypted backup.
+        const path = tmpBackupPath();
+        await backupExport(PASSWORD, path);
+
+        // It's a compact BINARY container (magic "ASCPBAK"), not JSON/base64,
+        // and far smaller than the old format would have produced.
+        const bytes = await readFile(path);
+        expect(bytes.subarray(0, 7).toString("latin1")).to.equal("ASCPBAK");
+        expect(bytes[0]).to.not.equal("{".charCodeAt(0)); // not a JSON document
+        expect(bytes.length).to.be.greaterThan(40); // header + ciphertext
+        expect(bytes.length).to.be.lessThan(64 * 1024); // not the old ~190KB bloat
+
+        // 3. Wipe everything, relaunch, and confirm NOTHING is left.
+        await factoryReset();
+        await relaunchApp();
+        await waitForDashboard();
+        expect(await dataCounts()).to.deep.equal({ hosts: 0, groups: 0, snippets: 0 });
+        await assertHostAbsent(hostLabel);
+        expect(await hostCardCount()).to.equal(0);
+
+        // 4. Restore from the backup, relaunch, and confirm EVERYTHING is back.
+        await backupImport(PASSWORD, path);
+        await relaunchApp();
+        await waitForDashboard();
+        expect(await dataCounts()).to.deep.equal({ hosts: 1, groups: 1, snippets: 1 });
+        await findHostCardByLabel(hostLabel);
+        expect(await hostCardCount()).to.equal(1);
+    });
+
+    it("rejects import with the wrong password", async () => {
+        await seedHost("Wrong Pw Host");
+        const path = tmpBackupPath();
+        await backupExport(PASSWORD, path);
+
+        let threw = false;
+        try {
+            await backupImport("not-the-password", path);
+        } catch {
+            threw = true;
+        }
+        expect(threw, "import with the wrong password must reject").to.equal(true);
+    });
+
+    it("rejects a file that isn't an anySCP backup", async () => {
+        const path = join(tmpdir(), `anyscp-e2e-notabackup-${Date.now()}.ascpbak`);
+        createdFiles.push(path);
+        await writeFile(path, "this is definitely not an anySCP backup");
+
+        let threw = false;
+        try {
+            await backupImport(PASSWORD, path);
+        } catch {
+            threw = true;
+        }
+        expect(threw, "import of a non-backup file must reject").to.equal(true);
+    });
+});
+
+describe("Settings → Data: UI gating", () => {
+    beforeEach(async () => {
+        await resetApp();
+        await waitForDashboard();
+        await openSettingsData();
+    });
+
+    it("shows Export, Import, and Clear-all-data actions", async () => {
+        await (await $("[data-testid='s-export-backup']")).waitForDisplayed({ timeout: 10_000 });
+        await (await $("[data-testid='s-import-backup']")).waitForDisplayed({ timeout: 10_000 });
+        await (await $("[data-testid='s-clear-data']")).waitForDisplayed({ timeout: 10_000 });
+    });
+
+    it("clear-all-data stays disabled until you type DELETE", async () => {
+        await (await $("[data-testid='s-clear-data']")).click();
+        const submit = await $("[data-testid='reset-confirm-submit']");
+        await submit.waitForDisplayed({ timeout: 5_000 });
+        expect(await submit.isEnabled()).to.equal(false);
+
+        await (await $("[data-testid='reset-confirm-input']")).setValue("DELETE");
+        await browser.waitUntil(async () => await submit.isEnabled(), {
+            timeout: 5_000,
+            timeoutMsg: "Clear-all-data submit never enabled after typing DELETE",
+        });
+
+        // Close WITHOUT confirming — must not wipe anything.
+        await browser.keys("Escape");
+    });
+
+    it("export submit stays disabled until passwords match and are long enough", async () => {
+        await (await $("[data-testid='s-export-backup']")).click();
+        const submit = await $("[data-testid='backup-submit']");
+        await submit.waitForDisplayed({ timeout: 5_000 });
+        expect(await submit.isEnabled()).to.equal(false);
+
+        const pw = await $("[data-testid='backup-password']");
+        const confirm = await $("[data-testid='backup-password-confirm']");
+
+        // Too short (matching but < 8 chars).
+        await pw.setValue("short");
+        await confirm.setValue("short");
+        expect(await submit.isEnabled()).to.equal(false);
+
+        // Long enough but mismatched.
+        await pw.setValue("longenough1");
+        await confirm.setValue("different123");
+        expect(await submit.isEnabled()).to.equal(false);
+
+        // Long + matching → enabled.
+        await confirm.setValue("longenough1");
+        await browser.waitUntil(async () => await submit.isEnabled(), {
+            timeout: 5_000,
+            timeoutMsg: "Export submit never enabled with matching long passwords",
+        });
+
+        await browser.keys("Escape");
+    });
+});


### PR DESCRIPTION
Adds a new **Settings → Data** section with two related data-management features.

## 1. Clear all data (factory reset)
A danger-zone action that permanently wipes every DB table (saved hosts, groups, connection history, snippets, port-forward rules, S3 connections) **and** app settings, plus the matching credentials in the OS keychain — returning anySCP to first-launch state. Gated behind a typed `DELETE` confirmation; relaunches the app afterwards.

- `HostDb::factory_reset` clears all tables + `app_settings` in one transaction (`defer_foreign_keys` avoids FK-ordering issues), preserving the schema/`_meta` so the DB matches a fresh install. Returns host/S3 ids so their keychain secrets are purged (the keyring crate can't enumerate).
- `factory_reset` command; inconclusive userland detection now defaults to the universal path rather than Gnu.

## 2. Encrypted backup & restore
Password-protected, full-fidelity export/import.

- **Format**: a single JSON envelope. Payload = a raw SQLite snapshot of the whole DB + every stored credential, **gzip-compressed** then encrypted with **AES-256-GCM** under a key derived from the passphrase via **Argon2id** (m=64 MiB, t=3, p=1). Fresh random salt + nonce per backup; AAD-bound; secrets never hit disk in plaintext.
- **Compact**: framing keeps the DB as raw bytes (no inner base64) and gzip crushes SQLite's zero-filled pages — a near-empty backup is ~5 KB instead of ~190 KB.
- **Export**: `VACUUM INTO` an owner-only (0700) temp dir → gather keychain credentials → encrypt → write.
- **Import**: decrypt → validate + migrate the snapshot up to the current schema (older backups restore; newer-than-app rejected) → atomic `ATTACH` copy with **name-mapped** column lists (no positional `SELECT *`) → restore credentials → relaunch.
- **Hardening** (from an adversarial review): untrusted KDF params clamped on import (OOM-DoS guard), owner-only temp dirs for the transient plaintext snapshot, cleanup on all paths, empty-password rejection.
- New deps: `argon2`, `aes-gcm`, `getrandom`, `base64`, `flate2`.

## UI
Settings → Data → **Backup** (Export… / Import… with a passphrase dialog) and **Danger zone** (Clear all data…). Kept as its own focused section.

## Tests / checks
- 143 Rust unit tests pass, including: factory-reset wipe; DB snapshot round-trip (incl. FTS, replace semantics, garbage rejection); backup crypto round-trip (wrong-password / tamper / fresh-nonce); frame + gzip round-trips; and a full build→restore round-trip asserting the output is smaller than the raw snapshot.
- `clippy -D warnings`, `cargo fmt`, and `tsc` all clean.

Note: the encrypted-backup file format / end-to-end flow through the real OS keychain + relaunch was validated by unit tests at each layer; a manual run is recommended before release.