### PR TITLE
feat(ssh): cancellable connection attempts

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -216,6 +216,7 @@ pub fn run() {
             scp::commands::scp_set_concurrency,
             // SSH
             ssh::commands::ssh_connect,
+            ssh::commands::ssh_cancel_connect,
             ssh::commands::ssh_split_session,
             ssh::commands::ssh_disconnect,
             ssh::commands::ssh_send_input,

--- a/src-tauri/src/portforward/commands.rs
+++ b/src-tauri/src/portforward/commands.rs
@@ -212,7 +212,7 @@ pub async fn pf_start_tunnel(
         jump_host: None,
     };
 
-    let session_id = ssh_manager.connect_no_pty(config).await?;
+    let session_id = ssh_manager.connect_no_pty(config, None).await?;
     let handle = ssh_manager.get_handle(&session_id.0)?;
 
     // Record last_used_at

--- a/src-tauri/src/ssh/commands.rs
+++ b/src-tauri/src/ssh/commands.rs
@@ -33,10 +33,23 @@ const HEALTH_CHECK_TIMEOUT: Duration = Duration::from_secs(5);
 #[tauri::command]
 pub async fn ssh_connect(
     host_config: HostConfig,
+    attempt_id: Option<String>,
     state: State<'_, SshManager>,
     app_handle: AppHandle,
 ) -> Result<SessionId, SshError> {
-    state.connect(host_config, app_handle).await
+    state.connect(host_config, app_handle, attempt_id).await
+}
+
+/// Abort an in-flight connection attempt identified by the frontend-supplied
+/// `attempt_id`. The pending `connect`/`connect_no_pty` call unwinds its partial
+/// state and returns `SshError::Cancelled`. A no-op if the attempt already
+/// settled (returns `false`).
+#[tauri::command]
+pub async fn ssh_cancel_connect(
+    attempt_id: String,
+    state: State<'_, SshManager>,
+) -> Result<bool, SshError> {
+    Ok(state.cancel_connect(&attempt_id))
 }
 
 #[tauri::command]
@@ -522,6 +535,7 @@ mod tests {
 #[tauri::command]
 pub async fn connect_saved_host(
     host_id: String,
+    attempt_id: Option<String>,
     state: State<'_, SshManager>,
     db: State<'_, Arc<HostDb>>,
     app_handle: AppHandle,
@@ -539,7 +553,7 @@ pub async fn connect_saved_host(
     .map_err(|e| SshError::IoError(format!("task panicked: {e}")))??;
 
     let auth_type = auth_method_label(&config.auth_method).to_string();
-    let session_id = state.connect(config, app_handle).await?;
+    let session_id = state.connect(config, app_handle, attempt_id).await?;
 
     crate::telemetry::capture(
         "ssh_connected",
@@ -651,6 +665,7 @@ fn build_host_config_blocking(
 #[tauri::command]
 pub async fn connect_saved_host_no_pty(
     host_id: String,
+    attempt_id: Option<String>,
     state: State<'_, SshManager>,
     db: State<'_, Arc<HostDb>>,
 ) -> Result<SessionId, SshError> {
@@ -662,5 +677,5 @@ pub async fn connect_saved_host_no_pty(
     .await
     .map_err(|e| SshError::IoError(format!("task panicked: {e}")))??;
 
-    state.connect_no_pty(config).await
+    state.connect_no_pty(config, attempt_id).await
 }

--- a/src-tauri/src/ssh/manager.rs
+++ b/src-tauri/src/ssh/manager.rs
@@ -7,6 +7,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 use tauri::{AppHandle, Emitter};
+use tokio_util::sync::CancellationToken;
 use tracing::info;
 
 use super::handler::SshClientHandler;
@@ -40,6 +41,11 @@ pub struct SshManager {
     sessions: DashMap<String, SshSession>,
     /// Bare SSH handles for SFTP-only connections (no PTY).
     bare_handles: DashMap<String, BareConn>,
+    /// In-flight connection attempts, keyed by the frontend-supplied attempt ID.
+    /// A handle exists here only while a `connect`/`connect_no_pty` call is
+    /// running; cancelling its token aborts the attempt before any session is
+    /// registered, so no ghost session or lingering handle is left behind.
+    pending_connects: DashMap<String, CancellationToken>,
 }
 
 impl SshManager {
@@ -47,6 +53,34 @@ impl SshManager {
         Self {
             sessions: DashMap::new(),
             bare_handles: DashMap::new(),
+            pending_connects: DashMap::new(),
+        }
+    }
+
+    /// Register a cancellation token for an in-flight connection attempt and
+    /// return a clone the connect path can await on. Re-registering the same
+    /// attempt ID replaces (and orphans) the previous token.
+    fn register_pending(&self, attempt_id: String) -> CancellationToken {
+        let token = CancellationToken::new();
+        self.pending_connects.insert(attempt_id, token.clone());
+        token
+    }
+
+    /// Drop the pending registration for `attempt_id` once the attempt settles
+    /// (succeeded, failed, or was cancelled).
+    fn clear_pending(&self, attempt_id: &str) {
+        self.pending_connects.remove(attempt_id);
+    }
+
+    /// Abort an in-flight connection attempt by its attempt ID. Returns `true`
+    /// if a matching attempt was found and signalled. The connect path observes
+    /// the cancellation, unwinds its partial state, and removes the registration.
+    pub fn cancel_connect(&self, attempt_id: &str) -> bool {
+        if let Some(entry) = self.pending_connects.get(attempt_id) {
+            entry.cancel();
+            true
+        } else {
+            false
         }
     }
 
@@ -55,9 +89,16 @@ impl SshManager {
         &self,
         config: HostConfig,
         app_handle: AppHandle,
+        attempt_id: Option<String>,
     ) -> Result<SessionId, SshError> {
         let session_id = SessionId::new();
         let sid = session_id.0.clone();
+
+        // Arm cancellation for this attempt (if the frontend supplied an ID) so
+        // `cancel_connect` can abort it mid-handshake.
+        let cancel_token = attempt_id
+            .as_ref()
+            .map(|id| self.register_pending(id.clone()));
 
         let _ = app_handle.emit(
             "ssh:status",
@@ -88,22 +129,44 @@ impl SshManager {
         // chain. The jump handles must outlive the target session, so they are
         // handed (shared) to the SshSession to keep alive; sharing via Arc lets
         // split panes on the same connection hold the tunnel open too.
-        let (handle, jump_handles) = Self::establish(&config, russh_config).await?;
+        //
+        // The whole establish + PTY-open is raced against the cancellation token:
+        // if the user cancels, the future is dropped mid-await, which drops any
+        // partially-established handles and lets russh tear the connection down.
+        // Nothing is inserted into `sessions` until this succeeds, so a cancel
+        // leaves no ghost session behind.
+        let connect_fut = async {
+            let (handle, jump_handles) = Self::establish(&config, russh_config).await?;
 
-        info!(session_id = %sid, host = %config.host, "SSH authenticated");
+            info!(session_id = %sid, host = %config.host, "SSH authenticated");
 
-        let session = SshSession::open_pty(
-            handle,
-            Arc::new(jump_handles),
-            sid.clone(),
-            80,
-            24,
-            app_handle,
-            config.default_shell.clone(),
-            config.startup_command.clone(),
-        )
-        .await?;
+            SshSession::open_pty(
+                handle,
+                Arc::new(jump_handles),
+                sid.clone(),
+                80,
+                24,
+                app_handle,
+                config.default_shell.clone(),
+                config.startup_command.clone(),
+            )
+            .await
+        };
 
+        let outcome = match &cancel_token {
+            Some(token) => tokio::select! {
+                biased;
+                _ = token.cancelled() => Err(SshError::Cancelled),
+                r = connect_fut => r,
+            },
+            None => connect_fut.await,
+        };
+
+        if let Some(id) = &attempt_id {
+            self.clear_pending(id);
+        }
+
+        let session = outcome?;
         self.sessions.insert(sid.clone(), session);
 
         Ok(session_id)
@@ -112,17 +175,40 @@ impl SshManager {
     /// Establish an SSH connection without opening a PTY.
     /// Used for SFTP-only sessions where no terminal is needed.
     /// Returns a session ID that can be used with `get_handle`.
-    pub async fn connect_no_pty(&self, config: HostConfig) -> Result<SessionId, SshError> {
+    pub async fn connect_no_pty(
+        &self,
+        config: HostConfig,
+        attempt_id: Option<String>,
+    ) -> Result<SessionId, SshError> {
         let session_id = SessionId::new();
         let sid = session_id.0.clone();
+
+        let cancel_token = attempt_id
+            .as_ref()
+            .map(|id| self.register_pending(id.clone()));
 
         let russh_config = Arc::new(client::Config {
             inactivity_timeout: None, // SFTP connections stay alive indefinitely
             ..Default::default()
         });
 
-        // Establish the connection — directly or tunnelled through a ProxyJump.
-        let (handle, jump_handles) = Self::establish(&config, russh_config).await?;
+        // Establish the connection — directly or tunnelled through a ProxyJump —
+        // racing against the cancellation token so the user can abort mid-handshake.
+        let establish_fut = Self::establish(&config, russh_config);
+        let established = match &cancel_token {
+            Some(token) => tokio::select! {
+                biased;
+                _ = token.cancelled() => Err(SshError::Cancelled),
+                r = establish_fut => r,
+            },
+            None => establish_fut.await,
+        };
+
+        if let Some(id) = &attempt_id {
+            self.clear_pending(id);
+        }
+
+        let (handle, jump_handles) = established?;
 
         info!(session_id = %sid, host = %config.host, "SSH authenticated (no PTY, for SFTP)");
 

--- a/src-tauri/src/ssh/manager.rs
+++ b/src-tauri/src/ssh/manager.rs
@@ -459,12 +459,24 @@ impl SshManager {
             },
         );
 
-        let (_, session) = self
-            .sessions
-            .remove(session_id)
-            .ok_or_else(|| SshError::SessionNotFound(session_id.to_string()))?;
-
-        session.disconnect().await?;
+        // PTY sessions and bare (SFTP-only) handles live in separate maps —
+        // check both so a no-PTY connection (e.g. an explorer connect whose
+        // cancel landed after the handshake settled) can be torn down through
+        // this same command instead of lingering in `bare_handles` forever.
+        if let Some((_, session)) = self.sessions.remove(session_id) {
+            session.disconnect().await?;
+        } else if let Some((_, bare)) = self.bare_handles.remove(session_id) {
+            // Best-effort goodbye — dropping the handles closes the connection
+            // (and any ProxyJump tunnel beneath it) even if the server is gone.
+            let _ = bare
+                .handle
+                .lock()
+                .await
+                .disconnect(russh::Disconnect::ByApplication, "", "en")
+                .await;
+        } else {
+            return Err(SshError::SessionNotFound(session_id.to_string()));
+        }
 
         let _ = app_handle.emit(
             "ssh:status",
@@ -476,5 +488,55 @@ impl SshManager {
 
         info!(session_id = %session_id, "SSH disconnected");
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Cancelling an attempt ID that was never registered (or whose attempt
+    /// already settled) must report that nothing was found.
+    #[test]
+    fn cancel_connect_returns_false_for_unknown_attempt() {
+        let manager = SshManager::new();
+        assert!(!manager.cancel_connect("no-such-attempt"));
+    }
+
+    /// The token handed to the connect path observes a cancel issued through
+    /// the manager by attempt ID.
+    #[test]
+    fn cancel_connect_signals_the_registered_token() {
+        let manager = SshManager::new();
+        let token = manager.register_pending("attempt-1".to_string());
+        assert!(!token.is_cancelled());
+
+        assert!(manager.cancel_connect("attempt-1"));
+        assert!(token.is_cancelled());
+    }
+
+    /// Once an attempt settles and clears its registration, a late cancel is a
+    /// no-op: the settled attempt's token must not be signalled.
+    #[test]
+    fn clear_pending_makes_a_late_cancel_a_no_op() {
+        let manager = SshManager::new();
+        let token = manager.register_pending("attempt-1".to_string());
+        manager.clear_pending("attempt-1");
+
+        assert!(!manager.cancel_connect("attempt-1"));
+        assert!(!token.is_cancelled());
+    }
+
+    /// Re-registering an attempt ID replaces the token: a cancel reaches the
+    /// new attempt, never the orphaned one.
+    #[test]
+    fn reregistering_an_attempt_id_replaces_the_token() {
+        let manager = SshManager::new();
+        let orphaned = manager.register_pending("attempt-1".to_string());
+        let active = manager.register_pending("attempt-1".to_string());
+
+        assert!(manager.cancel_connect("attempt-1"));
+        assert!(active.is_cancelled());
+        assert!(!orphaned.is_cancelled());
     }
 }

--- a/src-tauri/src/types/error.rs
+++ b/src-tauri/src/types/error.rs
@@ -24,6 +24,9 @@ pub enum SshError {
     #[allow(dead_code)]
     #[error("Session already disconnected")]
     AlreadyDisconnected,
+
+    #[error("Connection cancelled")]
+    Cancelled,
 }
 
 impl Serialize for SshError {
@@ -41,6 +44,7 @@ impl Serialize for SshError {
             SshError::KeyParseError(_) => "key_parse_error",
             SshError::IoError(_) => "io_error",
             SshError::AlreadyDisconnected => "already_disconnected",
+            SshError::Cancelled => "cancelled",
         };
         state.serialize_field("kind", kind)?;
         state.serialize_field("message", &self.to_string())?;

--- a/src-tauri/src/types/error.rs
+++ b/src-tauri/src/types/error.rs
@@ -69,3 +69,17 @@ impl From<russh_keys::Error> for SshError {
         SshError::KeyParseError(e.to_string())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The frontend distinguishes a deliberate cancel from a failure by the
+    /// serialized `kind`, so the wire shape is a contract.
+    #[test]
+    fn cancelled_serializes_with_a_distinct_kind() {
+        let json = serde_json::to_value(SshError::Cancelled).expect("serialize");
+        assert_eq!(json["kind"], "cancelled");
+        assert_eq!(json["message"], "Connection cancelled");
+    }
+}

--- a/src/components/dashboard/ConnectionDialog.tsx
+++ b/src/components/dashboard/ConnectionDialog.tsx
@@ -8,17 +8,21 @@ interface ConnectionDialogProps {
   error: string | null;
   onClose: () => void;
   onRetry?: () => void;
+  /** Abort the in-progress attempt. When set, a Cancel button is shown while connecting. */
+  onCancel?: () => void;
 }
 
-export function ConnectionDialog({ label, error, onClose, onRetry }: ConnectionDialogProps) {
-  // Close on Escape
+export function ConnectionDialog({ label, error, onClose, onRetry, onCancel }: ConnectionDialogProps) {
+  // While connecting, Escape cancels the attempt; in the error state it closes.
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
+      if (e.key !== "Escape") return;
+      if (!error && onCancel) onCancel();
+      else onClose();
     };
     document.addEventListener("keydown", handler);
     return () => document.removeEventListener("keydown", handler);
-  }, [onClose]);
+  }, [onClose, onCancel, error]);
 
   return (
     <div
@@ -85,6 +89,14 @@ export function ConnectionDialog({ label, error, onClose, onRetry }: ConnectionD
                 {label}
               </p>
             </div>
+            {onCancel && (
+              <button
+                onClick={onCancel}
+                className="mt-1 px-4 py-2 text-[length:var(--text-sm)] text-text-secondary hover:text-text-primary rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                Cancel
+              </button>
+            )}
           </div>
         )}
       </div>

--- a/src/components/dashboard/HostsDashboard.tsx
+++ b/src/components/dashboard/HostsDashboard.tsx
@@ -24,6 +24,18 @@ import { GroupModal } from "./GroupModal";
 import { ConnectionDialog } from "./ConnectionDialog";
 import { RecentConnections } from "./RecentConnections";
 
+// Abort an in-flight SSH connection attempt on the Rust side. Best-effort:
+// the attempt may already have settled, in which case the backend reports it
+// found nothing and we simply move on.
+async function cancelConnectAttempt(attemptId: string) {
+  try {
+    const { invoke } = await import("@tauri-apps/api/core");
+    await invoke("ssh_cancel_connect", { attemptId });
+  } catch {
+    /* attempt already finished — nothing to cancel */
+  }
+}
+
 // ─── Component ───────────────────────────────────────────────────────────────
 
 export function HostsDashboard() {
@@ -83,10 +95,16 @@ export function HostsDashboard() {
   };
 
   const handleS3Connect = async (conn: S3Connection) => {
-    setConnectingHost({ label: conn.label, error: null, retry: () => void handleS3Connect(conn) });
+    let cancelled = false;
+    const cancel = () => {
+      cancelled = true;
+      setConnectingHost(null);
+    };
+    setConnectingHost({ label: conn.label, error: null, retry: () => void handleS3Connect(conn), cancel });
     try {
       const { invoke } = await import("@tauri-apps/api/core");
       await invoke("s3_reconnect", { id: conn.id });
+      if (cancelled) return;
       useS3Store.getState().openSession(conn.id, conn.label);
       if (conn.bucket) {
         useS3Store.getState().setCurrentBucket(conn.id, conn.bucket);
@@ -94,10 +112,11 @@ export function HostsDashboard() {
       setConnectingHost(null);
       useTabStore.getState().addTab({ type: "s3", id: conn.id, label: conn.label });
     } catch (err) {
+      if (cancelled) return;
       const msg = err && typeof err === "object" && "message" in err
         ? String((err as { message: string }).message)
         : "S3 connection failed";
-      setConnectingHost({ label: conn.label, error: msg, retry: () => void handleS3Connect(conn) });
+      setConnectingHost({ label: conn.label, error: msg, retry: () => void handleS3Connect(conn), cancel: null });
     }
   };
 
@@ -110,7 +129,7 @@ export function HostsDashboard() {
   };
 
   // Connection dialog state
-  const [connectingHost, setConnectingHost] = useState<{ label: string; error: string | null; retry: (() => void) | null } | null>(null);
+  const [connectingHost, setConnectingHost] = useState<{ label: string; error: string | null; retry: (() => void) | null; cancel: (() => void) | null } | null>(null);
 
   // Load data on mount
   useEffect(() => {
@@ -203,11 +222,22 @@ export function HostsDashboard() {
   const connectToHost = useCallback(
     async (host: SavedHost) => {
       const label = host.label || `${host.username}@${host.host}`;
-      setConnectingHost({ label, error: null, retry: () => void connectToHost(host) });
+      const attemptId = crypto.randomUUID();
+      let cancelled = false;
+      const cancel = () => {
+        cancelled = true;
+        void cancelConnectAttempt(attemptId);
+        setConnectingHost(null);
+      };
+      setConnectingHost({ label, error: null, retry: () => void connectToHost(host), cancel });
       try {
         const { invoke } = await import("@tauri-apps/api/core");
         const addSession = useSessionStore.getState().addSession;
-        const sessionId = await invoke<string>("connect_saved_host", { hostId: host.id });
+        const sessionId = await invoke<string>("connect_saved_host", { hostId: host.id, attemptId });
+        if (cancelled) {
+          void invoke("ssh_disconnect", { sessionId });
+          return;
+        }
         const hostLabel = host.label || `${host.username}@${host.host}`;
         addSession(sessionId, {
           host: host.host,
@@ -220,10 +250,11 @@ export function HostsDashboard() {
         setConnectingHost(null);
         useTabStore.getState().addTab({ type: "terminal", id: sessionId, label: hostLabel });
       } catch (err) {
+        if (cancelled) return;
         const msg = err && typeof err === "object" && "message" in err
           ? String((err as { message: string }).message)
           : "Connection failed. Check host, port, and credentials.";
-        setConnectingHost({ label, error: msg, retry: () => void connectToHost(host) });
+        setConnectingHost({ label, error: msg, retry: () => void connectToHost(host), cancel: null });
       }
     },
     [],
@@ -232,11 +263,22 @@ export function HostsDashboard() {
   const handleRecentConnect = useCallback(
     async (conn: RecentConnection) => {
       const label = conn.host_label || `${conn.username}@${conn.host}`;
-      setConnectingHost({ label, error: null, retry: () => void handleRecentConnect(conn) });
+      const attemptId = crypto.randomUUID();
+      let cancelled = false;
+      const cancel = () => {
+        cancelled = true;
+        void cancelConnectAttempt(attemptId);
+        setConnectingHost(null);
+      };
+      setConnectingHost({ label, error: null, retry: () => void handleRecentConnect(conn), cancel });
       try {
         const { invoke } = await import("@tauri-apps/api/core");
         const addSession = useSessionStore.getState().addSession;
-        const sessionId = await invoke<string>("connect_saved_host", { hostId: conn.host_id });
+        const sessionId = await invoke<string>("connect_saved_host", { hostId: conn.host_id, attemptId });
+        if (cancelled) {
+          void invoke("ssh_disconnect", { sessionId });
+          return;
+        }
         const connLabel = conn.host_label || `${conn.username}@${conn.host}`;
         addSession(sessionId, {
           host: conn.host,
@@ -249,10 +291,11 @@ export function HostsDashboard() {
         setConnectingHost(null);
         useTabStore.getState().addTab({ type: "terminal", id: sessionId, label: connLabel });
       } catch (err) {
+        if (cancelled) return;
         const msg = err && typeof err === "object" && "message" in err
           ? String((err as { message: string }).message)
           : "Connection failed.";
-        setConnectingHost({ label, error: msg, retry: () => void handleRecentConnect(conn) });
+        setConnectingHost({ label, error: msg, retry: () => void handleRecentConnect(conn), cancel: null });
       }
     },
     [],
@@ -266,11 +309,19 @@ export function HostsDashboard() {
   const exploreHost = useCallback(
     async (host: SavedHost) => {
       const label = host.label || `${host.username}@${host.host}`;
-      setConnectingHost({ label, error: null, retry: () => void exploreHost(host) });
+      const attemptId = crypto.randomUUID();
+      let cancelled = false;
+      const cancel = () => {
+        cancelled = true;
+        void cancelConnectAttempt(attemptId);
+        setConnectingHost(null);
+      };
+      setConnectingHost({ label, error: null, retry: () => void exploreHost(host), cancel });
       try {
         const { invoke } = await import("@tauri-apps/api/core");
 
-        const sessionId = await invoke<string>("connect_saved_host_no_pty", { hostId: host.id });
+        const sessionId = await invoke<string>("connect_saved_host_no_pty", { hostId: host.id, attemptId });
+        if (cancelled) return;
 
         let explorerSessionId: string;
         let transport: "sftp" | "scp" = "sftp";
@@ -292,10 +343,11 @@ export function HostsDashboard() {
         setConnectingHost(null);
         useTabStore.getState().addTab({ type: "sftp", id: explorerSessionId, label, transport });
       } catch (err) {
+        if (cancelled) return;
         const msg = err && typeof err === "object" && "message" in err
           ? String((err as { message: string }).message)
           : "Connection failed.";
-        setConnectingHost({ label, error: msg, retry: () => void exploreHost(host) });
+        setConnectingHost({ label, error: msg, retry: () => void exploreHost(host), cancel: null });
       }
     },
     [],
@@ -651,6 +703,7 @@ export function HostsDashboard() {
           error={connectingHost.error}
           onClose={() => setConnectingHost(null)}
           onRetry={connectingHost.retry ?? undefined}
+          onCancel={connectingHost.cancel ?? undefined}
         />
       )}
     </>

--- a/src/components/dashboard/HostsDashboard.tsx
+++ b/src/components/dashboard/HostsDashboard.tsx
@@ -321,7 +321,12 @@ export function HostsDashboard() {
         const { invoke } = await import("@tauri-apps/api/core");
 
         const sessionId = await invoke<string>("connect_saved_host_no_pty", { hostId: host.id, attemptId });
-        if (cancelled) return;
+        if (cancelled) {
+          // The handshake settled before the cancel landed — tear the bare
+          // connection down, otherwise nothing ever references it again.
+          void invoke("ssh_disconnect", { sessionId });
+          return;
+        }
 
         let explorerSessionId: string;
         let transport: "sftp" | "scp" = "sftp";
@@ -336,6 +341,15 @@ export function HostsDashboard() {
             // Surface the original SFTP error if SCP also fails.
             throw sftpErr;
           }
+        }
+
+        if (cancelled) {
+          // Cancel landed while the explorer channel was opening — drop the
+          // explorer session and the connection beneath it; no tab was added.
+          if (transport === "sftp") void invoke("sftp_close", { sftpSessionId: explorerSessionId });
+          else void invoke("scp_close", { scpSessionId: explorerSessionId });
+          void invoke("ssh_disconnect", { sessionId });
+          return;
         }
 
         useSftpStore.getState().openSession(explorerSessionId, sessionId, label, host.username, false, host.start_directory ?? undefined);


### PR DESCRIPTION
This pull request adds support for cancelling in-progress SSH connection attempts from the frontend, improving the user experience when connecting to SSH hosts. The changes introduce a new cancellation mechanism on both the backend (Rust) and frontend (React/TypeScript), allowing users to abort SSH handshakes cleanly and avoid ghost sessions or lingering handles. Additionally, the UI now provides a Cancel button during connection attempts, and Escape key handling is improved for cancelling or closing dialogs.

**SSH Connection Cancellation Support**

_Backend (Rust):_

* Added a new `ssh_cancel_connect` Tauri command and corresponding handler in `SshManager`, allowing the frontend to abort an in-flight SSH connection attempt via a frontend-supplied `attempt_id`. The backend races the handshake against a cancellation token, ensuring no ghost sessions are left on cancellation. [[1]](diffhunk://#diff-dce2c88bb6b4c136351d540a607064f184328efbe68c5b161222e1ef1c268a91R36-R52) [[2]](diffhunk://#diff-eabcebd0ae5c9b77a5247e1bdbdb88b1869fc0c932d0ef0cf2ecf9ee5221be7cR219) [[3]](diffhunk://#diff-5f2541adc7e7e8237dd35a843f30e1d1f006af7b2289269b82eddb0b279e33adR44-R83) [[4]](diffhunk://#diff-5f2541adc7e7e8237dd35a843f30e1d1f006af7b2289269b82eddb0b279e33adR92-R102) [[5]](diffhunk://#diff-5f2541adc7e7e8237dd35a843f30e1d1f006af7b2289269b82eddb0b279e33adR132-R143) [[6]](diffhunk://#diff-5f2541adc7e7e8237dd35a843f30e1d1f006af7b2289269b82eddb0b279e33adL105-R169) [[7]](diffhunk://#diff-5f2541adc7e7e8237dd35a843f30e1d1f006af7b2289269b82eddb0b279e33adL115-R211)
* Modified all SSH connect commands (including saved hosts and no-PTY variants) to accept an optional `attempt_id` parameter, wiring it through to the manager for cancellation support. [[1]](diffhunk://#diff-dce2c88bb6b4c136351d540a607064f184328efbe68c5b161222e1ef1c268a91R538) [[2]](diffhunk://#diff-dce2c88bb6b4c136351d540a607064f184328efbe68c5b161222e1ef1c268a91L542-R556) [[3]](diffhunk://#diff-dce2c88bb6b4c136351d540a607064f184328efbe68c5b161222e1ef1c268a91R668) [[4]](diffhunk://#diff-dce2c88bb6b4c136351d540a607064f184328efbe68c5b161222e1ef1c268a91L665-R680) [[5]](diffhunk://#diff-76fcc767dc11d667475e39978d9dabf36d1ed2d3c1e3a9b06d1c20ee2c51a2bbL215-R215)
* Added a new `SshError::Cancelled` variant to signal when a connection attempt was cancelled, and updated serialization for error reporting. [[1]](diffhunk://#diff-97d15e597cf15aac852ee80833296ecf022001b3f82e5d99936ca77ddde686f6R27-R29) [[2]](diffhunk://#diff-97d15e597cf15aac852ee80833296ecf022001b3f82e5d99936ca77ddde686f6R47)

_Frontend (React/TypeScript):_

* Updated the `ConnectionDialog` component to support an `onCancel` callback, display a Cancel button while connecting, and use Escape to cancel or close as appropriate. [[1]](diffhunk://#diff-393ffe6bc25a3d7ae905ae911fdb1274a35817c3207c91e12c4222cc80d8934bR11-R25) [[2]](diffhunk://#diff-393ffe6bc25a3d7ae905ae911fdb1274a35817c3207c91e12c4222cc80d8934bR92-R99)
* Refactored connection logic in `HostsDashboard` to generate a unique `attemptId` per connect attempt, provide a cancel function that calls the backend cancel command, and clean up UI state and backend sessions if cancelled. [[1]](diffhunk://#diff-33dea691ae7b728409572101e9bcde6ee90e3488aa993cc9df5468b19b9d9ed4R27-R38) [[2]](diffhunk://#diff-33dea691ae7b728409572101e9bcde6ee90e3488aa993cc9df5468b19b9d9ed4L86-R119) [[3]](diffhunk://#diff-33dea691ae7b728409572101e9bcde6ee90e3488aa993cc9df5468b19b9d9ed4L113-R132) [[4]](diffhunk://#diff-33dea691ae7b728409572101e9bcde6ee90e3488aa993cc9df5468b19b9d9ed4L206-R240) [[5]](diffhunk://#diff-33dea691ae7b728409572101e9bcde6ee90e3488aa993cc9df5468b19b9d9ed4R253-R257) [[6]](diffhunk://#diff-33dea691ae7b728409572101e9bcde6ee90e3488aa993cc9df5468b19b9d9ed4L235-R281) [[7]](diffhunk://#diff-33dea691ae7b728409572101e9bcde6ee90e3488aa993cc9df5468b19b9d9ed4R294-R298)

These changes ensure that users can abort SSH connection attempts responsively, and the backend will not leave any partial or ghost sessions if a connection is cancelled.