### PR TITLE
Unify Delete UX: Add Consistent Confirmation Dialogs Across Pages and Introduce Per-Entry Delete in History

### DIFF
--- a/src-tauri/src/db/commands.rs
+++ b/src-tauri/src/db/commands.rs
@@ -150,6 +150,18 @@ pub async fn list_connection_history(
         .map_err(|e| DbError::InitError(format!("task panicked: {e}")))?
 }
 
+#[tauri::command]
+#[instrument(skip(state), fields(id = %id))]
+pub async fn delete_connection_history_entry(
+    id: i64,
+    state: State<'_, Arc<HostDb>>,
+) -> Result<(), DbError> {
+    let db = Arc::clone(&state);
+    task::spawn_blocking(move || db.delete_connection_history_entry(id))
+        .await
+        .map_err(|e| DbError::InitError(format!("task panicked: {e}")))?
+}
+
 // ─── App Settings ─────────────────────────────────────────────────────────────
 
 #[tauri::command]

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -919,6 +919,20 @@ impl HostDb {
         }
     }
 
+    /// Permanently delete a single connection history row by its integer id.
+    #[instrument(skip(self), fields(id = %id))]
+    pub fn delete_connection_history_entry(&self, id: i64) -> Result<(), DbError> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| DbError::InitError(format!("db lock poisoned: {e}")))?;
+        let affected = conn.execute("DELETE FROM connection_history WHERE id = ?1", params![id])?;
+        if affected == 0 {
+            return Err(DbError::NotFound(id.to_string()));
+        }
+        Ok(())
+    }
+
     fn map_history_row(row: &rusqlite::Row) -> rusqlite::Result<ConnectionHistoryEntry> {
         Ok(ConnectionHistoryEntry {
             id: row.get(0)?,

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -16,7 +16,7 @@ pub enum DbError {
     #[error("Database error: {0}")]
     Sqlite(#[from] rusqlite::Error),
 
-    #[error("Host not found: {0}")]
+    #[error("Not found: {0}")]
     NotFound(String),
 
     #[error("Failed to initialize database: {0}")]
@@ -2400,6 +2400,35 @@ mod tests {
             .query_row("SELECT COUNT(*) FROM connection_history", [], |r| r.get(0))
             .expect("count");
         assert_eq!(count, 0, "history should be empty after host deletion");
+    }
+
+    #[test]
+    fn delete_history_entry_removes_single_row() {
+        let (db, _dir) = test_db();
+        let h = sample_host("history-del-host");
+        db.save_host(&h).expect("save_host");
+        db.record_connection("history-del-host").expect("record 1");
+        db.record_connection("history-del-host").expect("record 2");
+
+        let entries = db.list_connection_history(None, 10, 0).expect("list");
+        assert_eq!(entries.len(), 2);
+
+        let target_id = entries[0].id;
+        db.delete_connection_history_entry(target_id)
+            .expect("delete should succeed");
+
+        let remaining = db.list_connection_history(None, 10, 0).expect("list after");
+        assert_eq!(remaining.len(), 1);
+        assert!(remaining.iter().all(|e| e.id != target_id));
+    }
+
+    #[test]
+    fn delete_history_entry_returns_not_found_for_missing_id() {
+        let (db, _dir) = test_db();
+        let err = db
+            .delete_connection_history_entry(99999)
+            .expect_err("should fail for unknown id");
+        assert!(matches!(err, DbError::NotFound(_)));
     }
 
     // -----------------------------------------------------------------------

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -248,6 +248,7 @@ pub fn run() {
             db::commands::list_recent_connections,
             // Connection history (full audit)
             db::commands::list_connection_history,
+            db::commands::delete_connection_history_entry,
             // App settings
             db::commands::save_setting,
             db::commands::load_all_settings,

--- a/src/components/dashboard/GroupDeleteDialog.tsx
+++ b/src/components/dashboard/GroupDeleteDialog.tsx
@@ -92,20 +92,20 @@ export function GroupDeleteDialog({
         </div>
 
         {/* Footer */}
-        <div className="px-6 pb-5 pt-3 flex items-center justify-end gap-2 border-t border-border shrink-0">
+        <div className="px-6 py-3 flex items-center justify-end gap-2 border-t border-border shrink-0">
           <button
             // eslint-disable-next-line jsx-a11y/no-autofocus
             autoFocus
             type="button"
             onClick={onCancel}
-            className="px-4 py-2 text-[length:var(--text-sm)] font-medium text-text-secondary hover:text-text-primary rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            className="px-4 py-1.5 text-[length:var(--text-sm)] font-medium text-text-secondary hover:text-text-primary rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
             Cancel
           </button>
           <button
             type="button"
             onClick={() => onConfirm(deleteHosts)}
-            className="px-4 py-2 text-[length:var(--text-sm)] font-medium text-text-inverse bg-status-error hover:opacity-90 active:opacity-80 rounded-lg transition-opacity duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            className="px-4 py-1.5 text-[length:var(--text-sm)] font-medium text-text-inverse bg-status-error hover:opacity-90 active:opacity-80 rounded-lg transition-opacity duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
             {confirmLabel}
           </button>

--- a/src/components/dashboard/GroupDeleteDialog.tsx
+++ b/src/components/dashboard/GroupDeleteDialog.tsx
@@ -1,6 +1,7 @@
-import { useState, useEffect, useId } from "react";
-import { AlertTriangle, X } from "lucide-react";
+import { useState, useId } from "react";
+import { AlertTriangle } from "lucide-react";
 import type { HostGroup } from "../../types";
+import { ModalShell, BTN_GHOST, BTN_DANGER } from "../shared/ModalShell";
 
 interface GroupDeleteDialogProps {
   group: HostGroup;
@@ -16,101 +17,59 @@ export function GroupDeleteDialog({
   onCancel,
 }: GroupDeleteDialogProps) {
   const [deleteHosts, setDeleteHosts] = useState(false);
-  const titleId = useId();
-
-  useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
-      if (e.key === "Escape") { e.stopPropagation(); onCancel(); }
-    };
-    document.addEventListener("keydown", handler, true);
-    return () => document.removeEventListener("keydown", handler, true);
-  }, [onCancel]);
+  const checkboxId = useId();
 
   const confirmLabel =
     hostCount > 0 && deleteHosts ? "Delete Group & Hosts" : "Delete Group";
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-start justify-center pt-[8vh] bg-black/50 backdrop-blur-sm"
-      onClick={(e) => e.target === e.currentTarget && onCancel()}
-    >
-      <div
-        aria-modal="true"
-        role="dialog"
-        aria-labelledby={titleId}
-        className="w-full max-w-sm rounded-xl bg-bg-overlay border border-border shadow-[var(--shadow-lg)] flex flex-col animate-in fade-in slide-in-from-top-2 duration-[var(--duration-base)]"
-      >
-        {/* Header */}
-        <div className="flex items-center justify-between px-6 pt-5 pb-4 border-b border-border shrink-0">
-          <div className="flex items-center gap-2.5">
-            <div className="flex items-center justify-center w-7 h-7 rounded-md shrink-0 bg-status-error/10">
-              <AlertTriangle size={15} strokeWidth={1.8} className="text-status-error" aria-hidden="true" />
-            </div>
-            <h2 id={titleId} className="text-[length:var(--text-lg)] font-semibold text-text-primary">
-              Delete &ldquo;{group.name}&rdquo;?
-            </h2>
-          </div>
-          <button
-            type="button"
-            onClick={onCancel}
-            aria-label="Close"
-            className="p-1.5 rounded-md text-text-muted hover:text-text-primary hover:bg-bg-subtle transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-          >
-            <X size={14} strokeWidth={1.8} aria-hidden="true" />
-          </button>
-        </div>
-
-        {/* Body */}
-        <div className="px-6 py-4 flex flex-col gap-3">
-          <p className="text-[length:var(--text-sm)] text-text-secondary">
-            {hostCount === 0
-              ? "This empty group will be permanently removed."
-              : `This group contains ${hostCount} ${hostCount === 1 ? "host" : "hosts"}.`}
-          </p>
-
-          {/* Checkbox — only shown when the group has hosts */}
-          {hostCount > 0 && (
-            <label className={[
-              "flex items-start gap-2.5 cursor-pointer rounded-lg px-3 py-2.5",
-              "bg-bg-subtle border border-border",
-              "hover:border-border-focus transition-colors duration-[var(--duration-fast)]",
-            ].join(" ")}>
-              <input
-                type="checkbox"
-                checked={deleteHosts}
-                onChange={(e) => setDeleteHosts(e.target.checked)}
-                className="mt-0.5 h-3.5 w-3.5 rounded shrink-0 cursor-pointer accent-[oklch(0.650_0.200_25)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-              />
-              <span className="text-[length:var(--text-xs)] text-text-secondary leading-snug select-none">
-                Also delete all {hostCount} {hostCount === 1 ? "host" : "hosts"} in this group
-                <span className="block text-text-muted mt-0.5">
-                  Unchecked: hosts will be moved out of the group
-                </span>
-              </span>
-            </label>
-          )}
-        </div>
-
-        {/* Footer */}
-        <div className="px-6 py-3 flex items-center justify-end gap-2 border-t border-border shrink-0">
-          <button
-            // eslint-disable-next-line jsx-a11y/no-autofocus
-            autoFocus
-            type="button"
-            onClick={onCancel}
-            className="px-4 py-1.5 text-[length:var(--text-sm)] font-medium text-text-secondary hover:text-text-primary rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-          >
+    <ModalShell
+      open
+      onClose={onCancel}
+      title={`Delete "${group.name}"?`}
+      icon={AlertTriangle}
+      iconVariant="danger"
+      maxWidth="sm"
+      footer={
+        <>
+          {/* eslint-disable-next-line jsx-a11y/no-autofocus */}
+          <button autoFocus type="button" onClick={onCancel} className={BTN_GHOST}>
             Cancel
           </button>
-          <button
-            type="button"
-            onClick={() => onConfirm(deleteHosts)}
-            className="px-4 py-1.5 text-[length:var(--text-sm)] font-medium text-text-inverse bg-status-error hover:opacity-90 active:opacity-80 rounded-lg transition-opacity duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-          >
+          <button type="button" onClick={() => onConfirm(deleteHosts)} className={BTN_DANGER}>
             {confirmLabel}
           </button>
-        </div>
+        </>
+      }
+    >
+      <div className="flex flex-col gap-3">
+        <p className="text-[length:var(--text-sm)] text-text-secondary">
+          {hostCount === 0
+            ? "This empty group will be permanently removed."
+            : `This group contains ${hostCount} ${hostCount === 1 ? "host" : "hosts"}.`}
+        </p>
+
+        {hostCount > 0 && (
+          <label
+            htmlFor={checkboxId}
+            className="flex items-start gap-2.5 cursor-pointer rounded-lg px-3 py-2.5 bg-bg-subtle border border-border hover:border-border-focus transition-colors duration-[var(--duration-fast)]"
+          >
+            <input
+              id={checkboxId}
+              type="checkbox"
+              checked={deleteHosts}
+              onChange={(e) => setDeleteHosts(e.target.checked)}
+              className="mt-0.5 h-3.5 w-3.5 rounded shrink-0 cursor-pointer accent-[oklch(0.650_0.200_25)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            />
+            <span className="text-[length:var(--text-xs)] text-text-secondary leading-snug select-none">
+              Also delete all {hostCount} {hostCount === 1 ? "host" : "hosts"} in this group
+              <span className="block text-text-muted mt-0.5">
+                Unchecked: hosts will be moved out of the group
+              </span>
+            </span>
+          </label>
+        )}
       </div>
-    </div>
+    </ModalShell>
   );
 }

--- a/src/components/dashboard/GroupDeleteDialog.tsx
+++ b/src/components/dashboard/GroupDeleteDialog.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect, useRef } from "react";
-import { AlertTriangle } from "lucide-react";
+import { useState, useEffect, useId } from "react";
+import { AlertTriangle, X } from "lucide-react";
 import type { HostGroup } from "../../types";
 
 interface GroupDeleteDialogProps {
@@ -16,135 +16,96 @@ export function GroupDeleteDialog({
   onCancel,
 }: GroupDeleteDialogProps) {
   const [deleteHosts, setDeleteHosts] = useState(false);
-  const cancelRef = useRef<HTMLButtonElement>(null);
+  const titleId = useId();
 
-  // Focus the Cancel button on mount for safe default
   useEffect(() => {
-    cancelRef.current?.focus();
-  }, []);
-
-  // Close on Escape
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        e.stopPropagation();
-        onCancel();
-      }
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") { e.stopPropagation(); onCancel(); }
     };
-    document.addEventListener("keydown", handleKeyDown, true);
-    return () => document.removeEventListener("keydown", handleKeyDown, true);
+    document.addEventListener("keydown", handler, true);
+    return () => document.removeEventListener("keydown", handler, true);
   }, [onCancel]);
 
   const confirmLabel =
     hostCount > 0 && deleteHosts ? "Delete Group & Hosts" : "Delete Group";
 
   return (
-    /* Backdrop */
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center"
-      aria-modal="true"
-      role="dialog"
-      aria-labelledby="group-delete-title"
-      aria-describedby="group-delete-desc"
+      className="fixed inset-0 z-50 flex items-start justify-center pt-[8vh] bg-black/50 backdrop-blur-sm"
+      onClick={(e) => e.target === e.currentTarget && onCancel()}
     >
-      {/* Blur overlay */}
       <div
-        className="absolute inset-0 bg-bg-base/70 backdrop-blur-sm"
-        onClick={onCancel}
-        aria-hidden="true"
-      />
-
-      {/* Panel */}
-      <div
-        className={[
-          "relative z-10 w-full max-w-sm mx-4 p-6 rounded-xl",
-          "bg-bg-surface border border-border",
-          "shadow-[var(--shadow-lg)]",
-        ].join(" ")}
+        aria-modal="true"
+        role="dialog"
+        aria-labelledby={titleId}
+        className="w-full max-w-sm rounded-xl bg-bg-overlay border border-border shadow-[var(--shadow-lg)] flex flex-col animate-in fade-in slide-in-from-top-2 duration-[var(--duration-base)]"
       >
         {/* Header */}
-        <div className="flex items-start gap-3 mb-4">
-          <div
-            className="flex items-center justify-center w-9 h-9 rounded-lg shrink-0"
-            style={{ backgroundColor: "oklch(0.650 0.200 25 / 0.12)" }}
-          >
-            <AlertTriangle
-              size={19}
-              strokeWidth={1.8}
-              className="text-status-error"
-              aria-hidden="true"
-            />
-          </div>
-          <div>
-            <h2
-              id="group-delete-title"
-              className="text-[length:var(--text-sm)] font-semibold text-text-primary leading-snug"
-            >
-              Delete &ldquo;{group.name}&rdquo; group?
+        <div className="flex items-center justify-between px-6 pt-5 pb-4 border-b border-border shrink-0">
+          <div className="flex items-center gap-2.5">
+            <div className="flex items-center justify-center w-7 h-7 rounded-md shrink-0 bg-status-error/10">
+              <AlertTriangle size={15} strokeWidth={1.8} className="text-status-error" aria-hidden="true" />
+            </div>
+            <h2 id={titleId} className="text-[length:var(--text-lg)] font-semibold text-text-primary">
+              Delete &ldquo;{group.name}&rdquo;?
             </h2>
-            <p
-              id="group-delete-desc"
-              className="text-[length:var(--text-xs)] text-text-muted mt-0.5"
-            >
-              {hostCount === 0
-                ? "Delete this empty group?"
-                : `This group contains ${hostCount} ${hostCount === 1 ? "host" : "hosts"}.`}
-            </p>
           </div>
+          <button
+            type="button"
+            onClick={onCancel}
+            aria-label="Close"
+            className="p-1.5 rounded-md text-text-muted hover:text-text-primary hover:bg-bg-subtle transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <X size={14} strokeWidth={1.8} aria-hidden="true" />
+          </button>
         </div>
 
-        {/* Checkbox — only shown when the group has hosts */}
-        {hostCount > 0 && (
-          <label
-            className={[
-              "flex items-start gap-2.5 mb-5 cursor-pointer rounded-lg px-3 py-2.5",
-              "bg-bg-overlay border border-border",
-              "hover:border-border-focus transition-colors duration-[var(--duration-fast)]",
-            ].join(" ")}
-          >
-            <input
-              type="checkbox"
-              checked={deleteHosts}
-              onChange={(e) => setDeleteHosts(e.target.checked)}
-              className={[
-                "mt-0.5 h-3.5 w-3.5 rounded shrink-0 cursor-pointer",
-                "accent-[oklch(0.650_0.200_25)]",
-                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-              ].join(" ")}
-            />
-            <span className="text-[length:var(--text-xs)] text-text-secondary leading-snug select-none">
-              Also delete all {hostCount} {hostCount === 1 ? "host" : "hosts"} in this group
-              <span className="block text-text-muted mt-0.5">
-                Unchecked: hosts will be moved out of the group
-              </span>
-            </span>
-          </label>
-        )}
+        {/* Body */}
+        <div className="px-6 py-4 flex flex-col gap-3">
+          <p className="text-[length:var(--text-sm)] text-text-secondary">
+            {hostCount === 0
+              ? "This empty group will be permanently removed."
+              : `This group contains ${hostCount} ${hostCount === 1 ? "host" : "hosts"}.`}
+          </p>
 
-        {/* Actions */}
-        <div className="flex gap-2 justify-end">
+          {/* Checkbox — only shown when the group has hosts */}
+          {hostCount > 0 && (
+            <label className={[
+              "flex items-start gap-2.5 cursor-pointer rounded-lg px-3 py-2.5",
+              "bg-bg-subtle border border-border",
+              "hover:border-border-focus transition-colors duration-[var(--duration-fast)]",
+            ].join(" ")}>
+              <input
+                type="checkbox"
+                checked={deleteHosts}
+                onChange={(e) => setDeleteHosts(e.target.checked)}
+                className="mt-0.5 h-3.5 w-3.5 rounded shrink-0 cursor-pointer accent-[oklch(0.650_0.200_25)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              />
+              <span className="text-[length:var(--text-xs)] text-text-secondary leading-snug select-none">
+                Also delete all {hostCount} {hostCount === 1 ? "host" : "hosts"} in this group
+                <span className="block text-text-muted mt-0.5">
+                  Unchecked: hosts will be moved out of the group
+                </span>
+              </span>
+            </label>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="px-6 pb-5 pt-3 flex items-center justify-end gap-2 border-t border-border shrink-0">
           <button
-            ref={cancelRef}
+            // eslint-disable-next-line jsx-a11y/no-autofocus
+            autoFocus
+            type="button"
             onClick={onCancel}
-            className={[
-              "px-4 py-1.5 rounded-lg text-[length:var(--text-sm)] font-medium",
-              "text-text-secondary bg-bg-overlay border border-border",
-              "hover:text-text-primary hover:border-border-focus hover:bg-bg-subtle",
-              "transition-all duration-[var(--duration-fast)]",
-              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-            ].join(" ")}
+            className="px-4 py-2 text-[length:var(--text-sm)] font-medium text-text-secondary hover:text-text-primary rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
             Cancel
           </button>
           <button
+            type="button"
             onClick={() => onConfirm(deleteHosts)}
-            className={[
-              "px-4 py-1.5 rounded-lg text-[length:var(--text-sm)] font-medium",
-              "bg-status-error text-text-inverse",
-              "hover:opacity-90 active:opacity-80",
-              "transition-opacity duration-[var(--duration-fast)]",
-              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-            ].join(" ")}
+            className="px-4 py-2 text-[length:var(--text-sm)] font-medium text-text-inverse bg-status-error hover:opacity-90 active:opacity-80 rounded-lg transition-opacity duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
             {confirmLabel}
           </button>

--- a/src/components/dashboard/GroupModal.tsx
+++ b/src/components/dashboard/GroupModal.tsx
@@ -110,14 +110,7 @@ export function GroupModal({ open, onClose, onSave, initial }: GroupModalProps) 
       open={open}
       onClose={onClose}
       title={isEdit ? "Edit Group" : "New Group"}
-      iconNode={
-        <div
-          className="flex items-center justify-center w-8 h-8 rounded-lg shrink-0"
-          style={{ backgroundColor: `${color}20` }}
-        >
-          <SelectedIcon size={16} strokeWidth={1.8} style={{ color }} aria-hidden="true" />
-        </div>
-      }
+      icon={SelectedIcon}
       maxWidth="sm"
       busy={saving}
       testId="group-modal"

--- a/src/components/dashboard/GroupModal.tsx
+++ b/src/components/dashboard/GroupModal.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef, useCallback } from "react";
 import {
   Folder, Cloud, Server, Database, Globe, Shield, Code,
   Wifi, Home, Building2, Rocket, Wrench, Monitor, Lock,
-  Zap, Cpu, HardDrive, Network, Radio, Warehouse,
+  Zap, Cpu, HardDrive, Network, Radio, Warehouse, X,
 } from "lucide-react";
 import { HOST_COLORS } from "./HostCard";
 
@@ -132,34 +132,47 @@ export function GroupModal({ open, onClose, onSave, initial }: GroupModalProps) 
     <div
       ref={backdropRef}
       onClick={handleBackdropClick}
-      className={`
-        fixed inset-0 z-50 flex items-start justify-center pt-[12vh]
-        transition-[background-color,backdrop-filter] duration-[var(--duration-base)]
-        ${visible ? "bg-black/50 backdrop-blur-sm" : "bg-black/0 backdrop-blur-none"}
-      `}
+      className={[
+        "fixed inset-0 z-50 flex items-start justify-center pt-[8vh]",
+        "transition-[background-color,backdrop-filter] duration-[var(--duration-base)]",
+        visible ? "bg-black/50 backdrop-blur-sm" : "bg-black/0 backdrop-blur-none",
+      ].join(" ")}
     >
-      <div
+      <form
         data-testid="group-modal"
-        className={`
-          w-full max-w-sm rounded-xl bg-bg-overlay border border-border p-6 shadow-[var(--shadow-lg)]
-          transition-[opacity,transform] duration-[var(--duration-slow)] ease-[var(--ease-expo-out)]
-          ${visible ? "opacity-100 translate-y-0" : "opacity-0 -translate-y-3"}
-        `}
+        onSubmit={handleSubmit}
+        className={[
+          "w-full max-w-sm rounded-xl bg-bg-overlay border border-border shadow-[var(--shadow-lg)] flex flex-col",
+          "transition-[opacity,transform] duration-[var(--duration-slow)] ease-[var(--ease-expo-out)]",
+          visible ? "opacity-100 translate-y-0" : "opacity-0 -translate-y-3",
+        ].join(" ")}
       >
-        {/* Preview + Title */}
-        <div className="flex items-center gap-3 mb-5">
-          <div
-            className="flex items-center justify-center w-10 h-10 rounded-lg shrink-0"
-            style={{ backgroundColor: `${color}20` }}
-          >
-            <SelectedIcon size={22} strokeWidth={1.8} style={{ color }} />
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 pt-5 pb-4 border-b border-border shrink-0">
+          <div className="flex items-center gap-3">
+            <div
+              className="flex items-center justify-center w-8 h-8 rounded-lg shrink-0"
+              style={{ backgroundColor: `${color}20` }}
+            >
+              <SelectedIcon size={18} strokeWidth={1.8} style={{ color }} aria-hidden="true" />
+            </div>
+            <h2 className="text-[length:var(--text-lg)] font-semibold text-text-primary">
+              {isEdit ? "Edit Group" : "New Group"}
+            </h2>
           </div>
-          <h2 className="text-[length:var(--text-lg)] font-semibold text-text-primary">
-            {isEdit ? "Edit Group" : "New Group"}
-          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={saving}
+            aria-label="Close"
+            className="p-1.5 rounded-md text-text-muted hover:text-text-primary hover:bg-bg-subtle transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
+          >
+            <X size={14} strokeWidth={1.8} aria-hidden="true" />
+          </button>
         </div>
 
-        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+        {/* Body */}
+        <div className="px-6 py-5 flex flex-col gap-4">
           {/* Name */}
           <div>
             <label className={labelClass}>
@@ -245,28 +258,28 @@ export function GroupModal({ open, onClose, onSave, initial }: GroupModalProps) 
               {error}
             </p>
           )}
+        </div>
 
-          {/* Actions */}
-          <div className="flex justify-end gap-2 mt-1">
-            <button
-              type="button"
-              onClick={onClose}
-              disabled={saving}
-              className="px-4 py-2 text-[length:var(--text-sm)] text-text-secondary hover:text-text-primary rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-            >
-              Cancel
-            </button>
-            <button
-              type="submit"
-              data-testid="group-modal-save"
-              disabled={saving || !name.trim()}
-              className="px-4 py-2 text-[length:var(--text-sm)] font-medium text-text-inverse bg-accent hover:bg-accent-hover disabled:opacity-50 rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-bg-overlay"
-            >
-              {saving ? "Saving\u2026" : isEdit ? "Save" : "Create Group"}
-            </button>
-          </div>
-        </form>
-      </div>
+        {/* Footer */}
+        <div className="px-6 py-3 flex items-center justify-end gap-2 border-t border-border shrink-0">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={saving}
+            className="px-4 py-1.5 text-[length:var(--text-sm)] font-medium text-text-secondary hover:text-text-primary rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            data-testid="group-modal-save"
+            disabled={saving || !name.trim()}
+            className="px-4 py-1.5 text-[length:var(--text-sm)] font-medium text-text-inverse bg-accent hover:bg-accent-hover disabled:opacity-50 rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-bg-overlay"
+          >
+            {saving ? "Saving\u2026" : isEdit ? "Save" : "Create Group"}
+          </button>
+        </div>
+      </form>
     </div>
   );
 }

--- a/src/components/dashboard/GroupModal.tsx
+++ b/src/components/dashboard/GroupModal.tsx
@@ -2,9 +2,10 @@ import { useState, useEffect, useRef, useCallback } from "react";
 import {
   Folder, Cloud, Server, Database, Globe, Shield, Code,
   Wifi, Home, Building2, Rocket, Wrench, Monitor, Lock,
-  Zap, Cpu, HardDrive, Network, Radio, Warehouse, X,
+  Zap, Cpu, HardDrive, Network, Radio, Warehouse,
 } from "lucide-react";
 import { HOST_COLORS } from "./HostCard";
+import { ModalShell, BTN_GHOST, BTN_PRIMARY } from "../shared/ModalShell";
 
 // ─── Icon registry ───────────────────────────────────────────────────────────
 
@@ -61,11 +62,7 @@ export function GroupModal({ open, onClose, onSave, initial }: GroupModalProps) 
   const [icon, setIcon] = useState("Folder");
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
-  const [visible, setVisible] = useState(false);
-
-  const backdropRef = useRef<HTMLDivElement>(null);
   const nameRef = useRef<HTMLInputElement>(null);
-
   const isEdit = !!initial;
 
   useEffect(() => {
@@ -75,28 +72,10 @@ export function GroupModal({ open, onClose, onSave, initial }: GroupModalProps) 
       setIcon(initial?.icon ?? "Folder");
       setError(null);
       setSaving(false);
-      requestAnimationFrame(() => setVisible(true));
-    } else {
-      setVisible(false);
+      // Focus the name field once the modal is open
+      requestAnimationFrame(() => nameRef.current?.focus());
     }
   }, [open, initial]);
-
-  useEffect(() => {
-    if (visible) requestAnimationFrame(() => nameRef.current?.focus());
-  }, [visible]);
-
-  useEffect(() => {
-    if (!open) return;
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-    };
-    document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [open, onClose]);
-
-  const handleBackdropClick = (e: React.MouseEvent) => {
-    if (e.target === backdropRef.current) onClose();
-  };
 
   const handleSubmit = useCallback(async (e: React.FormEvent) => {
     e.preventDefault();
@@ -115,7 +94,7 @@ export function GroupModal({ open, onClose, onSave, initial }: GroupModalProps) 
     }
   }, [name, color, icon, onSave]);
 
-  if (!open) return null;
+  const SelectedIcon = resolveGroupIcon(icon);
 
   const inputClass = [
     "w-full rounded-lg bg-bg-base border border-border px-3 py-2",
@@ -126,160 +105,118 @@ export function GroupModal({ open, onClose, onSave, initial }: GroupModalProps) 
 
   const labelClass = "block text-[length:var(--text-xs)] font-medium text-text-secondary mb-1.5";
 
-  const SelectedIcon = resolveGroupIcon(icon);
-
   return (
-    <div
-      ref={backdropRef}
-      onClick={handleBackdropClick}
-      className={[
-        "fixed inset-0 z-50 flex items-start justify-center pt-[8vh]",
-        "transition-[background-color,backdrop-filter] duration-[var(--duration-base)]",
-        visible ? "bg-black/50 backdrop-blur-sm" : "bg-black/0 backdrop-blur-none",
-      ].join(" ")}
-    >
-      <form
-        data-testid="group-modal"
-        onSubmit={handleSubmit}
-        className={[
-          "w-full max-w-sm rounded-xl bg-bg-overlay border border-border shadow-[var(--shadow-lg)] flex flex-col",
-          "transition-[opacity,transform] duration-[var(--duration-slow)] ease-[var(--ease-expo-out)]",
-          visible ? "opacity-100 translate-y-0" : "opacity-0 -translate-y-3",
-        ].join(" ")}
-      >
-        {/* Header */}
-        <div className="flex items-center justify-between px-6 pt-5 pb-4 border-b border-border shrink-0">
-          <div className="flex items-center gap-3">
-            <div
-              className="flex items-center justify-center w-8 h-8 rounded-lg shrink-0"
-              style={{ backgroundColor: `${color}20` }}
-            >
-              <SelectedIcon size={18} strokeWidth={1.8} style={{ color }} aria-hidden="true" />
-            </div>
-            <h2 className="text-[length:var(--text-lg)] font-semibold text-text-primary">
-              {isEdit ? "Edit Group" : "New Group"}
-            </h2>
-          </div>
-          <button
-            type="button"
-            onClick={onClose}
-            disabled={saving}
-            aria-label="Close"
-            className="p-1.5 rounded-md text-text-muted hover:text-text-primary hover:bg-bg-subtle transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
-          >
-            <X size={14} strokeWidth={1.8} aria-hidden="true" />
-          </button>
+    <ModalShell
+      open={open}
+      onClose={onClose}
+      title={isEdit ? "Edit Group" : "New Group"}
+      iconNode={
+        <div
+          className="flex items-center justify-center w-8 h-8 rounded-lg shrink-0"
+          style={{ backgroundColor: `${color}20` }}
+        >
+          <SelectedIcon size={16} strokeWidth={1.8} style={{ color }} aria-hidden="true" />
         </div>
-
-        {/* Body */}
-        <div className="px-6 py-5 flex flex-col gap-4">
-          {/* Name */}
-          <div>
-            <label className={labelClass}>
-              Name <span className="text-status-error">*</span>
-            </label>
-            <input
-              ref={nameRef}
-              data-testid="group-modal-name"
-              type="text"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              placeholder="e.g., Production, Staging, Home Lab"
-              disabled={saving}
-              className={inputClass}
-            />
-          </div>
-
-          {/* Icon picker */}
-          <div>
-            <span className={labelClass}>Icon</span>
-            <div className="grid grid-cols-10 gap-1">
-              {GROUP_ICONS.map((item) => {
-                const Icon = item.icon;
-                const isSelected = icon === item.name;
-                return (
-                  <button
-                    key={item.name}
-                    type="button"
-                    onClick={() => setIcon(item.name)}
-                    disabled={saving}
-                    title={item.name}
-                    aria-label={item.name}
-                    aria-pressed={isSelected}
-                    className={[
-                      "flex items-center justify-center w-8 h-8 rounded-lg",
-                      "transition-all duration-[var(--duration-fast)]",
-                      "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-                      isSelected
-                        ? "bg-accent/15 ring-1 ring-accent"
-                        : "hover:bg-bg-subtle text-text-muted hover:text-text-secondary",
-                    ].join(" ")}
-                  >
-                    <Icon
-                      size={16}
-                      strokeWidth={isSelected ? 2 : 1.6}
-                      style={isSelected ? { color } : undefined}
-                    />
-                  </button>
-                );
-              })}
-            </div>
-          </div>
-
-          {/* Color */}
-          <div>
-            <span className={labelClass}>Color</span>
-            <div className="flex items-center gap-2 flex-wrap">
-              {HOST_COLORS.map((c) => (
-                <button
-                  key={c}
-                  type="button"
-                  onClick={() => setColor(c)}
-                  disabled={saving}
-                  aria-label={`Color ${c}`}
-                  aria-pressed={color === c}
-                  className={[
-                    "w-7 h-7 rounded-full border-2",
-                    "transition-[border-color,box-shadow,transform] duration-[var(--duration-fast)]",
-                    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-bg-overlay",
-                    color === c
-                      ? "border-white ring-2 ring-ring scale-110"
-                      : "border-transparent hover:border-white/60 hover:scale-105",
-                  ].join(" ")}
-                  style={{ backgroundColor: c }}
-                />
-              ))}
-            </div>
-          </div>
-
-          {/* Error */}
-          {error && (
-            <p className="text-[length:var(--text-sm)] text-status-error bg-status-error/10 rounded-lg px-3 py-2" role="alert">
-              {error}
-            </p>
-          )}
-        </div>
-
-        {/* Footer */}
-        <div className="px-6 py-3 flex items-center justify-end gap-2 border-t border-border shrink-0">
-          <button
-            type="button"
-            onClick={onClose}
-            disabled={saving}
-            className="px-4 py-1.5 text-[length:var(--text-sm)] font-medium text-text-secondary hover:text-text-primary rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
-          >
+      }
+      maxWidth="sm"
+      busy={saving}
+      testId="group-modal"
+      footer={
+        <>
+          <button type="button" onClick={onClose} disabled={saving} className={BTN_GHOST}>
             Cancel
           </button>
           <button
+            form="group-modal-form"
             type="submit"
             data-testid="group-modal-save"
             disabled={saving || !name.trim()}
-            className="px-4 py-1.5 text-[length:var(--text-sm)] font-medium text-text-inverse bg-accent hover:bg-accent-hover disabled:opacity-50 rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-bg-overlay"
+            className={BTN_PRIMARY}
           >
-            {saving ? "Saving\u2026" : isEdit ? "Save" : "Create Group"}
+            {saving ? "Saving…" : isEdit ? "Save" : "Create Group"}
           </button>
+        </>
+      }
+    >
+      <form id="group-modal-form" onSubmit={handleSubmit} className="flex flex-col gap-4">
+        <div>
+          <label className={labelClass}>
+            Name <span className="text-status-error">*</span>
+          </label>
+          <input
+            ref={nameRef}
+            data-testid="group-modal-name"
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="e.g., Production, Staging, Home Lab"
+            disabled={saving}
+            className={inputClass}
+          />
         </div>
+
+        <div>
+          <span className={labelClass}>Icon</span>
+          <div className="grid grid-cols-10 gap-1">
+            {GROUP_ICONS.map((item) => {
+              const Icon = item.icon;
+              const isSelected = icon === item.name;
+              return (
+                <button
+                  key={item.name}
+                  type="button"
+                  onClick={() => setIcon(item.name)}
+                  disabled={saving}
+                  title={item.name}
+                  aria-label={item.name}
+                  aria-pressed={isSelected}
+                  className={[
+                    "flex items-center justify-center w-8 h-8 rounded-lg",
+                    "transition-all duration-[var(--duration-fast)]",
+                    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                    isSelected
+                      ? "bg-accent/15 ring-1 ring-accent"
+                      : "hover:bg-bg-subtle text-text-muted hover:text-text-secondary",
+                  ].join(" ")}
+                >
+                  <Icon size={16} strokeWidth={isSelected ? 2 : 1.6} style={isSelected ? { color } : undefined} />
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        <div>
+          <span className={labelClass}>Color</span>
+          <div className="flex items-center gap-2 flex-wrap">
+            {HOST_COLORS.map((c) => (
+              <button
+                key={c}
+                type="button"
+                onClick={() => setColor(c)}
+                disabled={saving}
+                aria-label={`Color ${c}`}
+                aria-pressed={color === c}
+                className={[
+                  "w-7 h-7 rounded-full border-2",
+                  "transition-[border-color,box-shadow,transform] duration-[var(--duration-fast)]",
+                  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-bg-overlay",
+                  color === c
+                    ? "border-white ring-2 ring-ring scale-110"
+                    : "border-transparent hover:border-white/60 hover:scale-105",
+                ].join(" ")}
+                style={{ backgroundColor: c }}
+              />
+            ))}
+          </div>
+        </div>
+
+        {error && (
+          <p className="text-[length:var(--text-sm)] text-status-error bg-status-error/10 rounded-lg px-3 py-2" role="alert">
+            {error}
+          </p>
+        )}
       </form>
-    </div>
+    </ModalShell>
   );
 }

--- a/src/components/dashboard/HostCard.tsx
+++ b/src/components/dashboard/HostCard.tsx
@@ -3,6 +3,7 @@ import { Activity, Pencil, TerminalSquare, Copy, Trash2, FolderOpen, Waypoints }
 import type { SavedHost } from "../../types";
 import { relativeTime } from "../../utils/time";
 import { ContextMenu } from "../shared/ContextMenu";
+import { ConfirmDangerDialog } from "../shared/ConfirmDangerDialog";
 import { useHealthStore, IDLE_HEALTH, type HealthStatus } from "../../stores/health-store";
 import { useHostsStore } from "../../stores/hosts-store";
 
@@ -72,6 +73,7 @@ export function HostCard({ host, onConnect, onExplore, onEdit, onDelete, onDupli
   const initial = displayName.charAt(0).toUpperCase();
 
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number } | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState(false);
   // Health lives in a store (keyed by host id), not local state, so a status
   // survives the dashboard unmounting when a terminal/other tab becomes active.
   const health = useHealthStore((s) => s.byHostId[host.id] ?? IDLE_HEALTH);
@@ -139,7 +141,7 @@ export function HostCard({ host, onConnect, onExplore, onEdit, onDelete, onDupli
       label: "Delete",
       icon: Trash2,
       danger: true,
-      onClick: () => onDelete(host.id),
+      onClick: () => setConfirmDelete(true),
     },
   ];
 
@@ -350,6 +352,17 @@ export function HostCard({ host, onConnect, onExplore, onEdit, onDelete, onDupli
           onClose={() => setContextMenu(null)}
         />
       )}
+
+      <ConfirmDangerDialog
+        open={confirmDelete}
+        title="Delete this host?"
+        message="This host will be permanently removed."
+        onCancel={() => setConfirmDelete(false)}
+        onConfirm={() => {
+          setConfirmDelete(false);
+          onDelete(host.id);
+        }}
+      />
     </>
   );
 }

--- a/src/components/dashboard/HostEditModal.tsx
+++ b/src/components/dashboard/HostEditModal.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect, useRef } from "react";
-import { X } from "lucide-react";
+import { X, Monitor } from "lucide-react";
 import { useUiStore } from "../../stores/ui-store";
 import { useHostsStore } from "../../stores/hosts-store";
 import { useGroupsStore } from "../../stores/groups-store";
@@ -494,9 +494,14 @@ export function HostEditModal() {
       >
         {/* ── Header ─────────────────────────────────────────────────────── */}
         <div className="flex items-center justify-between px-6 pt-5 pb-4 border-b border-border shrink-0">
-          <h2 className="text-[length:var(--text-lg)] font-semibold text-text-primary">
-            {isNewHost ? "New Host" : "Edit Host"}
-          </h2>
+          <div className="flex items-center gap-3">
+            <div className="flex items-center justify-center w-8 h-8 rounded-lg shrink-0 bg-accent/10">
+              <Monitor size={16} strokeWidth={1.8} className="text-accent" aria-hidden="true" />
+            </div>
+            <h2 className="text-[length:var(--text-lg)] font-semibold text-text-primary">
+              {isNewHost ? "New Host" : "Edit Host"}
+            </h2>
+          </div>
           <button
             type="button"
             onClick={close}

--- a/src/components/dashboard/HostEditModal.tsx
+++ b/src/components/dashboard/HostEditModal.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback, useEffect, useRef } from "react";
+import { X } from "lucide-react";
 import { useUiStore } from "../../stores/ui-store";
 import { useHostsStore } from "../../stores/hosts-store";
 import { useGroupsStore } from "../../stores/groups-store";
@@ -497,19 +498,13 @@ export function HostEditModal() {
             {isNewHost ? "New Host" : "Edit Host"}
           </h2>
           <button
+            type="button"
             onClick={close}
             disabled={isBusy}
             aria-label="Close"
-            className="p-1.5 rounded-md text-text-muted hover:text-text-primary hover:bg-bg-subtle transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            className="p-1.5 rounded-md text-text-muted hover:text-text-primary hover:bg-bg-subtle transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
           >
-            <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
-              <path
-                d="M1 1l12 12M13 1L1 13"
-                stroke="currentColor"
-                strokeWidth="1.6"
-                strokeLinecap="round"
-              />
-            </svg>
+            <X size={14} strokeWidth={1.8} aria-hidden="true" />
           </button>
         </div>
 
@@ -986,7 +981,7 @@ export function HostEditModal() {
         </div>
 
         {/* ── Footer ─────────────────────────────────────────────────────── */}
-        <div className="px-6 pb-5 pt-3 flex items-center justify-between gap-2 border-t border-border shrink-0">
+        <div className="px-6 py-3 flex items-center justify-between gap-2 border-t border-border shrink-0">
           {/* Left: Delete / delete confirmation (hidden for new hosts) */}
           <div className="flex items-center gap-2">
             {isNewHost ? (
@@ -1003,7 +998,7 @@ export function HostEditModal() {
                 data-testid="host-modal-delete"
                 onClick={() => setDeleteConfirm(true)}
                 disabled={isBusy || loadingHost}
-                className="px-3 py-2 text-[length:var(--text-sm)] text-status-error hover:bg-status-error/10 rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                className="px-3 py-1.5 text-[length:var(--text-sm)] text-status-error hover:bg-status-error/10 rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
               >
                 Delete
               </button>
@@ -1018,7 +1013,7 @@ export function HostEditModal() {
                 data-testid="host-modal-cancel"
                 onClick={close}
                 disabled={isBusy}
-                className="px-4 py-2 text-[length:var(--text-sm)] text-text-secondary hover:text-text-primary rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                className="px-4 py-1.5 text-[length:var(--text-sm)] font-medium text-text-secondary hover:text-text-primary rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
               >
                 Cancel
               </button>
@@ -1027,7 +1022,7 @@ export function HostEditModal() {
                 data-testid="host-modal-save"
                 onClick={handleSave}
                 disabled={isBusy || loadingHost}
-                className="px-4 py-2 text-[length:var(--text-sm)] font-medium text-text-secondary hover:text-text-primary bg-bg-subtle hover:bg-bg-muted disabled:opacity-50 rounded-lg border border-border transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                className="px-4 py-1.5 text-[length:var(--text-sm)] font-medium text-text-secondary hover:text-text-primary bg-bg-subtle hover:bg-bg-muted disabled:opacity-50 rounded-lg border border-border transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
               >
                 {saving ? "Saving\u2026" : "Save"}
               </button>
@@ -1036,7 +1031,7 @@ export function HostEditModal() {
                 data-testid="host-modal-connect"
                 onClick={handleConnect}
                 disabled={isBusy || loadingHost}
-                className="px-4 py-2 text-[length:var(--text-sm)] font-medium text-text-inverse bg-accent hover:bg-accent-hover disabled:opacity-50 rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-bg-overlay"
+                className="px-4 py-1.5 text-[length:var(--text-sm)] font-medium text-text-inverse bg-accent hover:bg-accent-hover disabled:opacity-50 rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-bg-overlay"
               >
                 {connecting ? "Connecting\u2026" : "Connect"}
               </button>

--- a/src/components/dashboard/HostEditModal.tsx
+++ b/src/components/dashboard/HostEditModal.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback, useEffect, useRef } from "react";
-import { X, Monitor } from "lucide-react";
+import { Monitor } from "lucide-react";
+import { ModalShell, BTN_GHOST, BTN_SECONDARY, BTN_PRIMARY } from "../shared/ModalShell";
 import { useUiStore } from "../../stores/ui-store";
 import { useHostsStore } from "../../stores/hosts-store";
 import { useGroupsStore } from "../../stores/groups-store";
@@ -130,9 +131,6 @@ export function HostEditModal() {
   // Whether "Connect through SSH tunnel" is enabled for this host.
   const [tunnelEnabled, setTunnelEnabled] = useState(false);
 
-  // Animation gate — separate from editingHostId to allow exit animation
-  const [visible, setVisible] = useState(false);
-
   // Original host snapshot (preserved for id + created_at on save)
   const [originalHost, setOriginalHost] = useState<SavedHost | null>(null);
 
@@ -149,9 +147,7 @@ export function HostEditModal() {
   /** True when the user has explicitly clicked "Clear" on the saved credential. */
   const [credCleared, setCredCleared] = useState(false);
 
-  const backdropRef = useRef<HTMLDivElement>(null);
   const firstInputRef = useRef<HTMLInputElement>(null);
-  const scrollBodyRef = useRef<HTMLDivElement>(null);
 
   const isOpen = editingHostId !== null;
 
@@ -183,7 +179,6 @@ export function HostEditModal() {
   // ── Load host data when modal opens ────────────────────────────────────────
   useEffect(() => {
     if (!isOpen || !editingHostId) {
-      setVisible(false);
       return;
     }
 
@@ -205,7 +200,6 @@ export function HostEditModal() {
     if (isNewHost) {
       // New host — no fetch needed
       setLoadingHost(false);
-      requestAnimationFrame(() => setVisible(true));
       return;
     }
 
@@ -226,41 +220,23 @@ export function HostEditModal() {
         setError(extractError(err, "Failed to load host data"));
       } finally {
         setLoadingHost(false);
-        requestAnimationFrame(() => setVisible(true));
+        requestAnimationFrame(() => firstInputRef.current?.focus());
       }
     })();
   }, [isOpen, editingHostId, isNewHost, loadGroups, loadHosts]);
 
-  // Scroll to top and focus the first field (Label) when the modal opens.
+  // Focus the first field (Label) when the modal opens.
   useEffect(() => {
-    if (visible && !loadingHost) {
-      requestAnimationFrame(() => {
-        scrollBodyRef.current?.scrollTo(0, 0);
-        firstInputRef.current?.focus();
-      });
+    if (isOpen && !loadingHost) {
+      requestAnimationFrame(() => firstInputRef.current?.focus());
     }
-  }, [visible, loadingHost]);
+  }, [isOpen, loadingHost]);
 
-  // ── Escape key ──────────────────────────────────────────────────────────────
-  useEffect(() => {
-    if (!isOpen) return;
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        if (deleteConfirm) {
-          setDeleteConfirm(false);
-        } else {
-          close();
-        }
-      }
-    };
-    document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [isOpen, deleteConfirm, close]);
-
-  // ── Backdrop click ──────────────────────────────────────────────────────────
-  const handleBackdropClick = (e: React.MouseEvent) => {
-    if (e.target === backdropRef.current) close();
-  };
+  // When deleteConfirm is active, Escape clears it rather than closing the modal.
+  const handleClose = useCallback(() => {
+    if (deleteConfirm) setDeleteConfirm(false);
+    else close();
+  }, [deleteConfirm, close]);
 
   // ── Form field updater ──────────────────────────────────────────────────────
   const setField = <K extends keyof FormState>(key: K, value: FormState[K]) => {
@@ -473,48 +449,53 @@ export function HostEditModal() {
 
 
   return (
-    <div
-      ref={backdropRef}
-      onClick={handleBackdropClick}
-      className={`
-        fixed inset-0 z-50 flex items-start justify-center pt-[8vh]
-        transition-[background-color,backdrop-filter] duration-[var(--duration-base)]
-        ${visible ? "bg-black/50 backdrop-blur-sm" : "bg-black/0 backdrop-blur-none"}
-      `}
+    <ModalShell
+      open={isOpen}
+      onClose={handleClose}
+      title={isNewHost ? "New Host" : "Edit Host"}
+      icon={Monitor}
+      maxWidth="lg"
+      scrollable
+      busy={isBusy}
+      testId="host-modal"
+      footerStart={
+        !isNewHost ? (
+          deleteConfirm ? (
+            <DeleteConfirmRow
+              onCancel={() => setDeleteConfirm(false)}
+              onConfirm={handleDeleteConfirmed}
+              busy={isBusy}
+            />
+          ) : (
+            <button
+              type="button"
+              data-testid="host-modal-delete"
+              onClick={() => setDeleteConfirm(true)}
+              disabled={isBusy || loadingHost}
+              className="px-3 py-1.5 text-[length:var(--text-sm)] font-medium text-status-error hover:bg-status-error/10 rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
+            >
+              Delete
+            </button>
+          )
+        ) : undefined
+      }
+      footer={
+        !deleteConfirm ? (
+          <>
+            <button type="button" data-testid="host-modal-cancel" onClick={close} disabled={isBusy} className={BTN_GHOST}>
+              Cancel
+            </button>
+            <button type="button" data-testid="host-modal-save" onClick={handleSave} disabled={isBusy || loadingHost} className={BTN_SECONDARY}>
+              {saving ? "Saving…" : "Save"}
+            </button>
+            <button type="button" data-testid="host-modal-connect" onClick={handleConnect} disabled={isBusy || loadingHost} className={BTN_PRIMARY}>
+              {connecting ? "Connecting…" : "Connect"}
+            </button>
+          </>
+        ) : undefined
+      }
     >
-      <div
-        data-testid="host-modal"
-        data-host-modal-mode={isNewHost ? "new" : "edit"}
-        className={`
-          w-full max-w-lg rounded-xl bg-bg-overlay border border-border shadow-[var(--shadow-lg)]
-          flex flex-col max-h-[84vh]
-          transition-[opacity,transform] duration-[var(--duration-slow)] ease-[var(--ease-expo-out)]
-          ${visible ? "opacity-100 translate-y-0" : "opacity-0 -translate-y-3"}
-        `}
-      >
-        {/* ── Header ─────────────────────────────────────────────────────── */}
-        <div className="flex items-center justify-between px-6 pt-5 pb-4 border-b border-border shrink-0">
-          <div className="flex items-center gap-3">
-            <div className="flex items-center justify-center w-8 h-8 rounded-lg shrink-0 bg-accent/10">
-              <Monitor size={16} strokeWidth={1.8} className="text-accent" aria-hidden="true" />
-            </div>
-            <h2 className="text-[length:var(--text-lg)] font-semibold text-text-primary">
-              {isNewHost ? "New Host" : "Edit Host"}
-            </h2>
-          </div>
-          <button
-            type="button"
-            onClick={close}
-            disabled={isBusy}
-            aria-label="Close"
-            className="p-1.5 rounded-md text-text-muted hover:text-text-primary hover:bg-bg-subtle transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
-          >
-            <X size={14} strokeWidth={1.8} aria-hidden="true" />
-          </button>
-        </div>
-
-        {/* ── Scrollable body ─────────────────────────────────────────────── */}
-        <div ref={scrollBodyRef} className="px-6 py-4 overflow-y-auto flex-1 min-h-0">
+      <div>
           {loadingHost ? (
             <LoadingSkeleton />
           ) : (
@@ -984,69 +965,10 @@ export function HostEditModal() {
             </div>
           )}
         </div>
-
-        {/* ── Footer ─────────────────────────────────────────────────────── */}
-        <div className="px-6 py-3 flex items-center justify-between gap-2 border-t border-border shrink-0">
-          {/* Left: Delete / delete confirmation (hidden for new hosts) */}
-          <div className="flex items-center gap-2">
-            {isNewHost ? (
-              <span />
-            ) : deleteConfirm ? (
-              <DeleteConfirmRow
-                onCancel={() => setDeleteConfirm(false)}
-                onConfirm={handleDeleteConfirmed}
-                busy={isBusy}
-              />
-            ) : (
-              <button
-                type="button"
-                data-testid="host-modal-delete"
-                onClick={() => setDeleteConfirm(true)}
-                disabled={isBusy || loadingHost}
-                className="px-3 py-1.5 text-[length:var(--text-sm)] text-status-error hover:bg-status-error/10 rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-              >
-                Delete
-              </button>
-            )}
-          </div>
-
-          {/* Right: Cancel / Save / Connect */}
-          {!deleteConfirm && (
-            <div className="flex items-center gap-2">
-              <button
-                type="button"
-                data-testid="host-modal-cancel"
-                onClick={close}
-                disabled={isBusy}
-                className="px-4 py-1.5 text-[length:var(--text-sm)] font-medium text-text-secondary hover:text-text-primary rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
-              >
-                Cancel
-              </button>
-              <button
-                type="button"
-                data-testid="host-modal-save"
-                onClick={handleSave}
-                disabled={isBusy || loadingHost}
-                className="px-4 py-1.5 text-[length:var(--text-sm)] font-medium text-text-secondary hover:text-text-primary bg-bg-subtle hover:bg-bg-muted disabled:opacity-50 rounded-lg border border-border transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-              >
-                {saving ? "Saving\u2026" : "Save"}
-              </button>
-              <button
-                type="button"
-                data-testid="host-modal-connect"
-                onClick={handleConnect}
-                disabled={isBusy || loadingHost}
-                className="px-4 py-1.5 text-[length:var(--text-sm)] font-medium text-text-inverse bg-accent hover:bg-accent-hover disabled:opacity-50 rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-bg-overlay"
-              >
-                {connecting ? "Connecting\u2026" : "Connect"}
-              </button>
-            </div>
-          )}
-        </div>
-      </div>
-    </div>
+    </ModalShell>
   );
 }
+
 
 // ─── Sub-components ────────────────────────────────────────────────────────────
 

--- a/src/components/dashboard/ImportSshConfigModal.tsx
+++ b/src/components/dashboard/ImportSshConfigModal.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { Loader2, AlertCircle, Check, FileText } from "lucide-react";
+import { ModalShell, BTN_GHOST, BTN_PRIMARY } from "../shared/ModalShell";
 import type { SshConfigEntry, ImportResult } from "../../types";
 
 interface ImportSshConfigModalProps {
@@ -126,31 +127,33 @@ export function ImportSshConfigModal({ onClose, onImported }: ImportSshConfigMod
   const importableCount = entries.filter((e) => selected.has(e.host_alias) && !e.is_pattern).length;
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-start justify-center pt-[8vh]"
-      style={{ backgroundColor: "oklch(0 0 0 / 0.5)", backdropFilter: "blur(4px)" }}
-      onClick={(e) => e.target === e.currentTarget && !importing && onClose()}
+    <ModalShell
+      open
+      onClose={onClose}
+      title="Import SSH Config"
+      maxWidth="lg"
+      scrollable
+      busy={importing}
+      footer={
+        result ? (
+          <button type="button" onClick={onClose} className={BTN_PRIMARY}>Done</button>
+        ) : (
+          <>
+            <button type="button" onClick={onClose} disabled={importing} className={BTN_GHOST}>Cancel</button>
+            <button
+              type="button"
+              data-testid="import-ssh-config-submit"
+              onClick={() => void handleImport()}
+              disabled={importing || importableCount === 0}
+              className={BTN_PRIMARY}
+            >
+              {importing ? "Importing…" : `Import ${importableCount} host${importableCount !== 1 ? "s" : ""}`}
+            </button>
+          </>
+        )
+      }
     >
-      <div className="w-full max-w-lg rounded-xl bg-bg-overlay border border-border shadow-[var(--shadow-lg)] flex flex-col max-h-[84vh] animate-[fadeIn_120ms_var(--ease-expo-out)_both]">
-        {/* Header */}
-        <div className="flex items-center justify-between px-6 pt-5 pb-4 border-b border-border shrink-0">
-          <h2 className="text-[length:var(--text-lg)] font-semibold text-text-primary">
-            Import SSH Config
-          </h2>
-          <button
-            onClick={onClose}
-            disabled={importing}
-            aria-label="Close"
-            className="p-1.5 rounded-md text-text-muted hover:text-text-primary hover:bg-bg-subtle transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-          >
-            <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
-              <path d="M1 1l12 12M13 1L1 13" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
-            </svg>
-          </button>
-        </div>
-
-        {/* Body */}
-        <div className="px-6 py-4 overflow-y-auto flex-1 min-h-0">
+        <div>
           {/* Result view */}
           {result ? (
             <div className="flex flex-col items-center gap-4 py-8">
@@ -277,37 +280,6 @@ export function ImportSshConfigModal({ onClose, onImported }: ImportSshConfigMod
             </>
           )}
         </div>
-
-        {/* Footer */}
-        <div className="px-6 pb-5 pt-3 flex items-center justify-end gap-2 border-t border-border shrink-0">
-          {result ? (
-            <button
-              onClick={onClose}
-              className="px-4 py-2 text-[length:var(--text-sm)] font-medium text-text-inverse bg-accent hover:bg-accent-hover rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-            >
-              Done
-            </button>
-          ) : (
-            <>
-              <button
-                onClick={onClose}
-                disabled={importing}
-                className="px-4 py-2 text-[length:var(--text-sm)] text-text-secondary hover:text-text-primary rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-              >
-                Cancel
-              </button>
-              <button
-                data-testid="import-ssh-config-submit"
-                onClick={() => void handleImport()}
-                disabled={importing || importableCount === 0}
-                className="px-4 py-2 text-[length:var(--text-sm)] font-medium text-text-inverse bg-accent hover:bg-accent-hover disabled:opacity-50 rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-              >
-                {importing ? "Importing..." : `Import ${importableCount} host${importableCount !== 1 ? "s" : ""}`}
-              </button>
-            </>
-          )}
-        </div>
-      </div>
-    </div>
+    </ModalShell>
   );
 }

--- a/src/components/dashboard/S3Card.tsx
+++ b/src/components/dashboard/S3Card.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Cloud, Pencil, Copy, Trash2, FolderOpen } from "lucide-react";
 import type { S3Connection } from "../../types";
 import { ContextMenu } from "../shared/ContextMenu";
+import { ConfirmDangerDialog } from "../shared/ConfirmDangerDialog";
 import { getHostColor } from "./HostCard";
 
 interface S3CardProps {
@@ -41,6 +42,7 @@ export function S3Card({ conn, onConnect, onEdit, onDuplicate, onDelete }: S3Car
   const accentColor = conn.color || getHostColor(conn.label);
 
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number } | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState(false);
 
   const subtitleParts: string[] = [conn.provider, conn.region];
   if (conn.bucket) subtitleParts.push(conn.bucket);
@@ -70,7 +72,7 @@ export function S3Card({ conn, onConnect, onEdit, onDuplicate, onDelete }: S3Car
     { label: "Explore", icon: FolderOpen, onClick: () => onConnect(conn) },
     { label: "Edit", icon: Pencil, onClick: () => onEdit(conn) },
     { label: "Duplicate", icon: Copy, onClick: () => onDuplicate(conn) },
-    { label: "Delete", icon: Trash2, danger: true, separator: true, onClick: () => onDelete(conn) },
+    { label: "Delete", icon: Trash2, danger: true, separator: true, onClick: () => setConfirmDelete(true) },
   ];
 
   return (
@@ -173,6 +175,17 @@ export function S3Card({ conn, onConnect, onEdit, onDuplicate, onDelete }: S3Car
           onClose={() => setContextMenu(null)}
         />
       )}
+
+      <ConfirmDangerDialog
+        open={confirmDelete}
+        title="Delete this S3 connection?"
+        message="This connection will be permanently removed."
+        onCancel={() => setConfirmDelete(false)}
+        onConfirm={() => {
+          setConfirmDelete(false);
+          onDelete(conn);
+        }}
+      />
     </>
   );
 }

--- a/src/components/explorer/ExplorerFileTable.tsx
+++ b/src/components/explorer/ExplorerFileTable.tsx
@@ -1133,14 +1133,14 @@ function DeleteConfirmDialog({
         </div>
 
         {/* Footer */}
-        <div className="px-6 pb-5 pt-3 flex items-center justify-end gap-2 border-t border-border shrink-0">
+        <div className="px-6 py-3 flex items-center justify-end gap-2 border-t border-border shrink-0">
           <button
             // eslint-disable-next-line jsx-a11y/no-autofocus
             autoFocus
             data-testid="explorer-delete-cancel"
             type="button"
             onClick={onCancel}
-            className="px-4 py-2 text-[length:var(--text-sm)] font-medium text-text-secondary hover:text-text-primary rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            className="px-4 py-1.5 text-[length:var(--text-sm)] font-medium text-text-secondary hover:text-text-primary rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
             Cancel
           </button>
@@ -1148,7 +1148,7 @@ function DeleteConfirmDialog({
             data-testid="explorer-delete-confirm-button"
             type="button"
             onClick={onConfirm}
-            className="px-4 py-2 text-[length:var(--text-sm)] font-medium text-text-inverse bg-status-error hover:opacity-90 rounded-lg transition-[opacity] duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            className="px-4 py-1.5 text-[length:var(--text-sm)] font-medium text-text-inverse bg-status-error hover:opacity-90 rounded-lg transition-[opacity] duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
             {confirmLabel}
           </button>

--- a/src/components/explorer/ExplorerFileTable.tsx
+++ b/src/components/explorer/ExplorerFileTable.tsx
@@ -18,8 +18,8 @@ import {
   Info,
   Link2,
   AlertTriangle,
-  X,
 } from "lucide-react";
+import { ModalShell, BTN_GHOST, BTN_DANGER } from "../shared/ModalShell";
 import type { ExplorerEntry, ExplorerClipboard, FileSystemProvider, ChmodResult } from "../../types/explorer";
 import { ContextMenu } from "../shared/ContextMenu";
 import type { ContextMenuItem } from "../shared/ContextMenu";
@@ -1053,6 +1053,7 @@ export function ExplorerFileTable({
   );
 }
 
+
 // ─── Delete confirm dialog ────────────────────────────────────────────────────
 
 function DeleteConfirmDialog({
@@ -1069,91 +1070,44 @@ function DeleteConfirmDialog({
   const entry = entries[0];
   const hasDirs = entries.some((e) => e.entryType === "Directory");
 
-  useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
-      if (e.key === "Escape") { e.stopPropagation(); onCancel(); }
-    };
-    document.addEventListener("keydown", handler, true);
-    return () => document.removeEventListener("keydown", handler, true);
-  }, [onCancel]);
-
   const title = isSingle
     ? `Delete ${entry.entryType === "Directory" ? "Directory" : "File"}`
     : `Delete ${count} items`;
 
-  const confirmLabel = isSingle ? "Delete" : `Delete ${count} items`;
-
   return (
-    <div
-      data-testid="explorer-delete-confirm"
-      className="fixed inset-0 z-50 flex items-start justify-center pt-[8vh] bg-black/50 backdrop-blur-sm"
-      onClick={(e) => e.target === e.currentTarget && onCancel()}
-    >
-      <div
-        aria-modal="true"
-        role="dialog"
-        aria-labelledby="explorer-delete-title"
-        className="w-full max-w-sm rounded-xl bg-bg-overlay border border-border shadow-[var(--shadow-lg)] flex flex-col animate-in fade-in slide-in-from-top-2 duration-[var(--duration-base)]"
-      >
-        {/* Header */}
-        <div className="flex items-center justify-between px-6 pt-5 pb-4 border-b border-border shrink-0">
-          <div className="flex items-center gap-2.5">
-            <div className="flex items-center justify-center w-7 h-7 rounded-md shrink-0 bg-status-error/10">
-              <AlertTriangle size={15} strokeWidth={1.8} className="text-status-error" aria-hidden="true" />
-            </div>
-            <h2 id="explorer-delete-title" className="text-[length:var(--text-lg)] font-semibold text-text-primary">
-              {title}
-            </h2>
-          </div>
-          <button
-            type="button"
-            onClick={onCancel}
-            aria-label="Close"
-            className="p-1.5 rounded-md text-text-muted hover:text-text-primary hover:bg-bg-subtle transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-          >
-            <X size={14} strokeWidth={1.8} aria-hidden="true" />
-          </button>
-        </div>
-
-        {/* Body */}
-        <div className="px-6 py-4">
-          <p className="text-[length:var(--text-sm)] text-text-secondary">
-            {isSingle ? (
-              <>
-                <span className="font-mono text-text-primary">{entry.name}</span> will be permanently deleted.
-                {entry.entryType === "Directory" && <> All contents inside will also be removed.</>}
-              </>
-            ) : (
-              <>
-                {count} items will be permanently deleted.
-                {hasDirs && <> Directories and all their contents will be removed.</>}
-              </>
-            )}
-          </p>
-        </div>
-
-        {/* Footer */}
-        <div className="px-6 py-3 flex items-center justify-end gap-2 border-t border-border shrink-0">
-          <button
-            // eslint-disable-next-line jsx-a11y/no-autofocus
-            autoFocus
-            data-testid="explorer-delete-cancel"
-            type="button"
-            onClick={onCancel}
-            className="px-4 py-1.5 text-[length:var(--text-sm)] font-medium text-text-secondary hover:text-text-primary rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-          >
+    <ModalShell
+      open
+      onClose={onCancel}
+      title={title}
+      icon={AlertTriangle}
+      iconVariant="danger"
+      maxWidth="sm"
+      testId="explorer-delete-confirm"
+      footer={
+        <>
+          {/* eslint-disable-next-line jsx-a11y/no-autofocus */}
+          <button autoFocus data-testid="explorer-delete-cancel" type="button" onClick={onCancel} className={BTN_GHOST}>
             Cancel
           </button>
-          <button
-            data-testid="explorer-delete-confirm-button"
-            type="button"
-            onClick={onConfirm}
-            className="px-4 py-1.5 text-[length:var(--text-sm)] font-medium text-text-inverse bg-status-error hover:opacity-90 rounded-lg transition-[opacity] duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-          >
-            {confirmLabel}
+          <button data-testid="explorer-delete-confirm-button" type="button" onClick={onConfirm} className={BTN_DANGER}>
+            {isSingle ? "Delete" : `Delete ${count} items`}
           </button>
-        </div>
-      </div>
-    </div>
+        </>
+      }
+    >
+      <p className="text-[length:var(--text-sm)] text-text-secondary">
+        {isSingle ? (
+          <>
+            <span className="font-mono text-text-primary">{entry.name}</span> will be permanently deleted.
+            {entry.entryType === "Directory" && <> All contents inside will also be removed.</>}
+          </>
+        ) : (
+          <>
+            {count} items will be permanently deleted.
+            {hasDirs && <> Directories and all their contents will be removed.</>}
+          </>
+        )}
+      </p>
+    </ModalShell>
   );
 }

--- a/src/components/explorer/ExplorerFileTable.tsx
+++ b/src/components/explorer/ExplorerFileTable.tsx
@@ -17,6 +17,8 @@ import {
   ExternalLink,
   Info,
   Link2,
+  AlertTriangle,
+  X,
 } from "lucide-react";
 import type { ExplorerEntry, ExplorerClipboard, FileSystemProvider, ChmodResult } from "../../types/explorer";
 import { ContextMenu } from "../shared/ContextMenu";
@@ -1067,50 +1069,88 @@ function DeleteConfirmDialog({
   const entry = entries[0];
   const hasDirs = entries.some((e) => e.entryType === "Directory");
 
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") { e.stopPropagation(); onCancel(); }
+    };
+    document.addEventListener("keydown", handler, true);
+    return () => document.removeEventListener("keydown", handler, true);
+  }, [onCancel]);
+
+  const title = isSingle
+    ? `Delete ${entry.entryType === "Directory" ? "Directory" : "File"}`
+    : `Delete ${count} items`;
+
+  const confirmLabel = isSingle ? "Delete" : `Delete ${count} items`;
+
   return (
     <div
       data-testid="explorer-delete-confirm"
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm"
+      className="fixed inset-0 z-50 flex items-start justify-center pt-[8vh] bg-black/50 backdrop-blur-sm"
       onClick={(e) => e.target === e.currentTarget && onCancel()}
     >
-      <div className="w-full max-w-sm mx-4 rounded-xl bg-bg-overlay border border-border p-6 shadow-[var(--shadow-lg)]">
-        <h2 className="text-[length:var(--text-lg)] font-semibold text-text-primary mb-2">
-          {isSingle
-            ? `Delete ${entry.entryType === "Directory" ? "Directory" : "File"}`
-            : `Delete ${count} items`}
-        </h2>
-        <p className="text-[length:var(--text-sm)] text-text-secondary mb-6">
-          {isSingle ? (
-            <>
-              Are you sure you want to delete{" "}
-              <span className="font-mono text-text-primary">{entry.name}</span>?
-              {entry.entryType === "Directory" && (
-                <> This will delete all contents inside the directory.</>
-              )}
-            </>
-          ) : (
-            <>
-              Are you sure you want to delete {count} items?
-              {hasDirs && <> Directories and all their contents will be removed.</>}
-            </>
-          )}
-          <span className="block mt-1 text-status-error">This action cannot be undone.</span>
-        </p>
-
-        <div className="flex justify-end gap-2">
+      <div
+        aria-modal="true"
+        role="dialog"
+        aria-labelledby="explorer-delete-title"
+        className="w-full max-w-sm rounded-xl bg-bg-overlay border border-border shadow-[var(--shadow-lg)] flex flex-col animate-in fade-in slide-in-from-top-2 duration-[var(--duration-base)]"
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 pt-5 pb-4 border-b border-border shrink-0">
+          <div className="flex items-center gap-2.5">
+            <div className="flex items-center justify-center w-7 h-7 rounded-md shrink-0 bg-status-error/10">
+              <AlertTriangle size={15} strokeWidth={1.8} className="text-status-error" aria-hidden="true" />
+            </div>
+            <h2 id="explorer-delete-title" className="text-[length:var(--text-lg)] font-semibold text-text-primary">
+              {title}
+            </h2>
+          </div>
           <button
-            data-testid="explorer-delete-cancel"
+            type="button"
             onClick={onCancel}
-            className="px-4 py-2 text-[length:var(--text-sm)] text-text-secondary hover:text-text-primary rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            aria-label="Close"
+            className="p-1.5 rounded-md text-text-muted hover:text-text-primary hover:bg-bg-subtle transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <X size={14} strokeWidth={1.8} aria-hidden="true" />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="px-6 py-4">
+          <p className="text-[length:var(--text-sm)] text-text-secondary">
+            {isSingle ? (
+              <>
+                <span className="font-mono text-text-primary">{entry.name}</span> will be permanently deleted.
+                {entry.entryType === "Directory" && <> All contents inside will also be removed.</>}
+              </>
+            ) : (
+              <>
+                {count} items will be permanently deleted.
+                {hasDirs && <> Directories and all their contents will be removed.</>}
+              </>
+            )}
+          </p>
+        </div>
+
+        {/* Footer */}
+        <div className="px-6 pb-5 pt-3 flex items-center justify-end gap-2 border-t border-border shrink-0">
+          <button
+            // eslint-disable-next-line jsx-a11y/no-autofocus
+            autoFocus
+            data-testid="explorer-delete-cancel"
+            type="button"
+            onClick={onCancel}
+            className="px-4 py-2 text-[length:var(--text-sm)] font-medium text-text-secondary hover:text-text-primary rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
             Cancel
           </button>
           <button
             data-testid="explorer-delete-confirm-button"
+            type="button"
             onClick={onConfirm}
-            className="px-4 py-2 text-[length:var(--text-sm)] font-medium text-white bg-status-error hover:opacity-90 rounded-lg transition-[opacity] duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            className="px-4 py-2 text-[length:var(--text-sm)] font-medium text-text-inverse bg-status-error hover:opacity-90 rounded-lg transition-[opacity] duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
-            {isSingle ? "Delete" : `Delete ${count} items`}
+            {confirmLabel}
           </button>
         </div>
       </div>

--- a/src/components/history/HistoryPage.tsx
+++ b/src/components/history/HistoryPage.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useState, useRef, useCallback } from "react";
-import { Search, Clock, ChevronDown, Loader2, TerminalSquare, FolderOpen } from "lucide-react";
+import { Search, Clock, ChevronDown, Loader2, TerminalSquare, FolderOpen, Trash2 } from "lucide-react";
 import { CustomSelect } from "../shared/CustomSelect";
 import { useSftpStore } from "../../stores/sftp-store";
 import { useSessionStore } from "../../stores/session-store";
 import { useHostsStore } from "../../stores/hosts-store";
 import { useTabStore } from "../../stores/tab-store";
 import { ContextMenu } from "../shared/ContextMenu";
+import { ConfirmDangerDialog } from "../shared/ConfirmDangerDialog";
 import type { ContextMenuItem } from "../shared/ContextMenu";
 import type { ConnectionHistoryEntry } from "../../types";
 import { parseSqliteUtc } from "../../utils/time";
@@ -52,9 +53,11 @@ export function HistoryPage() {
   const [query, setQuery] = useState("");
   const [hostFilter, setHostFilter] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
+  const [mutating, setMutating] = useState(false);
   const [hasMore, setHasMore] = useState(true);
   const offsetRef = useRef(0);
   const [contextMenu, setContextMenu] = useState<{ entry: ConnectionHistoryEntry; x: number; y: number } | null>(null);
+  const [confirmDeleteId, setConfirmDeleteId] = useState<number | null>(null);
 
   const loadEntries = async (reset: boolean) => {
     setLoading(true);
@@ -122,6 +125,11 @@ export function HistoryPage() {
     }
   }, []);
 
+  const handleContextMenu = (e: React.MouseEvent, entry: ConnectionHistoryEntry) => {
+    e.preventDefault();
+    setContextMenu({ entry, x: e.clientX, y: e.clientY });
+  };
+
   const handleExplorer = useCallback(async (entry: ConnectionHistoryEntry) => {
     try {
       const { invoke } = await import("@tauri-apps/api/core");
@@ -150,10 +158,18 @@ export function HistoryPage() {
     }
   }, []);
 
-  const handleContextMenu = (e: React.MouseEvent, entry: ConnectionHistoryEntry) => {
-    e.preventDefault();
-    setContextMenu({ entry, x: e.clientX, y: e.clientY });
-  };
+  const handleDeleteHistoryEntry = useCallback(async (entryId: number) => {
+    setMutating(true);
+    try {
+      const { invoke } = await import("@tauri-apps/api/core");
+      await invoke("delete_connection_history_entry", { id: entryId });
+      setEntries((prev) => prev.filter((entry) => entry.id !== entryId));
+    } catch {
+      // best-effort
+    } finally {
+      setMutating(false);
+    }
+  }, []);
 
   const buildContextItems = (entry: ConnectionHistoryEntry): ContextMenuItem[] => [
     {
@@ -167,8 +183,16 @@ export function HistoryPage() {
       onClick: () => void handleExplorer(entry),
     },
     {
+      label: "Delete",
+      icon: Trash2,
+      danger: true,
+      disabled: mutating,
+      onClick: () => setConfirmDeleteId(entry.id),
+    },
+    {
       label: `Filter by ${entry.host_label || entry.host}`,
       separator: true,
+      disabled: mutating,
       onClick: () => {
         setHostFilter(entry.host_id);
         setQuery("");
@@ -352,6 +376,21 @@ export function HistoryPage() {
           onClose={() => setContextMenu(null)}
         />
       )}
+
+      <ConfirmDangerDialog
+        open={confirmDeleteId !== null}
+        title="Delete this history record?"
+        message="This record will be permanently removed."
+        busy={mutating}
+        onCancel={() => setConfirmDeleteId(null)}
+        onConfirm={() => {
+          const id = confirmDeleteId;
+          setConfirmDeleteId(null);
+          if (id !== null) {
+            void handleDeleteHistoryEntry(id);
+          }
+        }}
+      />
     </>
   );
 }

--- a/src/components/history/HistoryPage.tsx
+++ b/src/components/history/HistoryPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, useRef, useCallback } from "react";
 import { Search, Clock, ChevronDown, Loader2, TerminalSquare, FolderOpen, Trash2 } from "lucide-react";
+import { toast } from "../../stores/toast-store";
 import { CustomSelect } from "../shared/CustomSelect";
 import { useSftpStore } from "../../stores/sftp-store";
 import { useSessionStore } from "../../stores/session-store";
@@ -164,8 +165,10 @@ export function HistoryPage() {
       const { invoke } = await import("@tauri-apps/api/core");
       await invoke("delete_connection_history_entry", { id: entryId });
       setEntries((prev) => prev.filter((entry) => entry.id !== entryId));
+      offsetRef.current -= 1;
+      setConfirmDeleteId(null);
     } catch {
-      // best-effort
+      toast.error("Failed to delete history entry.");
     } finally {
       setMutating(false);
     }
@@ -384,11 +387,7 @@ export function HistoryPage() {
         busy={mutating}
         onCancel={() => setConfirmDeleteId(null)}
         onConfirm={() => {
-          const id = confirmDeleteId;
-          setConfirmDeleteId(null);
-          if (id !== null) {
-            void handleDeleteHistoryEntry(id);
-          }
+          if (confirmDeleteId !== null) void handleDeleteHistoryEntry(confirmDeleteId);
         }}
       />
     </>

--- a/src/components/port-forwarding/PortForwardingPage.tsx
+++ b/src/components/port-forwarding/PortForwardingPage.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useState, useCallback, useMemo } from "react";
-import { Plus, Trash2, ArrowRight, Search, Wifi, Pencil, Copy, Clock } from "lucide-react";
+import { Plus, Trash2, ArrowRight, Search, Wifi, Pencil, Copy, Clock, Plug } from "lucide-react";
 import { CustomSelect } from "../shared/CustomSelect";
 import { usePortForwardStore } from "../../stores/port-forward-store";
 import { useHostsStore } from "../../stores/hosts-store";
 import { ContextMenu } from "../shared/ContextMenu";
 import { ConfirmDangerDialog } from "../shared/ConfirmDangerDialog";
+import { ModalShell, BTN_GHOST, BTN_PRIMARY } from "../shared/ModalShell";
 import type { ContextMenuItem } from "../shared/ContextMenu";
 import type { PortForwardRule, SavedHost } from "../../types";
 
@@ -440,13 +441,6 @@ function RuleDialog({
     });
   };
 
-  useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onCancel();
-    };
-    document.addEventListener("keydown", handler);
-    return () => document.removeEventListener("keydown", handler);
-  }, [onCancel]);
 
   const inputClass =
     "w-full rounded-lg bg-bg-base border border-border px-3 py-2 text-[length:var(--text-sm)] text-text-primary placeholder:text-text-muted outline-none focus:border-border-focus focus:ring-2 focus:ring-ring transition-[border-color,box-shadow] duration-[var(--duration-fast)]";
@@ -455,37 +449,24 @@ function RuleDialog({
     "block text-[length:var(--text-xs)] font-medium text-text-secondary mb-1";
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-start justify-center pt-[8vh]"
-      style={{ backgroundColor: "oklch(0 0 0 / 0.5)", backdropFilter: "blur(4px)" }}
-      onClick={(e) => e.target === e.currentTarget && onCancel()}
-    >
-      <form
-        onSubmit={handleSubmit}
-        role="dialog"
-        data-testid="rule-dialog"
-        aria-label={isEdit ? "Edit forwarding rule" : "New forwarding rule"}
-        className="w-full max-w-lg rounded-xl bg-bg-overlay border border-border shadow-[var(--shadow-lg)] flex flex-col max-h-[84vh] animate-[fadeIn_120ms_var(--ease-expo-out)_both]"
-      >
-        {/* Header */}
-        <div className="flex items-center justify-between px-6 pt-5 pb-4 border-b border-border shrink-0">
-          <h2 className="text-[length:var(--text-lg)] font-semibold text-text-primary">
-            {isEdit ? "Edit Rule" : "New Rule"}
-          </h2>
-          <button
-            type="button"
-            onClick={onCancel}
-            aria-label="Close"
-            className="p-1.5 rounded-md text-text-muted hover:text-text-primary hover:bg-bg-subtle transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-          >
-            <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
-              <path d="M1 1l12 12M13 1L1 13" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
-            </svg>
+    <ModalShell
+      open
+      onClose={onCancel}
+      title={isEdit ? "Edit Rule" : "New Rule"}
+      icon={Plug}
+      maxWidth="lg"
+      scrollable
+      testId="rule-dialog"
+      footer={
+        <>
+          <button type="button" onClick={onCancel} className={BTN_GHOST}>Cancel</button>
+          <button form="rule-dialog-form" type="submit" data-testid="rule-dialog-save" disabled={!canSubmit} className={BTN_PRIMARY}>
+            {isEdit ? "Save" : "Create"}
           </button>
-        </div>
-
-        {/* Body */}
-        <div className="px-6 py-4 flex flex-col gap-3.5 overflow-y-auto flex-1 min-h-0">
+        </>
+      }
+    >
+        <form id="rule-dialog-form" onSubmit={handleSubmit} className="flex flex-col gap-3.5">
           <SectionHeader>Connection</SectionHeader>
 
           {/* Host */}
@@ -642,27 +623,7 @@ function RuleDialog({
               ].join(" ")} />
             </button>
           </div>
-        </div>
-
-        {/* Footer */}
-        <div className="px-6 pb-5 pt-3 flex items-center justify-end gap-2 border-t border-border shrink-0">
-          <button
-            type="button"
-            onClick={onCancel}
-            className="px-4 py-2 text-[length:var(--text-sm)] text-text-secondary hover:text-text-primary rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-          >
-            Cancel
-          </button>
-          <button
-            type="submit"
-            data-testid="rule-dialog-save"
-            disabled={!canSubmit}
-            className="px-4 py-2 text-[length:var(--text-sm)] font-medium text-text-inverse bg-accent hover:bg-accent-hover disabled:opacity-50 rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-          >
-            {isEdit ? "Save" : "Create"}
-          </button>
-        </div>
-      </form>
-    </div>
+        </form>
+    </ModalShell>
   );
 }

--- a/src/components/port-forwarding/PortForwardingPage.tsx
+++ b/src/components/port-forwarding/PortForwardingPage.tsx
@@ -4,6 +4,7 @@ import { CustomSelect } from "../shared/CustomSelect";
 import { usePortForwardStore } from "../../stores/port-forward-store";
 import { useHostsStore } from "../../stores/hosts-store";
 import { ContextMenu } from "../shared/ContextMenu";
+import { ConfirmDangerDialog } from "../shared/ConfirmDangerDialog";
 import type { ContextMenuItem } from "../shared/ContextMenu";
 import type { PortForwardRule, SavedHost } from "../../types";
 
@@ -24,6 +25,7 @@ export function PortForwardingPage() {
 
   const [showForm, setShowForm] = useState(false);
   const [editingRule, setEditingRule] = useState<PortForwardRule | null>(null);
+  const [deletingRule, setDeletingRule] = useState<PortForwardRule | null>(null);
   const [query, setQuery] = useState("");
   const [contextMenu, setContextMenu] = useState<{ rule: PortForwardRule; x: number; y: number } | null>(null);
 
@@ -101,7 +103,7 @@ export function PortForwardingPage() {
       label: "Delete",
       icon: Trash2,
       danger: true,
-      onClick: () => void deleteRule(rule.id),
+      onClick: () => setDeletingRule(rule),
     });
 
     return items;
@@ -349,6 +351,20 @@ export function PortForwardingPage() {
           onCancel={() => setEditingRule(null)}
         />
       )}
+
+      <ConfirmDangerDialog
+        open={deletingRule !== null}
+        title="Delete this tunnel rule?"
+        message="This tunnel rule will be permanently removed."
+        onCancel={() => setDeletingRule(null)}
+        onConfirm={() => {
+          const rule = deletingRule;
+          setDeletingRule(null);
+          if (rule) {
+            void deleteRule(rule.id);
+          }
+        }}
+      />
     </>
   );
 }

--- a/src/components/s3/S3ConnectDialog.tsx
+++ b/src/components/s3/S3ConnectDialog.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from "react";
+import { X } from "lucide-react";
 import { useS3Store } from "../../stores/s3-store";
 import { useGroupsStore } from "../../stores/groups-store";
 import { CustomSelect } from "../shared/CustomSelect";
@@ -24,6 +25,8 @@ function SectionHeader({ children }: { children: React.ReactNode }) {
 
 export function S3ConnectDialog({ onClose, editConnection }: S3ConnectDialogProps) {
   const isEdit = !!editConnection;
+  const [visible, setVisible] = useState(false);
+  const backdropRef = useRef<HTMLDivElement>(null);
   const [provider, setProvider] = useState<S3Provider>(
     (editConnection?.provider as S3Provider) ?? "aws",
   );
@@ -53,6 +56,10 @@ export function S3ConnectDialog({ onClose, editConnection }: S3ConnectDialogProp
       setPathStyle(preset.pathStyle);
     }
   }, [provider, isEdit]);
+
+  useEffect(() => {
+    requestAnimationFrame(() => setVisible(true));
+  }, []);
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -169,25 +176,35 @@ export function S3ConnectDialog({ onClose, editConnection }: S3ConnectDialogProp
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-start justify-center pt-[8vh]"
-      style={{ backgroundColor: "oklch(0 0 0 / 0.5)", backdropFilter: "blur(4px)" }}
-      onClick={(e) => e.target === e.currentTarget && !connecting && onClose()}
+      ref={backdropRef}
+      onClick={(e) => e.target === backdropRef.current && !connecting && onClose()}
+      className={[
+        "fixed inset-0 z-50 flex items-start justify-center pt-[8vh]",
+        "transition-[background-color,backdrop-filter] duration-[var(--duration-base)]",
+        visible ? "bg-black/50 backdrop-blur-sm" : "bg-black/0 backdrop-blur-none",
+      ].join(" ")}
     >
-      <div data-testid="s3-dialog" className="w-full max-w-lg rounded-xl bg-bg-overlay border border-border shadow-[var(--shadow-lg)] flex flex-col max-h-[84vh] animate-[fadeIn_120ms_var(--ease-expo-out)_both]">
+      <div
+        data-testid="s3-dialog"
+        className={[
+          "w-full max-w-lg rounded-xl bg-bg-overlay border border-border shadow-[var(--shadow-lg)] flex flex-col max-h-[84vh]",
+          "transition-[opacity,transform] duration-[var(--duration-slow)] ease-[var(--ease-expo-out)]",
+          visible ? "opacity-100 translate-y-0" : "opacity-0 -translate-y-3",
+        ].join(" ")}
+      >
         {/* Header */}
         <div className="flex items-center justify-between px-6 pt-5 pb-4 border-b border-border shrink-0">
           <h2 className="text-[length:var(--text-lg)] font-semibold text-text-primary">
             {isEdit ? "Edit Connection" : "Connect to S3"}
           </h2>
           <button
+            type="button"
             onClick={onClose}
             disabled={connecting}
             aria-label="Close"
-            className="p-1.5 rounded-md text-text-muted hover:text-text-primary hover:bg-bg-subtle transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            className="p-1.5 rounded-md text-text-muted hover:text-text-primary hover:bg-bg-subtle transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
           >
-            <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
-              <path d="M1 1l12 12M13 1L1 13" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
-            </svg>
+            <X size={14} strokeWidth={1.8} aria-hidden="true" />
           </button>
         </div>
 
@@ -373,37 +390,41 @@ export function S3ConnectDialog({ onClose, editConnection }: S3ConnectDialogProp
         </div>
 
         {/* Footer */}
-        <div className="px-6 pb-5 pt-3 flex items-center justify-end gap-2 border-t border-border shrink-0">
+        <div className="px-6 py-3 flex items-center justify-end gap-2 border-t border-border shrink-0">
           <button
+            type="button"
             onClick={onClose}
             disabled={connecting || saving}
-            className="px-4 py-2 text-[length:var(--text-sm)] text-text-secondary hover:text-text-primary rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            className="px-4 py-1.5 text-[length:var(--text-sm)] font-medium text-text-secondary hover:text-text-primary rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
           >
             Cancel
           </button>
           {isEdit ? (
             <button
+              type="button"
               onClick={() => void handleSave()}
               disabled={saving || !canSubmit}
-              className="px-4 py-2 text-[length:var(--text-sm)] font-medium text-text-inverse bg-accent hover:bg-accent-hover disabled:opacity-50 rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              className="px-4 py-1.5 text-[length:var(--text-sm)] font-medium text-text-inverse bg-accent hover:bg-accent-hover disabled:opacity-50 rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             >
               {saving ? "Saving…" : "Save Changes"}
             </button>
           ) : (
             <>
               <button
+                type="button"
                 data-testid="s3-dialog-save"
                 onClick={() => void handleSave()}
                 disabled={saving || connecting || !canSubmit}
-                className="px-4 py-2 text-[length:var(--text-sm)] font-medium text-text-secondary hover:text-text-primary bg-bg-subtle hover:bg-bg-muted disabled:opacity-50 rounded-lg border border-border transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                className="px-4 py-1.5 text-[length:var(--text-sm)] font-medium text-text-secondary hover:text-text-primary bg-bg-subtle hover:bg-bg-muted disabled:opacity-50 rounded-lg border border-border transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
               >
                 {saving ? "Saving…" : "Save"}
               </button>
               <button
+                type="button"
                 data-testid="s3-dialog-connect"
                 onClick={() => void handleConnect()}
                 disabled={connecting || saving || !canSubmit}
-                className="px-4 py-2 text-[length:var(--text-sm)] font-medium text-text-inverse bg-accent hover:bg-accent-hover disabled:opacity-50 rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                className="px-4 py-1.5 text-[length:var(--text-sm)] font-medium text-text-inverse bg-accent hover:bg-accent-hover disabled:opacity-50 rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
               >
                 {connecting ? "Connecting…" : "Connect"}
               </button>

--- a/src/components/s3/S3ConnectDialog.tsx
+++ b/src/components/s3/S3ConnectDialog.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from "react";
-import { X } from "lucide-react";
+import { X, Cloud } from "lucide-react";
 import { useS3Store } from "../../stores/s3-store";
 import { useGroupsStore } from "../../stores/groups-store";
 import { CustomSelect } from "../shared/CustomSelect";
@@ -194,9 +194,14 @@ export function S3ConnectDialog({ onClose, editConnection }: S3ConnectDialogProp
       >
         {/* Header */}
         <div className="flex items-center justify-between px-6 pt-5 pb-4 border-b border-border shrink-0">
-          <h2 className="text-[length:var(--text-lg)] font-semibold text-text-primary">
-            {isEdit ? "Edit Connection" : "Connect to S3"}
-          </h2>
+          <div className="flex items-center gap-3">
+            <div className="flex items-center justify-center w-8 h-8 rounded-lg shrink-0 bg-accent/10">
+              <Cloud size={16} strokeWidth={1.8} className="text-accent" aria-hidden="true" />
+            </div>
+            <h2 className="text-[length:var(--text-lg)] font-semibold text-text-primary">
+              {isEdit ? "Edit Connection" : "Connect to S3"}
+            </h2>
+          </div>
           <button
             type="button"
             onClick={onClose}

--- a/src/components/s3/S3ConnectDialog.tsx
+++ b/src/components/s3/S3ConnectDialog.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from "react";
-import { X, Cloud } from "lucide-react";
+import { Cloud } from "lucide-react";
 import { useS3Store } from "../../stores/s3-store";
+import { ModalShell, BTN_GHOST, BTN_SECONDARY, BTN_PRIMARY } from "../shared/ModalShell";
 import { useGroupsStore } from "../../stores/groups-store";
 import { CustomSelect } from "../shared/CustomSelect";
 import { S3_PROVIDERS } from "../../types";
@@ -25,8 +26,6 @@ function SectionHeader({ children }: { children: React.ReactNode }) {
 
 export function S3ConnectDialog({ onClose, editConnection }: S3ConnectDialogProps) {
   const isEdit = !!editConnection;
-  const [visible, setVisible] = useState(false);
-  const backdropRef = useRef<HTMLDivElement>(null);
   const [provider, setProvider] = useState<S3Provider>(
     (editConnection?.provider as S3Provider) ?? "aws",
   );
@@ -57,17 +56,6 @@ export function S3ConnectDialog({ onClose, editConnection }: S3ConnectDialogProp
     }
   }, [provider, isEdit]);
 
-  useEffect(() => {
-    requestAnimationFrame(() => setVisible(true));
-  }, []);
-
-  useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
-      if (e.key === "Escape" && !connecting) onClose();
-    };
-    document.addEventListener("keydown", handler);
-    return () => document.removeEventListener("keydown", handler);
-  }, [onClose, connecting]);
 
   const [groupId, setGroupId] = useState(editConnection?.group_id ?? "");
   const [color, setColor] = useState<string | null>(editConnection?.color ?? null);
@@ -175,46 +163,38 @@ export function S3ConnectDialog({ onClose, editConnection }: S3ConnectDialogProp
     "block text-[length:var(--text-xs)] font-medium text-text-secondary mb-1";
 
   return (
-    <div
-      ref={backdropRef}
-      onClick={(e) => e.target === backdropRef.current && !connecting && onClose()}
-      className={[
-        "fixed inset-0 z-50 flex items-start justify-center pt-[8vh]",
-        "transition-[background-color,backdrop-filter] duration-[var(--duration-base)]",
-        visible ? "bg-black/50 backdrop-blur-sm" : "bg-black/0 backdrop-blur-none",
-      ].join(" ")}
-    >
-      <div
-        data-testid="s3-dialog"
-        className={[
-          "w-full max-w-lg rounded-xl bg-bg-overlay border border-border shadow-[var(--shadow-lg)] flex flex-col max-h-[84vh]",
-          "transition-[opacity,transform] duration-[var(--duration-slow)] ease-[var(--ease-expo-out)]",
-          visible ? "opacity-100 translate-y-0" : "opacity-0 -translate-y-3",
-        ].join(" ")}
-      >
-        {/* Header */}
-        <div className="flex items-center justify-between px-6 pt-5 pb-4 border-b border-border shrink-0">
-          <div className="flex items-center gap-3">
-            <div className="flex items-center justify-center w-8 h-8 rounded-lg shrink-0 bg-accent/10">
-              <Cloud size={16} strokeWidth={1.8} className="text-accent" aria-hidden="true" />
-            </div>
-            <h2 className="text-[length:var(--text-lg)] font-semibold text-text-primary">
-              {isEdit ? "Edit Connection" : "Connect to S3"}
-            </h2>
-          </div>
-          <button
-            type="button"
-            onClick={onClose}
-            disabled={connecting}
-            aria-label="Close"
-            className="p-1.5 rounded-md text-text-muted hover:text-text-primary hover:bg-bg-subtle transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
-          >
-            <X size={14} strokeWidth={1.8} aria-hidden="true" />
+    <ModalShell
+      open
+      onClose={onClose}
+      title={isEdit ? "Edit Connection" : "Connect to S3"}
+      icon={Cloud}
+      maxWidth="lg"
+      scrollable
+      busy={connecting || saving}
+      testId="s3-dialog"
+      footer={
+        <>
+          <button type="button" onClick={onClose} disabled={connecting || saving} className={BTN_GHOST}>
+            Cancel
           </button>
-        </div>
-
-        {/* Body */}
-        <div className="px-6 py-4 overflow-y-auto flex-1 min-h-0 flex flex-col gap-3.5">
+          {isEdit ? (
+            <button type="button" onClick={() => void handleSave()} disabled={saving || !canSubmit} className={BTN_PRIMARY}>
+              {saving ? "Saving…" : "Save Changes"}
+            </button>
+          ) : (
+            <>
+              <button type="button" data-testid="s3-dialog-save" onClick={() => void handleSave()} disabled={saving || connecting || !canSubmit} className={BTN_SECONDARY}>
+                {saving ? "Saving…" : "Save"}
+              </button>
+              <button type="button" data-testid="s3-dialog-connect" onClick={() => void handleConnect()} disabled={connecting || saving || !canSubmit} className={BTN_PRIMARY}>
+                {connecting ? "Connecting…" : "Connect"}
+              </button>
+            </>
+          )}
+        </>
+      }
+    >
+        <div className="flex flex-col gap-3.5">
           <SectionHeader>Provider</SectionHeader>
 
           <div>
@@ -393,50 +373,6 @@ export function S3ConnectDialog({ onClose, editConnection }: S3ConnectDialogProp
             </p>
           )}
         </div>
-
-        {/* Footer */}
-        <div className="px-6 py-3 flex items-center justify-end gap-2 border-t border-border shrink-0">
-          <button
-            type="button"
-            onClick={onClose}
-            disabled={connecting || saving}
-            className="px-4 py-1.5 text-[length:var(--text-sm)] font-medium text-text-secondary hover:text-text-primary rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
-          >
-            Cancel
-          </button>
-          {isEdit ? (
-            <button
-              type="button"
-              onClick={() => void handleSave()}
-              disabled={saving || !canSubmit}
-              className="px-4 py-1.5 text-[length:var(--text-sm)] font-medium text-text-inverse bg-accent hover:bg-accent-hover disabled:opacity-50 rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-            >
-              {saving ? "Saving…" : "Save Changes"}
-            </button>
-          ) : (
-            <>
-              <button
-                type="button"
-                data-testid="s3-dialog-save"
-                onClick={() => void handleSave()}
-                disabled={saving || connecting || !canSubmit}
-                className="px-4 py-1.5 text-[length:var(--text-sm)] font-medium text-text-secondary hover:text-text-primary bg-bg-subtle hover:bg-bg-muted disabled:opacity-50 rounded-lg border border-border transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-              >
-                {saving ? "Saving…" : "Save"}
-              </button>
-              <button
-                type="button"
-                data-testid="s3-dialog-connect"
-                onClick={() => void handleConnect()}
-                disabled={connecting || saving || !canSubmit}
-                className="px-4 py-1.5 text-[length:var(--text-sm)] font-medium text-text-inverse bg-accent hover:bg-accent-hover disabled:opacity-50 rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-              >
-                {connecting ? "Connecting…" : "Connect"}
-              </button>
-            </>
-          )}
-        </div>
-      </div>
-    </div>
+    </ModalShell>
   );
 }

--- a/src/components/s3/S3Page.tsx
+++ b/src/components/s3/S3Page.tsx
@@ -5,6 +5,7 @@ import { useS3Store } from "../../stores/s3-store";
 import { S3Browser } from "./S3Browser";
 import { S3ConnectDialog } from "./S3ConnectDialog";
 import { ContextMenu } from "../shared/ContextMenu";
+import { ConfirmDangerDialog } from "../shared/ConfirmDangerDialog";
 import type { ContextMenuItem } from "../shared/ContextMenu";
 import type { S3Session } from "../../stores/s3-store";
 
@@ -19,6 +20,7 @@ export function S3Page() {
   const [savedConnections, setSavedConnections] = useState<S3Connection[]>([]);
   const [contextMenu, setContextMenu] = useState<{ session: S3Session; x: number; y: number } | null>(null);
   const [savedContextMenu, setSavedContextMenu] = useState<{ conn: S3Connection; x: number; y: number } | null>(null);
+  const [deletingSavedConn, setDeletingSavedConn] = useState<S3Connection | null>(null);
 
   // Load saved connections on mount
   useEffect(() => {
@@ -316,7 +318,7 @@ export function S3Page() {
               label: "Delete",
               icon: Trash2,
               danger: true,
-              onClick: () => void handleDeleteSaved(savedContextMenu.conn),
+              onClick: () => setDeletingSavedConn(savedContextMenu.conn),
             },
           ]}
           position={{ x: savedContextMenu.x, y: savedContextMenu.y }}
@@ -336,6 +338,20 @@ export function S3Page() {
           onClose={() => { setEditingConnection(null); void loadSavedConnections(); }}
         />
       )}
+
+      <ConfirmDangerDialog
+        open={deletingSavedConn !== null}
+        title="Delete this S3 connection?"
+        message="This connection will be permanently removed."
+        onCancel={() => setDeletingSavedConn(null)}
+        onConfirm={() => {
+          const conn = deletingSavedConn;
+          setDeletingSavedConn(null);
+          if (conn) {
+            void handleDeleteSaved(conn);
+          }
+        }}
+      />
     </>
   );
 }

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from "react";
+import { ModalShell, BTN_GHOST, BTN_PRIMARY, BTN_DANGER } from "../shared/ModalShell";
 import { useSettingsStore } from "../../stores/settings-store";
 import { CustomSelect, type SelectOption } from "../shared/CustomSelect";
 import { useUpdaterStore } from "../../stores/updater-store";
@@ -718,9 +719,7 @@ function BackupPasswordModal({ mode, open, path, onClose }: {
   const [pw, setPw] = useState("");
   const [confirm, setConfirm] = useState("");
   const [busy, setBusy] = useState(false);
-  const [visible, setVisible] = useState(false);
 
-  const backdropRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
   const valid = isExport ? pw.length >= MIN_LEN && pw === confirm : pw.length > 0;
@@ -731,22 +730,9 @@ function BackupPasswordModal({ mode, open, path, onClose }: {
       setPw("");
       setConfirm("");
       setBusy(false);
-      requestAnimationFrame(() => setVisible(true));
-    } else {
-      setVisible(false);
+      requestAnimationFrame(() => inputRef.current?.focus());
     }
   }, [open]);
-
-  useEffect(() => {
-    if (visible) requestAnimationFrame(() => inputRef.current?.focus());
-  }, [visible]);
-
-  useEffect(() => {
-    if (!open) return;
-    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape" && !busy) onClose(); };
-    document.addEventListener("keydown", onKey);
-    return () => document.removeEventListener("keydown", onKey);
-  }, [open, onClose, busy]);
 
   const submit = useCallback(async () => {
     if (!canSubmit) return;
@@ -785,45 +771,33 @@ function BackupPasswordModal({ mode, open, path, onClose }: {
     }
   }, [canSubmit, isExport, pw, path, onClose]);
 
-  if (!open) return null;
-
   return (
-    <div
-      ref={backdropRef}
-      onClick={(e) => { if (e.target === backdropRef.current && !busy) onClose(); }}
-      className={[
-        "fixed inset-0 z-50 flex items-start justify-center pt-[10vh]",
-        "transition-[background-color,backdrop-filter] duration-[var(--duration-base)]",
-        visible ? "bg-black/50 backdrop-blur-sm" : "bg-black/0 backdrop-blur-none",
-      ].join(" ")}
+    <ModalShell
+      open={open}
+      onClose={onClose}
+      title={isExport ? "Export encrypted backup" : "Import backup"}
+      icon={isExport ? ShieldCheck : AlertCircle}
+      iconVariant={isExport ? "accent" : "danger"}
+      maxWidth="md"
+      busy={busy}
+      testId={`backup-modal-${mode}`}
+      footer={
+        <>
+          <button type="button" onClick={onClose} disabled={busy} className={BTN_GHOST}>Cancel</button>
+          <button
+            form="backup-form"
+            type="submit"
+            data-testid="backup-submit"
+            disabled={!canSubmit}
+            className={isExport ? BTN_PRIMARY : BTN_DANGER}
+          >
+            {busy && <RefreshCw size={13} strokeWidth={2} className="motion-safe:animate-spin" />}
+            {isExport ? (busy ? "Exporting…" : "Choose file & export") : (busy ? "Restoring…" : "Import & restart")}
+          </button>
+        </>
+      }
     >
-      <div
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="backup-title"
-        data-testid={`backup-modal-${mode}`}
-        className={[
-          "w-full max-w-md rounded-xl bg-bg-overlay border border-border shadow-[var(--shadow-lg)]",
-          "flex flex-col",
-          "transition-[opacity,transform] duration-[var(--duration-slow)] ease-[var(--ease-expo-out)]",
-          visible ? "opacity-100 translate-y-0" : "opacity-0 -translate-y-3",
-        ].join(" ")}
-      >
-        {/* Header */}
-        <div className="flex items-center gap-2.5 px-6 pt-5 pb-4 border-b border-border shrink-0">
-          {isExport
-            ? <ShieldCheck size={18} strokeWidth={2} className="text-accent shrink-0" />
-            : <AlertCircle size={18} strokeWidth={2} className="text-status-error shrink-0" />}
-          <h2 id="backup-title" className="text-[length:var(--text-lg)] font-semibold text-text-primary">
-            {isExport ? "Export encrypted backup" : "Import backup"}
-          </h2>
-        </div>
-
-        {/* Body */}
-        <form
-          onSubmit={(e) => { e.preventDefault(); void submit(); }}
-          className="px-6 py-4 flex flex-col gap-4"
-        >
+        <form id="backup-form" onSubmit={(e) => { e.preventDefault(); void submit(); }} className="flex flex-col gap-4">
           <p className="text-[length:var(--text-sm)] text-text-secondary">
             {isExport
               ? "Choose a password to encrypt the backup. You’ll need it to restore — there’s no way to recover the data without it."
@@ -866,38 +840,8 @@ function BackupPasswordModal({ mode, open, path, onClose }: {
             </div>
           )}
 
-          {/* Footer */}
-          <div className="flex items-center justify-end gap-2 pt-1">
-            <button
-              type="button"
-              onClick={onClose}
-              disabled={busy}
-              className="px-4 py-2 text-[length:var(--text-sm)] text-text-secondary hover:text-text-primary rounded-lg transition-colors duration-[var(--duration-fast)] disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-            >
-              Cancel
-            </button>
-            <button
-              type="submit"
-              data-testid="backup-submit"
-              disabled={!canSubmit}
-              className={[
-                "flex items-center gap-1.5 px-4 py-2 rounded-lg",
-                "text-[length:var(--text-sm)] font-medium text-text-inverse",
-                isExport ? "bg-accent hover:bg-accent-hover" : "bg-status-error hover:opacity-90",
-                "disabled:opacity-50 disabled:cursor-not-allowed",
-                "transition-[opacity,background-color] duration-[var(--duration-fast)]",
-                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-bg-overlay",
-              ].join(" ")}
-            >
-              {busy && <RefreshCw size={13} strokeWidth={2} className="motion-safe:animate-spin" />}
-              {isExport
-                ? (busy ? "Exporting…" : "Choose file & export")
-                : (busy ? "Restoring…" : "Import & restart")}
-            </button>
-          </div>
         </form>
-      </div>
-    </div>
+    </ModalShell>
   );
 }
 
@@ -907,9 +851,7 @@ function ConfirmResetModal({ open, onClose }: { open: boolean; onClose: () => vo
   const CONFIRM_WORD = "DELETE";
   const [text, setText] = useState("");
   const [busy, setBusy] = useState(false);
-  const [visible, setVisible] = useState(false);
 
-  const backdropRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
   const canReset = text.trim() === CONFIRM_WORD && !busy;
@@ -918,22 +860,9 @@ function ConfirmResetModal({ open, onClose }: { open: boolean; onClose: () => vo
     if (open) {
       setText("");
       setBusy(false);
-      requestAnimationFrame(() => setVisible(true));
-    } else {
-      setVisible(false);
+      requestAnimationFrame(() => inputRef.current?.focus());
     }
   }, [open]);
-
-  useEffect(() => {
-    if (visible) requestAnimationFrame(() => inputRef.current?.focus());
-  }, [visible]);
-
-  useEffect(() => {
-    if (!open) return;
-    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape" && !busy) onClose(); };
-    document.addEventListener("keydown", onKey);
-    return () => document.removeEventListener("keydown", onKey);
-  }, [open, onClose, busy]);
 
   const doReset = useCallback(async () => {
     setBusy(true);
@@ -955,40 +884,33 @@ function ConfirmResetModal({ open, onClose }: { open: boolean; onClose: () => vo
     }
   }, []);
 
-  if (!open) return null;
-
   return (
-    <div
-      ref={backdropRef}
-      onClick={(e) => { if (e.target === backdropRef.current && !busy) onClose(); }}
-      className={[
-        "fixed inset-0 z-50 flex items-start justify-center pt-[12vh]",
-        "transition-[background-color,backdrop-filter] duration-[var(--duration-base)]",
-        visible ? "bg-black/50 backdrop-blur-sm" : "bg-black/0 backdrop-blur-none",
-      ].join(" ")}
+    <ModalShell
+      open={open}
+      onClose={onClose}
+      title="Clear all data?"
+      icon={AlertCircle}
+      iconVariant="danger"
+      maxWidth="md"
+      busy={busy}
+      testId="reset-modal"
+      footer={
+        <>
+          <button type="button" onClick={onClose} disabled={busy} className={BTN_GHOST}>Cancel</button>
+          <button
+            type="button"
+            data-testid="reset-confirm-submit"
+            onClick={() => void doReset()}
+            disabled={!canReset}
+            className={`flex items-center gap-1.5 ${BTN_DANGER}`}
+          >
+            {busy && <RefreshCw size={13} strokeWidth={2} className="motion-safe:animate-spin" />}
+            {busy ? "Clearing…" : "Clear all data"}
+          </button>
+        </>
+      }
     >
-      <div
-        role="alertdialog"
-        aria-modal="true"
-        aria-labelledby="reset-title"
-        data-testid="reset-modal"
-        className={[
-          "w-full max-w-md rounded-xl bg-bg-overlay border border-border shadow-[var(--shadow-lg)]",
-          "flex flex-col",
-          "transition-[opacity,transform] duration-[var(--duration-slow)] ease-[var(--ease-expo-out)]",
-          visible ? "opacity-100 translate-y-0" : "opacity-0 -translate-y-3",
-        ].join(" ")}
-      >
-        {/* Header */}
-        <div className="flex items-center gap-2.5 px-6 pt-5 pb-4 border-b border-border shrink-0">
-          <AlertCircle size={18} strokeWidth={2} className="text-status-error shrink-0" />
-          <h2 id="reset-title" className="text-[length:var(--text-lg)] font-semibold text-text-primary">
-            Clear all data?
-          </h2>
-        </div>
-
-        {/* Body */}
-        <div className="px-6 py-4 flex flex-col gap-4">
+        <div className="flex flex-col gap-4">
           <p className="text-[length:var(--text-sm)] text-text-secondary">
             This permanently deletes <strong className="text-text-primary">all</strong> saved
             hosts, groups, history, snippets, port-forward rules, S3 connections, stored
@@ -1014,30 +936,7 @@ function ConfirmResetModal({ open, onClose }: { open: boolean; onClose: () => vo
             />
           </div>
         </div>
-
-        {/* Footer */}
-        <div className="px-6 pb-5 pt-3 flex items-center justify-end gap-2 border-t border-border shrink-0">
-          <button
-            type="button"
-            onClick={onClose}
-            disabled={busy}
-            className="px-4 py-2 text-[length:var(--text-sm)] text-text-secondary hover:text-text-primary rounded-lg transition-colors duration-[var(--duration-fast)] disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-          >
-            Cancel
-          </button>
-          <button
-            type="button"
-            data-testid="reset-confirm-submit"
-            onClick={() => void doReset()}
-            disabled={!canReset}
-            className="flex items-center gap-1.5 px-4 py-2 text-[length:var(--text-sm)] font-medium text-text-inverse bg-status-error hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed rounded-lg transition-[opacity] duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-bg-overlay"
-          >
-            {busy && <RefreshCw size={13} strokeWidth={2} className="motion-safe:animate-spin" />}
-            {busy ? "Clearing…" : "Clear all data"}
-          </button>
-        </div>
-      </div>
-    </div>
+    </ModalShell>
   );
 }
 

--- a/src/components/sftp/DropOverwriteDialog.tsx
+++ b/src/components/sftp/DropOverwriteDialog.tsx
@@ -89,13 +89,13 @@ export function DropOverwriteDialog({
         </div>
 
         {/* Footer */}
-        <div className="px-6 pb-5 pt-3 flex items-center justify-end gap-2 border-t border-border shrink-0">
+        <div className="px-6 py-3 flex items-center justify-end gap-2 border-t border-border shrink-0">
           <button
             ref={cancelRef}
             data-testid="explorer-overwrite-cancel"
             type="button"
             onClick={onCancel}
-            className="px-4 py-2 text-[length:var(--text-sm)] font-medium text-text-secondary hover:text-text-primary rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            className="px-4 py-1.5 text-[length:var(--text-sm)] font-medium text-text-secondary hover:text-text-primary rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
             Cancel
           </button>
@@ -103,7 +103,7 @@ export function DropOverwriteDialog({
             data-testid="explorer-overwrite-confirm-button"
             type="button"
             onClick={onConfirm}
-            className="px-4 py-2 text-[length:var(--text-sm)] font-medium text-text-inverse bg-accent hover:bg-accent-hover rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            className="px-4 py-1.5 text-[length:var(--text-sm)] font-medium text-text-inverse bg-accent hover:bg-accent-hover rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
             {count === 1 ? "Overwrite" : `Overwrite ${count}`}
           </button>

--- a/src/components/sftp/DropOverwriteDialog.tsx
+++ b/src/components/sftp/DropOverwriteDialog.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useRef } from "react";
-import { AlertTriangle, X } from "lucide-react";
+import { AlertTriangle } from "lucide-react";
+import { ModalShell, BTN_GHOST, BTN_PRIMARY } from "../shared/ModalShell";
 
 interface DropOverwriteDialogProps {
   conflicts: string[];
@@ -12,7 +12,7 @@ interface DropOverwriteDialogProps {
  * Confirmation shown when a drag-drop upload would overwrite existing remote
  * entries. The conflict list is computed from top-level basenames, so for a
  * dropped folder the match means the folder already exists — its contents are
- * merged and only same-named files inside are replaced (see the note below).
+ * merged and only same-named files inside are replaced.
  */
 export function DropOverwriteDialog({
   conflicts,
@@ -21,94 +21,48 @@ export function DropOverwriteDialog({
   onCancel,
 }: DropOverwriteDialogProps) {
   const count = conflicts.length;
-  const cancelRef = useRef<HTMLButtonElement>(null);
-
-  useEffect(() => {
-    cancelRef.current?.focus();
-    const handler = (e: KeyboardEvent) => {
-      if (e.key === "Escape") { e.stopPropagation(); onCancel(); }
-    };
-    document.addEventListener("keydown", handler, true);
-    return () => document.removeEventListener("keydown", handler, true);
-  }, [onCancel]);
 
   return (
-    <div
-      data-testid="explorer-overwrite-confirm"
-      className="fixed inset-0 z-50 flex items-start justify-center pt-[8vh] bg-black/50 backdrop-blur-sm"
-      onClick={(e) => e.target === e.currentTarget && onCancel()}
-    >
-      <div
-        aria-modal="true"
-        role="dialog"
-        aria-labelledby="explorer-overwrite-title"
-        className="w-full max-w-sm rounded-xl bg-bg-overlay border border-border shadow-[var(--shadow-lg)] flex flex-col animate-in fade-in slide-in-from-top-2 duration-[var(--duration-base)]"
-      >
-        {/* Header */}
-        <div className="flex items-center justify-between px-6 pt-5 pb-4 border-b border-border shrink-0">
-          <div className="flex items-center gap-2.5">
-            <div className="flex items-center justify-center w-7 h-7 rounded-md shrink-0 bg-status-error/10">
-              <AlertTriangle size={15} strokeWidth={1.8} className="text-status-error" aria-hidden="true" />
-            </div>
-            <h2 id="explorer-overwrite-title" className="text-[length:var(--text-lg)] font-semibold text-text-primary">
-              {count === 1 ? "Overwrite item?" : `Overwrite ${count} items?`}
-            </h2>
-          </div>
-          <button
-            type="button"
-            onClick={onCancel}
-            aria-label="Close"
-            className="p-1.5 rounded-md text-text-muted hover:text-text-primary hover:bg-bg-subtle transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-          >
-            <X size={14} strokeWidth={1.8} aria-hidden="true" />
-          </button>
-        </div>
-
-        {/* Body */}
-        <div className="px-6 py-4 flex flex-col gap-3">
-          <p className="text-[length:var(--text-sm)] text-text-secondary">
-            {count === 1 ? (
-              <><span className="font-mono text-text-primary">{conflicts[0]}</span> already exists here.</>
-            ) : (
-              <>{count} items already exist here.</>
-            )}
-          </p>
-          {count > 1 && (
-            <ul className="max-h-32 overflow-y-auto rounded-md bg-bg-base border border-border/60 p-2 flex flex-col gap-0.5">
-              {conflicts.map((n) => (
-                <li key={n} className="font-mono text-[length:var(--text-2xs)] text-text-secondary truncate">
-                  {n}
-                </li>
-              ))}
-            </ul>
-          )}
-          <p className="text-[length:var(--text-2xs)] text-text-muted">
-            Files are replaced; folders are merged, replacing only same-named files inside.
-          </p>
-          <p className="font-mono text-[length:var(--text-2xs)] text-text-muted truncate">{targetDir}</p>
-        </div>
-
-        {/* Footer */}
-        <div className="px-6 py-3 flex items-center justify-end gap-2 border-t border-border shrink-0">
-          <button
-            ref={cancelRef}
-            data-testid="explorer-overwrite-cancel"
-            type="button"
-            onClick={onCancel}
-            className="px-4 py-1.5 text-[length:var(--text-sm)] font-medium text-text-secondary hover:text-text-primary rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-          >
+    <ModalShell
+      open
+      onClose={onCancel}
+      title={count === 1 ? "Overwrite item?" : `Overwrite ${count} items?`}
+      icon={AlertTriangle}
+      iconVariant="danger"
+      maxWidth="sm"
+      testId="explorer-overwrite-confirm"
+      footer={
+        <>
+          {/* eslint-disable-next-line jsx-a11y/no-autofocus */}
+          <button autoFocus data-testid="explorer-overwrite-cancel" type="button" onClick={onCancel} className={BTN_GHOST}>
             Cancel
           </button>
-          <button
-            data-testid="explorer-overwrite-confirm-button"
-            type="button"
-            onClick={onConfirm}
-            className="px-4 py-1.5 text-[length:var(--text-sm)] font-medium text-text-inverse bg-accent hover:bg-accent-hover rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-          >
+          <button data-testid="explorer-overwrite-confirm-button" type="button" onClick={onConfirm} className={BTN_PRIMARY}>
             {count === 1 ? "Overwrite" : `Overwrite ${count}`}
           </button>
-        </div>
+        </>
+      }
+    >
+      <div className="flex flex-col gap-3">
+        <p className="text-[length:var(--text-sm)] text-text-secondary">
+          {count === 1 ? (
+            <><span className="font-mono text-text-primary">{conflicts[0]}</span> already exists here.</>
+          ) : (
+            <>{count} items already exist here.</>
+          )}
+        </p>
+        {count > 1 && (
+          <ul className="max-h-32 overflow-y-auto rounded-md bg-bg-base border border-border/60 p-2 flex flex-col gap-0.5">
+            {conflicts.map((n) => (
+              <li key={n} className="font-mono text-[length:var(--text-2xs)] text-text-secondary truncate">{n}</li>
+            ))}
+          </ul>
+        )}
+        <p className="text-[length:var(--text-2xs)] text-text-muted">
+          Files are replaced; folders are merged, replacing only same-named files inside.
+        </p>
+        <p className="font-mono text-[length:var(--text-2xs)] text-text-muted truncate">{targetDir}</p>
       </div>
-    </div>
+    </ModalShell>
   );
 }

--- a/src/components/sftp/DropOverwriteDialog.tsx
+++ b/src/components/sftp/DropOverwriteDialog.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from "react";
+import { AlertTriangle, X } from "lucide-react";
 
 interface DropOverwriteDialogProps {
   conflicts: string[];
@@ -22,75 +23,87 @@ export function DropOverwriteDialog({
   const count = conflicts.length;
   const cancelRef = useRef<HTMLButtonElement>(null);
 
-  // Escape cancels; focus the (non-destructive) Cancel button on open so the
-  // dialog is keyboard-operable and doesn't leave focus on the page behind it.
   useEffect(() => {
     cancelRef.current?.focus();
-    const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        e.preventDefault();
-        onCancel();
-      }
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") { e.stopPropagation(); onCancel(); }
     };
-    window.addEventListener("keydown", onKeyDown);
-    return () => window.removeEventListener("keydown", onKeyDown);
+    document.addEventListener("keydown", handler, true);
+    return () => document.removeEventListener("keydown", handler, true);
   }, [onCancel]);
 
   return (
     <div
       data-testid="explorer-overwrite-confirm"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="explorer-overwrite-title"
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm"
+      className="fixed inset-0 z-50 flex items-start justify-center pt-[8vh] bg-black/50 backdrop-blur-sm"
       onClick={(e) => e.target === e.currentTarget && onCancel()}
     >
-      <div className="w-full max-w-sm mx-4 rounded-xl bg-bg-overlay border border-border p-6 shadow-[var(--shadow-lg)]">
-        <h2
-          id="explorer-overwrite-title"
-          className="text-[length:var(--text-lg)] font-semibold text-text-primary mb-2"
-        >
-          {count === 1 ? "Overwrite item?" : `Overwrite ${count} items?`}
-        </h2>
-        <p className="text-[length:var(--text-sm)] text-text-secondary mb-3">
-          {count === 1 ? (
-            <>
-              <span className="font-mono text-text-primary">{conflicts[0]}</span> already exists
-              here.
-            </>
-          ) : (
-            <>{count} items already exist here.</>
-          )}
-        </p>
-        {count > 1 && (
-          <ul className="mb-3 max-h-32 overflow-y-auto rounded-md bg-bg-base border border-border/60 p-2 flex flex-col gap-0.5">
-            {conflicts.map((n) => (
-              <li key={n} className="font-mono text-[length:var(--text-2xs)] text-text-secondary truncate">
-                {n}
-              </li>
-            ))}
-          </ul>
-        )}
-        <p className="text-[length:var(--text-2xs)] text-text-muted mb-2">
-          Files are replaced; folders are merged, replacing only same-named files inside.
-        </p>
-        <p className="font-mono text-[length:var(--text-2xs)] text-text-muted truncate mb-5">
-          {targetDir}
-        </p>
+      <div
+        aria-modal="true"
+        role="dialog"
+        aria-labelledby="explorer-overwrite-title"
+        className="w-full max-w-sm rounded-xl bg-bg-overlay border border-border shadow-[var(--shadow-lg)] flex flex-col animate-in fade-in slide-in-from-top-2 duration-[var(--duration-base)]"
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 pt-5 pb-4 border-b border-border shrink-0">
+          <div className="flex items-center gap-2.5">
+            <div className="flex items-center justify-center w-7 h-7 rounded-md shrink-0 bg-status-error/10">
+              <AlertTriangle size={15} strokeWidth={1.8} className="text-status-error" aria-hidden="true" />
+            </div>
+            <h2 id="explorer-overwrite-title" className="text-[length:var(--text-lg)] font-semibold text-text-primary">
+              {count === 1 ? "Overwrite item?" : `Overwrite ${count} items?`}
+            </h2>
+          </div>
+          <button
+            type="button"
+            onClick={onCancel}
+            aria-label="Close"
+            className="p-1.5 rounded-md text-text-muted hover:text-text-primary hover:bg-bg-subtle transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <X size={14} strokeWidth={1.8} aria-hidden="true" />
+          </button>
+        </div>
 
-        <div className="flex justify-end gap-2">
+        {/* Body */}
+        <div className="px-6 py-4 flex flex-col gap-3">
+          <p className="text-[length:var(--text-sm)] text-text-secondary">
+            {count === 1 ? (
+              <><span className="font-mono text-text-primary">{conflicts[0]}</span> already exists here.</>
+            ) : (
+              <>{count} items already exist here.</>
+            )}
+          </p>
+          {count > 1 && (
+            <ul className="max-h-32 overflow-y-auto rounded-md bg-bg-base border border-border/60 p-2 flex flex-col gap-0.5">
+              {conflicts.map((n) => (
+                <li key={n} className="font-mono text-[length:var(--text-2xs)] text-text-secondary truncate">
+                  {n}
+                </li>
+              ))}
+            </ul>
+          )}
+          <p className="text-[length:var(--text-2xs)] text-text-muted">
+            Files are replaced; folders are merged, replacing only same-named files inside.
+          </p>
+          <p className="font-mono text-[length:var(--text-2xs)] text-text-muted truncate">{targetDir}</p>
+        </div>
+
+        {/* Footer */}
+        <div className="px-6 pb-5 pt-3 flex items-center justify-end gap-2 border-t border-border shrink-0">
           <button
             ref={cancelRef}
             data-testid="explorer-overwrite-cancel"
+            type="button"
             onClick={onCancel}
-            className="px-4 py-2 text-[length:var(--text-sm)] text-text-secondary hover:text-text-primary rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            className="px-4 py-2 text-[length:var(--text-sm)] font-medium text-text-secondary hover:text-text-primary rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
             Cancel
           </button>
           <button
             data-testid="explorer-overwrite-confirm-button"
+            type="button"
             onClick={onConfirm}
-            className="px-4 py-2 text-[length:var(--text-sm)] font-medium text-white bg-accent hover:opacity-90 rounded-lg transition-[opacity] duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            className="px-4 py-2 text-[length:var(--text-sm)] font-medium text-text-inverse bg-accent hover:bg-accent-hover rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
             {count === 1 ? "Overwrite" : `Overwrite ${count}`}
           </button>

--- a/src/components/shared/ConfirmDangerDialog.tsx
+++ b/src/components/shared/ConfirmDangerDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, useRef, useState } from "react";
+import { useEffect, useId } from "react";
 import { AlertTriangle, X } from "lucide-react";
 
 interface ConfirmDangerDialogProps {
@@ -23,61 +23,35 @@ export function ConfirmDangerDialog({
   onCancel,
 }: ConfirmDangerDialogProps) {
   const titleId = useId();
-  const [visible, setVisible] = useState(false);
-  const cancelRef = useRef<HTMLButtonElement>(null);
-  const backdropRef = useRef<HTMLDivElement>(null);
 
-  // Drive the entrance animation separately from open so the panel
-  // fades/slides in after the backdrop is painted.
+  // Escape closes the dialog — document listener matches GroupDeleteDialog and
+  // HostEditModal so it fires regardless of which element has focus.
   useEffect(() => {
-    if (open) {
-      requestAnimationFrame(() => setVisible(true));
-    } else {
-      setVisible(false);
-    }
-  }, [open]);
-
-  // Focus the Cancel button once the panel is visible.
-  useEffect(() => {
-    if (visible) requestAnimationFrame(() => cancelRef.current?.focus());
-  }, [visible]);
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && !busy) {
+        e.stopPropagation();
+        onCancel();
+      }
+    };
+    document.addEventListener("keydown", handler, true);
+    return () => document.removeEventListener("keydown", handler, true);
+  }, [open, busy, onCancel]);
 
   if (!open) return null;
 
-  const handleBackdropClick = (e: React.MouseEvent) => {
-    if (e.target === backdropRef.current && !busy) onCancel();
-  };
-
-  // Keyboard: Escape cancels; Enter inside the form submits (handled by onSubmit).
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === "Escape" && !busy) {
-      e.stopPropagation();
-      onCancel();
-    }
-  };
-
   return (
     <div
-      ref={backdropRef}
-      onClick={handleBackdropClick}
-      className={[
-        "fixed inset-0 z-50 flex items-start justify-center pt-[8vh]",
-        "transition-[background-color,backdrop-filter] duration-[var(--duration-base)]",
-        visible ? "bg-black/50 backdrop-blur-sm" : "bg-black/0 backdrop-blur-none",
-      ].join(" ")}
+      className="fixed inset-0 z-50 flex items-start justify-center pt-[8vh] bg-black/50 backdrop-blur-sm"
+      onClick={(e) => { if (e.target === e.currentTarget && !busy) onCancel(); }}
     >
+      {/* Wrap in a form so Enter on the focused Confirm button submits naturally */}
       <form
         onSubmit={(e) => { e.preventDefault(); if (!busy) onConfirm(); }}
-        onKeyDown={handleKeyDown}
         aria-modal="true"
         role="dialog"
         aria-labelledby={titleId}
-        className={[
-          "w-full max-w-sm rounded-xl bg-bg-overlay border border-border shadow-[var(--shadow-lg)]",
-          "flex flex-col",
-          "transition-[opacity,transform] duration-[var(--duration-slow)] ease-[var(--ease-expo-out)]",
-          visible ? "opacity-100 translate-y-0" : "opacity-0 -translate-y-3",
-        ].join(" ")}
+        className="w-full max-w-sm rounded-xl bg-bg-overlay border border-border shadow-[var(--shadow-lg)] flex flex-col animate-in fade-in slide-in-from-top-2 duration-[var(--duration-base)]"
       >
         {/* Header */}
         <div className="flex items-center justify-between px-6 pt-5 pb-4 border-b border-border shrink-0">
@@ -85,7 +59,7 @@ export function ConfirmDangerDialog({
             <div className="flex items-center justify-center w-7 h-7 rounded-md shrink-0 bg-status-error/10">
               <AlertTriangle size={15} strokeWidth={1.8} className="text-status-error" aria-hidden="true" />
             </div>
-            <h2 id={titleId} className="text-[length:var(--text-base)] font-semibold text-text-primary">
+            <h2 id={titleId} className="text-[length:var(--text-lg)] font-semibold text-text-primary">
               {title}
             </h2>
           </div>
@@ -108,7 +82,10 @@ export function ConfirmDangerDialog({
         {/* Footer */}
         <div className="px-6 pb-5 pt-3 flex items-center justify-end gap-2 border-t border-border shrink-0">
           <button
-            ref={cancelRef}
+            // autoFocus lands on Cancel (the safe default) synchronously on mount.
+            // This is more reliable than a requestAnimationFrame focus() call.
+            // eslint-disable-next-line jsx-a11y/no-autofocus
+            autoFocus
             type="button"
             onClick={onCancel}
             disabled={busy}

--- a/src/components/shared/ConfirmDangerDialog.tsx
+++ b/src/components/shared/ConfirmDangerDialog.tsx
@@ -80,7 +80,7 @@ export function ConfirmDangerDialog({
         </div>
 
         {/* Footer */}
-        <div className="px-6 pb-5 pt-3 flex items-center justify-end gap-2 border-t border-border shrink-0">
+        <div className="px-6 py-3 flex items-center justify-end gap-2 border-t border-border shrink-0">
           <button
             // autoFocus lands on Cancel (the safe default) synchronously on mount.
             // This is more reliable than a requestAnimationFrame focus() call.
@@ -90,7 +90,7 @@ export function ConfirmDangerDialog({
             onClick={onCancel}
             disabled={busy}
             className={[
-              "px-4 py-2 rounded-lg text-[length:var(--text-sm)] font-medium",
+              "px-4 py-1.5 rounded-lg text-[length:var(--text-sm)] font-medium",
               "text-text-secondary hover:text-text-primary",
               "transition-colors duration-[var(--duration-fast)]",
               "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
@@ -103,7 +103,7 @@ export function ConfirmDangerDialog({
             type="submit"
             disabled={busy}
             className={[
-              "px-4 py-2 rounded-lg text-[length:var(--text-sm)] font-medium",
+              "px-4 py-1.5 rounded-lg text-[length:var(--text-sm)] font-medium",
               "bg-status-error text-text-inverse",
               "hover:opacity-90 active:opacity-80",
               "transition-opacity duration-[var(--duration-fast)]",

--- a/src/components/shared/ConfirmDangerDialog.tsx
+++ b/src/components/shared/ConfirmDangerDialog.tsx
@@ -1,0 +1,77 @@
+import { AlertTriangle } from "lucide-react";
+
+interface ConfirmDangerDialogProps {
+  open: boolean;
+  title: string;
+  message: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  busy?: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function ConfirmDangerDialog({
+  open,
+  title,
+  message,
+  confirmLabel = "Confirm",
+  cancelLabel = "Cancel",
+  busy = false,
+  onConfirm,
+  onCancel,
+}: ConfirmDangerDialogProps) {
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center" aria-modal="true" role="dialog" aria-labelledby="confirm-danger-title">
+      <div
+        className="absolute inset-0 bg-bg-base/70 backdrop-blur-sm"
+        onClick={onCancel}
+        aria-hidden="true"
+      />
+      <div className="relative z-10 w-full max-w-sm mx-4 p-6 rounded-xl bg-bg-surface border border-border shadow-[var(--shadow-lg)]">
+        <div className="flex items-start gap-3 mb-4">
+          <div className="flex items-center justify-center w-9 h-9 rounded-lg shrink-0 bg-status-error/10">
+            <AlertTriangle size={18} strokeWidth={1.8} className="text-status-error" aria-hidden="true" />
+          </div>
+          <div>
+            <h2 id="confirm-danger-title" className="text-[length:var(--text-sm)] font-semibold text-text-primary">
+              {title}
+            </h2>
+            <p className="text-[length:var(--text-xs)] text-text-muted mt-1">{message}</p>
+          </div>
+        </div>
+
+        <div className="flex gap-2 justify-end">
+          <button
+            onClick={onCancel}
+            className={[
+              "px-4 py-1.5 rounded-lg text-[length:var(--text-sm)] font-medium",
+              "text-text-secondary bg-bg-overlay border border-border",
+              "hover:text-text-primary hover:border-border-focus hover:bg-bg-subtle",
+              "transition-all duration-[var(--duration-fast)]",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+            ].join(" ")}
+          >
+            {cancelLabel}
+          </button>
+          <button
+            onClick={onConfirm}
+            disabled={busy}
+            className={[
+              "px-4 py-1.5 rounded-lg text-[length:var(--text-sm)] font-medium",
+              "bg-status-error text-text-inverse",
+              "hover:opacity-90 active:opacity-80",
+              "transition-opacity duration-[var(--duration-fast)]",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+              "disabled:opacity-50 disabled:pointer-events-none",
+            ].join(" ")}
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/shared/ConfirmDangerDialog.tsx
+++ b/src/components/shared/ConfirmDangerDialog.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useId } from "react";
-import { AlertTriangle, X } from "lucide-react";
+import { AlertTriangle } from "lucide-react";
+import { ModalShell, BTN_GHOST, BTN_DANGER } from "./ModalShell";
 
 interface ConfirmDangerDialogProps {
   open: boolean;
@@ -22,99 +22,28 @@ export function ConfirmDangerDialog({
   onConfirm,
   onCancel,
 }: ConfirmDangerDialogProps) {
-  const titleId = useId();
-
-  // Escape closes the dialog — document listener matches GroupDeleteDialog and
-  // HostEditModal so it fires regardless of which element has focus.
-  useEffect(() => {
-    if (!open) return;
-    const handler = (e: KeyboardEvent) => {
-      if (e.key === "Escape" && !busy) {
-        e.stopPropagation();
-        onCancel();
-      }
-    };
-    document.addEventListener("keydown", handler, true);
-    return () => document.removeEventListener("keydown", handler, true);
-  }, [open, busy, onCancel]);
-
-  if (!open) return null;
-
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-start justify-center pt-[8vh] bg-black/50 backdrop-blur-sm"
-      onClick={(e) => { if (e.target === e.currentTarget && !busy) onCancel(); }}
-    >
-      {/* Wrap in a form so Enter on the focused Confirm button submits naturally */}
-      <form
-        onSubmit={(e) => { e.preventDefault(); if (!busy) onConfirm(); }}
-        aria-modal="true"
-        role="dialog"
-        aria-labelledby={titleId}
-        className="w-full max-w-sm rounded-xl bg-bg-overlay border border-border shadow-[var(--shadow-lg)] flex flex-col animate-in fade-in slide-in-from-top-2 duration-[var(--duration-base)]"
-      >
-        {/* Header */}
-        <div className="flex items-center justify-between px-6 pt-5 pb-4 border-b border-border shrink-0">
-          <div className="flex items-center gap-2.5">
-            <div className="flex items-center justify-center w-7 h-7 rounded-md shrink-0 bg-status-error/10">
-              <AlertTriangle size={15} strokeWidth={1.8} className="text-status-error" aria-hidden="true" />
-            </div>
-            <h2 id={titleId} className="text-[length:var(--text-lg)] font-semibold text-text-primary">
-              {title}
-            </h2>
-          </div>
-          <button
-            type="button"
-            onClick={onCancel}
-            disabled={busy}
-            aria-label="Close"
-            className="p-1.5 rounded-md text-text-muted hover:text-text-primary hover:bg-bg-subtle transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
-          >
-            <X size={14} strokeWidth={1.8} aria-hidden="true" />
-          </button>
-        </div>
-
-        {/* Body */}
-        <div className="px-6 py-4">
-          <p className="text-[length:var(--text-sm)] text-text-secondary">{message}</p>
-        </div>
-
-        {/* Footer */}
-        <div className="px-6 py-3 flex items-center justify-end gap-2 border-t border-border shrink-0">
-          <button
-            // autoFocus lands on Cancel (the safe default) synchronously on mount.
-            // This is more reliable than a requestAnimationFrame focus() call.
-            // eslint-disable-next-line jsx-a11y/no-autofocus
-            autoFocus
-            type="button"
-            onClick={onCancel}
-            disabled={busy}
-            className={[
-              "px-4 py-1.5 rounded-lg text-[length:var(--text-sm)] font-medium",
-              "text-text-secondary hover:text-text-primary",
-              "transition-colors duration-[var(--duration-fast)]",
-              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-              "disabled:opacity-50 disabled:pointer-events-none",
-            ].join(" ")}
-          >
+    <ModalShell
+      open={open}
+      onClose={onCancel}
+      title={title}
+      icon={AlertTriangle}
+      iconVariant="danger"
+      maxWidth="sm"
+      busy={busy}
+      footer={
+        <>
+          {/* eslint-disable-next-line jsx-a11y/no-autofocus */}
+          <button autoFocus type="button" onClick={onCancel} disabled={busy} className={BTN_GHOST}>
             {cancelLabel}
           </button>
-          <button
-            type="submit"
-            disabled={busy}
-            className={[
-              "px-4 py-1.5 rounded-lg text-[length:var(--text-sm)] font-medium",
-              "bg-status-error text-text-inverse",
-              "hover:opacity-90 active:opacity-80",
-              "transition-opacity duration-[var(--duration-fast)]",
-              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-              "disabled:opacity-50 disabled:pointer-events-none",
-            ].join(" ")}
-          >
+          <button type="button" onClick={onConfirm} disabled={busy} className={BTN_DANGER}>
             {busy ? "Deleting…" : confirmLabel}
           </button>
-        </div>
-      </form>
-    </div>
+        </>
+      }
+    >
+      <p className="text-[length:var(--text-sm)] text-text-secondary">{message}</p>
+    </ModalShell>
   );
 }

--- a/src/components/shared/ConfirmDangerDialog.tsx
+++ b/src/components/shared/ConfirmDangerDialog.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useId, useRef } from "react";
 import { AlertTriangle } from "lucide-react";
 
 interface ConfirmDangerDialogProps {
@@ -21,13 +22,34 @@ export function ConfirmDangerDialog({
   onConfirm,
   onCancel,
 }: ConfirmDangerDialogProps) {
+  const titleId = useId();
+  const cancelRef = useRef<HTMLButtonElement>(null);
+
+  // Focus the Cancel button on open — safe default prevents accidental confirm.
+  useEffect(() => {
+    if (open) cancelRef.current?.focus();
+  }, [open]);
+
+  // Close on Escape (capture phase, consistent with GroupDeleteDialog).
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && !busy) {
+        e.stopPropagation();
+        onCancel();
+      }
+    };
+    document.addEventListener("keydown", handler, true);
+    return () => document.removeEventListener("keydown", handler, true);
+  }, [open, busy, onCancel]);
+
   if (!open) return null;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center" aria-modal="true" role="dialog" aria-labelledby="confirm-danger-title">
+    <div className="fixed inset-0 z-50 flex items-center justify-center" aria-modal="true" role="dialog" aria-labelledby={titleId}>
       <div
         className="absolute inset-0 bg-bg-base/70 backdrop-blur-sm"
-        onClick={onCancel}
+        onClick={() => { if (!busy) onCancel(); }}
         aria-hidden="true"
       />
       <div className="relative z-10 w-full max-w-sm mx-4 p-6 rounded-xl bg-bg-surface border border-border shadow-[var(--shadow-lg)]">
@@ -36,7 +58,7 @@ export function ConfirmDangerDialog({
             <AlertTriangle size={18} strokeWidth={1.8} className="text-status-error" aria-hidden="true" />
           </div>
           <div>
-            <h2 id="confirm-danger-title" className="text-[length:var(--text-sm)] font-semibold text-text-primary">
+            <h2 id={titleId} className="text-[length:var(--text-sm)] font-semibold text-text-primary">
               {title}
             </h2>
             <p className="text-[length:var(--text-xs)] text-text-muted mt-1">{message}</p>
@@ -45,13 +67,16 @@ export function ConfirmDangerDialog({
 
         <div className="flex gap-2 justify-end">
           <button
+            ref={cancelRef}
             onClick={onCancel}
+            disabled={busy}
             className={[
               "px-4 py-1.5 rounded-lg text-[length:var(--text-sm)] font-medium",
               "text-text-secondary bg-bg-overlay border border-border",
               "hover:text-text-primary hover:border-border-focus hover:bg-bg-subtle",
               "transition-all duration-[var(--duration-fast)]",
               "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+              "disabled:opacity-50 disabled:pointer-events-none",
             ].join(" ")}
           >
             {cancelLabel}

--- a/src/components/shared/ConfirmDangerDialog.tsx
+++ b/src/components/shared/ConfirmDangerDialog.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useId, useRef } from "react";
-import { AlertTriangle } from "lucide-react";
+import { useEffect, useId, useRef, useState } from "react";
+import { AlertTriangle, X } from "lucide-react";
 
 interface ConfirmDangerDialogProps {
   open: boolean;
@@ -23,58 +23,99 @@ export function ConfirmDangerDialog({
   onCancel,
 }: ConfirmDangerDialogProps) {
   const titleId = useId();
+  const [visible, setVisible] = useState(false);
   const cancelRef = useRef<HTMLButtonElement>(null);
+  const backdropRef = useRef<HTMLDivElement>(null);
 
-  // Focus the Cancel button on open — safe default prevents accidental confirm.
+  // Drive the entrance animation separately from open so the panel
+  // fades/slides in after the backdrop is painted.
   useEffect(() => {
-    if (open) cancelRef.current?.focus();
+    if (open) {
+      requestAnimationFrame(() => setVisible(true));
+    } else {
+      setVisible(false);
+    }
   }, [open]);
 
-  // Close on Escape (capture phase, consistent with GroupDeleteDialog).
+  // Focus the Cancel button once the panel is visible.
   useEffect(() => {
-    if (!open) return;
-    const handler = (e: KeyboardEvent) => {
-      if (e.key === "Escape" && !busy) {
-        e.stopPropagation();
-        onCancel();
-      }
-    };
-    document.addEventListener("keydown", handler, true);
-    return () => document.removeEventListener("keydown", handler, true);
-  }, [open, busy, onCancel]);
+    if (visible) requestAnimationFrame(() => cancelRef.current?.focus());
+  }, [visible]);
 
   if (!open) return null;
 
+  const handleBackdropClick = (e: React.MouseEvent) => {
+    if (e.target === backdropRef.current && !busy) onCancel();
+  };
+
+  // Keyboard: Escape cancels; Enter inside the form submits (handled by onSubmit).
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Escape" && !busy) {
+      e.stopPropagation();
+      onCancel();
+    }
+  };
+
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center" aria-modal="true" role="dialog" aria-labelledby={titleId}>
-      <div
-        className="absolute inset-0 bg-bg-base/70 backdrop-blur-sm"
-        onClick={() => { if (!busy) onCancel(); }}
-        aria-hidden="true"
-      />
-      <div className="relative z-10 w-full max-w-sm mx-4 p-6 rounded-xl bg-bg-surface border border-border shadow-[var(--shadow-lg)]">
-        <div className="flex items-start gap-3 mb-4">
-          <div className="flex items-center justify-center w-9 h-9 rounded-lg shrink-0 bg-status-error/10">
-            <AlertTriangle size={18} strokeWidth={1.8} className="text-status-error" aria-hidden="true" />
-          </div>
-          <div>
-            <h2 id={titleId} className="text-[length:var(--text-sm)] font-semibold text-text-primary">
+    <div
+      ref={backdropRef}
+      onClick={handleBackdropClick}
+      className={[
+        "fixed inset-0 z-50 flex items-start justify-center pt-[8vh]",
+        "transition-[background-color,backdrop-filter] duration-[var(--duration-base)]",
+        visible ? "bg-black/50 backdrop-blur-sm" : "bg-black/0 backdrop-blur-none",
+      ].join(" ")}
+    >
+      <form
+        onSubmit={(e) => { e.preventDefault(); if (!busy) onConfirm(); }}
+        onKeyDown={handleKeyDown}
+        aria-modal="true"
+        role="dialog"
+        aria-labelledby={titleId}
+        className={[
+          "w-full max-w-sm rounded-xl bg-bg-overlay border border-border shadow-[var(--shadow-lg)]",
+          "flex flex-col",
+          "transition-[opacity,transform] duration-[var(--duration-slow)] ease-[var(--ease-expo-out)]",
+          visible ? "opacity-100 translate-y-0" : "opacity-0 -translate-y-3",
+        ].join(" ")}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 pt-5 pb-4 border-b border-border shrink-0">
+          <div className="flex items-center gap-2.5">
+            <div className="flex items-center justify-center w-7 h-7 rounded-md shrink-0 bg-status-error/10">
+              <AlertTriangle size={15} strokeWidth={1.8} className="text-status-error" aria-hidden="true" />
+            </div>
+            <h2 id={titleId} className="text-[length:var(--text-base)] font-semibold text-text-primary">
               {title}
             </h2>
-            <p className="text-[length:var(--text-xs)] text-text-muted mt-1">{message}</p>
           </div>
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={busy}
+            aria-label="Close"
+            className="p-1.5 rounded-md text-text-muted hover:text-text-primary hover:bg-bg-subtle transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
+          >
+            <X size={14} strokeWidth={1.8} aria-hidden="true" />
+          </button>
         </div>
 
-        <div className="flex gap-2 justify-end">
+        {/* Body */}
+        <div className="px-6 py-4">
+          <p className="text-[length:var(--text-sm)] text-text-secondary">{message}</p>
+        </div>
+
+        {/* Footer */}
+        <div className="px-6 pb-5 pt-3 flex items-center justify-end gap-2 border-t border-border shrink-0">
           <button
             ref={cancelRef}
+            type="button"
             onClick={onCancel}
             disabled={busy}
             className={[
-              "px-4 py-1.5 rounded-lg text-[length:var(--text-sm)] font-medium",
-              "text-text-secondary bg-bg-overlay border border-border",
-              "hover:text-text-primary hover:border-border-focus hover:bg-bg-subtle",
-              "transition-all duration-[var(--duration-fast)]",
+              "px-4 py-2 rounded-lg text-[length:var(--text-sm)] font-medium",
+              "text-text-secondary hover:text-text-primary",
+              "transition-colors duration-[var(--duration-fast)]",
               "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
               "disabled:opacity-50 disabled:pointer-events-none",
             ].join(" ")}
@@ -82,10 +123,10 @@ export function ConfirmDangerDialog({
             {cancelLabel}
           </button>
           <button
-            onClick={onConfirm}
+            type="submit"
             disabled={busy}
             className={[
-              "px-4 py-1.5 rounded-lg text-[length:var(--text-sm)] font-medium",
+              "px-4 py-2 rounded-lg text-[length:var(--text-sm)] font-medium",
               "bg-status-error text-text-inverse",
               "hover:opacity-90 active:opacity-80",
               "transition-opacity duration-[var(--duration-fast)]",
@@ -93,10 +134,10 @@ export function ConfirmDangerDialog({
               "disabled:opacity-50 disabled:pointer-events-none",
             ].join(" ")}
           >
-            {confirmLabel}
+            {busy ? "Deleting…" : confirmLabel}
           </button>
         </div>
-      </div>
+      </form>
     </div>
   );
 }

--- a/src/components/shared/ModalShell.tsx
+++ b/src/components/shared/ModalShell.tsx
@@ -1,0 +1,192 @@
+import { useState, useEffect, useRef, useId } from "react";
+import { X } from "lucide-react";
+
+// ─── Shared button styles ─────────────────────────────────────────────────────
+// Import these in any modal footer so every button looks identical.
+
+export const BTN_GHOST =
+  "px-4 py-1.5 text-[length:var(--text-sm)] font-medium text-text-secondary hover:text-text-primary rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50";
+
+export const BTN_SECONDARY =
+  "px-4 py-1.5 text-[length:var(--text-sm)] font-medium text-text-secondary hover:text-text-primary bg-bg-subtle hover:bg-bg-muted border border-border disabled:opacity-50 rounded-lg transition-all duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring";
+
+export const BTN_PRIMARY =
+  "px-4 py-1.5 text-[length:var(--text-sm)] font-medium text-text-inverse bg-accent hover:bg-accent-hover disabled:opacity-50 rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-bg-overlay";
+
+export const BTN_DANGER =
+  "px-4 py-1.5 text-[length:var(--text-sm)] font-medium text-text-inverse bg-status-error hover:opacity-90 active:opacity-80 disabled:opacity-50 rounded-lg transition-opacity duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring";
+
+// ─── ModalShell ───────────────────────────────────────────────────────────────
+
+const MAX_W: Record<NonNullable<ModalShellProps["maxWidth"]>, string> = {
+  sm: "max-w-sm",
+  md: "max-w-md",
+  lg: "max-w-lg",
+  xl: "max-w-xl",
+};
+
+export interface ModalShellProps {
+  open: boolean;
+  onClose: () => void;
+  title: string;
+  /** Optional subtitle line below the title (e.g. snippet command preview). */
+  subtitle?: string;
+  /**
+   * Standard Lucide icon component. Rendered at size=16 inside a rounded
+   * accent-tinted container. Use `iconVariant="danger"` for error-red icons.
+   */
+  icon?: React.ElementType;
+  /** Color scheme for the built-in icon container. Defaults to "accent". */
+  iconVariant?: "accent" | "danger";
+  /**
+   * Fully custom icon node — replaces the built-in icon container entirely.
+   * Use this when the icon has a dynamic/user-chosen color (e.g. GroupModal).
+   */
+  iconNode?: React.ReactNode;
+  /** Panel max-width. Defaults to "lg". */
+  maxWidth?: "sm" | "md" | "lg" | "xl";
+  /** Adds overflow-y-auto + flex-1 + min-h-0 to the body and max-h-[84vh] to the panel. */
+  scrollable?: boolean;
+  /** Prevents backdrop click and Escape from closing the dialog. */
+  busy?: boolean;
+  /**
+   * Right-aligned footer buttons.
+   * Wrap in a fragment: `footer={<><Cancel /><Save /></>}`
+   */
+  footer?: React.ReactNode;
+  /**
+   * Left side of the footer row (e.g. a Delete button).
+   * When provided the footer becomes justify-between.
+   */
+  footerStart?: React.ReactNode;
+  children: React.ReactNode;
+  /** data-testid applied to the panel div. */
+  testId?: string;
+}
+
+export function ModalShell({
+  open,
+  onClose,
+  title,
+  subtitle,
+  icon: Icon,
+  iconVariant = "accent",
+  iconNode,
+  maxWidth = "lg",
+  scrollable = false,
+  busy = false,
+  footer,
+  footerStart,
+  children,
+  testId,
+}: ModalShellProps) {
+  const titleId = useId();
+  const [visible, setVisible] = useState(false);
+  const backdropRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (open) requestAnimationFrame(() => setVisible(true));
+    else setVisible(false);
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && !busy) onClose();
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [open, busy, onClose]);
+
+  if (!open) return null;
+
+  // Icon container — built-in accent/danger, or fully custom.
+  const iconContainer = iconNode ?? (Icon ? (
+    <div className={[
+      "flex items-center justify-center w-8 h-8 rounded-lg shrink-0",
+      iconVariant === "danger" ? "bg-status-error/10" : "bg-accent/10",
+    ].join(" ")}>
+      <Icon
+        size={16}
+        strokeWidth={1.8}
+        className={iconVariant === "danger" ? "text-status-error" : "text-accent"}
+        aria-hidden="true"
+      />
+    </div>
+  ) : null);
+
+  const hasFooter = footer !== undefined || footerStart !== undefined;
+
+  return (
+    <div
+      ref={backdropRef}
+      onClick={(e) => e.target === backdropRef.current && !busy && onClose()}
+      className={[
+        "fixed inset-0 z-50 flex items-start justify-center pt-[8vh]",
+        "transition-[background-color,backdrop-filter] duration-[var(--duration-base)]",
+        visible ? "bg-black/50 backdrop-blur-sm" : "bg-black/0 backdrop-blur-none",
+      ].join(" ")}
+    >
+      <div
+        data-testid={testId}
+        aria-modal="true"
+        role="dialog"
+        aria-labelledby={titleId}
+        className={[
+          `w-full ${MAX_W[maxWidth]} rounded-xl bg-bg-overlay border border-border shadow-[var(--shadow-lg)] flex flex-col`,
+          scrollable ? "max-h-[84vh]" : "",
+          "transition-[opacity,transform] duration-[var(--duration-slow)] ease-[var(--ease-expo-out)]",
+          visible ? "opacity-100 translate-y-0" : "opacity-0 -translate-y-3",
+        ].join(" ")}
+      >
+        {/* ── Header ── */}
+        <div className="flex items-center justify-between px-6 pt-5 pb-4 border-b border-border shrink-0">
+          <div className="flex items-center gap-3 min-w-0">
+            {iconContainer}
+            <div className="min-w-0">
+              <h2
+                id={titleId}
+                className="text-[length:var(--text-lg)] font-semibold text-text-primary truncate"
+              >
+                {title}
+              </h2>
+              {subtitle && (
+                <p className="text-[length:var(--text-xs)] text-text-muted mt-0.5 font-mono truncate">
+                  {subtitle}
+                </p>
+              )}
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={busy}
+            aria-label="Close"
+            className="ml-3 p-1.5 rounded-md text-text-muted hover:text-text-primary hover:bg-bg-subtle transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50 shrink-0"
+          >
+            <X size={14} strokeWidth={1.8} aria-hidden="true" />
+          </button>
+        </div>
+
+        {/* ── Body ── */}
+        <div className={[
+          "px-6 py-4",
+          scrollable ? "overflow-y-auto flex-1 min-h-0" : "",
+        ].join(" ")}>
+          {children}
+        </div>
+
+        {/* ── Footer ── */}
+        {hasFooter && (
+          <div className={[
+            "px-6 py-3 flex items-center gap-2 border-t border-border shrink-0",
+            footerStart ? "justify-between" : "justify-end",
+          ].join(" ")}>
+            {footerStart && <div>{footerStart}</div>}
+            <div className="flex items-center gap-2">{footer}</div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/snippets/SnippetCard.tsx
+++ b/src/components/snippets/SnippetCard.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Pencil, Copy, Trash2, AlertTriangle } from "lucide-react";
 import type { Snippet } from "../../types";
 import { ContextMenu } from "../shared/ContextMenu";
+import { ConfirmDangerDialog } from "../shared/ConfirmDangerDialog";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -52,6 +53,7 @@ interface SnippetCardProps {
 
 export function SnippetCard({ snippet, onEdit, onDelete, onDuplicate }: SnippetCardProps) {
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number } | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState(false);
 
   const handleContextMenu = (e: React.MouseEvent) => {
     e.preventDefault();
@@ -78,7 +80,7 @@ export function SnippetCard({ snippet, onEdit, onDelete, onDuplicate }: SnippetC
       label: "Delete",
       icon: Trash2,
       danger: true,
-      onClick: () => onDelete(snippet.id),
+      onClick: () => setConfirmDelete(true),
     },
   ];
 
@@ -170,6 +172,17 @@ export function SnippetCard({ snippet, onEdit, onDelete, onDuplicate }: SnippetC
           onClose={() => setContextMenu(null)}
         />
       )}
+
+      <ConfirmDangerDialog
+        open={confirmDelete}
+        title="Delete this snippet?"
+        message="This snippet will be permanently removed."
+        onCancel={() => setConfirmDelete(false)}
+        onConfirm={() => {
+          setConfirmDelete(false);
+          onDelete(snippet.id);
+        }}
+      />
     </>
   );
 }

--- a/src/components/snippets/SnippetEditModal.tsx
+++ b/src/components/snippets/SnippetEditModal.tsx
@@ -300,15 +300,10 @@ export function SnippetEditModal({
             type="button"
             onClick={onClose}
             disabled={saving}
-            className={[
-              "flex items-center justify-center w-7 h-7 rounded-md",
-              "text-text-muted hover:text-text-primary hover:bg-bg-subtle",
-              "transition-colors duration-[var(--duration-fast)]",
-              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-            ].join(" ")}
             aria-label="Close"
+            className="p-1.5 rounded-md text-text-muted hover:text-text-primary hover:bg-bg-subtle transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
           >
-            <X size={16} strokeWidth={2} aria-hidden="true" />
+            <X size={14} strokeWidth={1.8} aria-hidden="true" />
           </button>
         </div>
 
@@ -463,29 +458,18 @@ export function SnippetEditModal({
         </div>
 
         {/* ── Footer (sticky) ────────────────────────────────────────── */}
-        <div className="px-6 pb-5 pt-3 border-t border-border shrink-0">
-          {/* Error */}
+        <div className="px-6 py-3 border-t border-border shrink-0">
           {error && (
-            <p
-              className="text-[length:var(--text-sm)] text-status-error bg-status-error/10 rounded-lg px-3 py-2 mb-3"
-              role="alert"
-            >
+            <p className="text-[length:var(--text-sm)] text-status-error bg-status-error/10 rounded-lg px-3 py-2 mb-3" role="alert">
               {error}
             </p>
           )}
-
           <div className="flex justify-end gap-2">
             <button
               type="button"
               onClick={onClose}
               disabled={saving}
-              className={[
-                "px-4 py-2 text-[length:var(--text-sm)] text-text-secondary",
-                "hover:text-text-primary rounded-lg",
-                "disabled:opacity-50 disabled:cursor-not-allowed",
-                "transition-colors duration-[var(--duration-fast)]",
-                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-              ].join(" ")}
+              className="px-4 py-1.5 text-[length:var(--text-sm)] font-medium text-text-secondary hover:text-text-primary rounded-lg disabled:opacity-50 transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             >
               Cancel
             </button>
@@ -493,7 +477,7 @@ export function SnippetEditModal({
               type="submit"
               data-testid="snippet-modal-save"
               disabled={saving || !form.name.trim() || !form.command.trim()}
-              className="px-4 py-2 text-[length:var(--text-sm)] font-medium text-text-inverse bg-accent hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-bg-overlay"
+              className="px-4 py-1.5 text-[length:var(--text-sm)] font-medium text-text-inverse bg-accent hover:bg-accent-hover disabled:opacity-50 rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-bg-overlay"
             >
               {saving ? "Saving\u2026" : "Save"}
             </button>

--- a/src/components/snippets/SnippetEditModal.tsx
+++ b/src/components/snippets/SnippetEditModal.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from "react";
-import { X } from "lucide-react";
+import { X, Braces } from "lucide-react";
 import type { Snippet, SnippetFolder, SnippetVariable } from "../../types";
 import { extractVariables, parseVariables } from "../../utils/snippet-resolve";
 import { CustomSelect } from "../shared/CustomSelect";
@@ -293,9 +293,14 @@ export function SnippetEditModal({
       >
         {/* ── Header (sticky) ─────────────────────────────────────────── */}
         <div className="flex items-center justify-between px-6 pt-5 pb-4 border-b border-border shrink-0">
-          <h2 className="text-[length:var(--text-lg)] font-semibold text-text-primary">
-            {isEdit ? "Edit Snippet" : "New Snippet"}
-          </h2>
+          <div className="flex items-center gap-3">
+            <div className="flex items-center justify-center w-8 h-8 rounded-lg shrink-0 bg-accent/10">
+              <Braces size={16} strokeWidth={1.8} className="text-accent" aria-hidden="true" />
+            </div>
+            <h2 className="text-[length:var(--text-lg)] font-semibold text-text-primary">
+              {isEdit ? "Edit Snippet" : "New Snippet"}
+            </h2>
+          </div>
           <button
             type="button"
             onClick={onClose}

--- a/src/components/snippets/SnippetEditModal.tsx
+++ b/src/components/snippets/SnippetEditModal.tsx
@@ -1,8 +1,9 @@
 import { useState, useEffect, useRef, useCallback } from "react";
-import { X, Braces } from "lucide-react";
+import { Braces } from "lucide-react";
 import type { Snippet, SnippetFolder, SnippetVariable } from "../../types";
 import { extractVariables, parseVariables } from "../../utils/snippet-resolve";
 import { CustomSelect } from "../shared/CustomSelect";
+import { ModalShell, BTN_GHOST, BTN_PRIMARY } from "../shared/ModalShell";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -175,11 +176,8 @@ export function SnippetEditModal({
   const [variableMeta, setVariableMeta] = useState<SnippetVariable[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
-  const [visible, setVisible] = useState(false);
 
-  const backdropRef = useRef<HTMLDivElement>(null);
   const nameRef = useRef<HTMLInputElement>(null);
-
   const isEdit = !!initial;
 
   // Sync variable metadata whenever command changes
@@ -208,28 +206,9 @@ export function SnippetEditModal({
       syncVariables(base.command, parsed);
       setError(null);
       setSaving(false);
-      requestAnimationFrame(() => setVisible(true));
-    } else {
-      setVisible(false);
+      requestAnimationFrame(() => nameRef.current?.focus());
     }
   }, [open, initial, syncVariables]);
-
-  useEffect(() => {
-    if (visible) requestAnimationFrame(() => nameRef.current?.focus());
-  }, [visible]);
-
-  useEffect(() => {
-    if (!open) return;
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-    };
-    document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [open, onClose]);
-
-  const handleBackdropClick = (e: React.MouseEvent) => {
-    if (e.target === backdropRef.current) onClose();
-  };
 
   const handleCommandChange = (cmd: string) => {
     setForm((f) => ({ ...f, command: cmd }));
@@ -273,48 +252,33 @@ export function SnippetEditModal({
   const labelClass = "block text-[length:var(--text-xs)] font-medium text-text-secondary mb-1.5";
 
   return (
-    <div
-      ref={backdropRef}
-      onClick={handleBackdropClick}
-      className={[
-        "fixed inset-0 z-50 flex items-start justify-center pt-[8vh]",
-        "transition-[background-color,backdrop-filter] duration-[var(--duration-base)]",
-        visible ? "bg-black/50 backdrop-blur-sm" : "bg-black/0 backdrop-blur-none",
-      ].join(" ")}
-    >
-      <div
-        data-testid="snippet-modal"
-        className={[
-          "w-full max-w-xl rounded-xl bg-bg-overlay border border-border shadow-[var(--shadow-lg)]",
-          "flex flex-col max-h-[84vh]",
-          "transition-[opacity,transform] duration-[var(--duration-slow)] ease-[var(--ease-expo-out)]",
-          visible ? "opacity-100 translate-y-0" : "opacity-0 -translate-y-3",
-        ].join(" ")}
-      >
-        {/* ── Header (sticky) ─────────────────────────────────────────── */}
-        <div className="flex items-center justify-between px-6 pt-5 pb-4 border-b border-border shrink-0">
-          <div className="flex items-center gap-3">
-            <div className="flex items-center justify-center w-8 h-8 rounded-lg shrink-0 bg-accent/10">
-              <Braces size={16} strokeWidth={1.8} className="text-accent" aria-hidden="true" />
-            </div>
-            <h2 className="text-[length:var(--text-lg)] font-semibold text-text-primary">
-              {isEdit ? "Edit Snippet" : "New Snippet"}
-            </h2>
-          </div>
-          <button
-            type="button"
-            onClick={onClose}
-            disabled={saving}
-            aria-label="Close"
-            className="p-1.5 rounded-md text-text-muted hover:text-text-primary hover:bg-bg-subtle transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
-          >
-            <X size={14} strokeWidth={1.8} aria-hidden="true" />
+    <ModalShell
+      open={open}
+      onClose={onClose}
+      title={isEdit ? "Edit Snippet" : "New Snippet"}
+      icon={Braces}
+      maxWidth="xl"
+      scrollable
+      busy={saving}
+      testId="snippet-modal"
+      footer={
+        <>
+          <button type="button" onClick={onClose} disabled={saving} className={BTN_GHOST}>
+            Cancel
           </button>
-        </div>
-
-        <form onSubmit={handleSave} className="flex flex-col flex-1 min-h-0">
-        {/* ── Scrollable body ───────────────────────────────────────── */}
-        <div className="flex flex-col gap-5 px-6 py-4 overflow-y-auto flex-1 min-h-0">
+          <button
+            form="snippet-edit-form"
+            type="submit"
+            data-testid="snippet-modal-save"
+            disabled={saving || !form.name.trim() || !form.command.trim()}
+            className={BTN_PRIMARY}
+          >
+            {saving ? "Saving…" : "Save"}
+          </button>
+        </>
+      }
+    >
+      <form id="snippet-edit-form" onSubmit={handleSave} className="flex flex-col gap-5">
           {/* Name */}
           <div>
             <label className={labelClass}>
@@ -460,36 +424,13 @@ export function SnippetEditModal({
             </div>
           )}
 
-        </div>
 
-        {/* ── Footer (sticky) ────────────────────────────────────────── */}
-        <div className="px-6 py-3 border-t border-border shrink-0">
-          {error && (
-            <p className="text-[length:var(--text-sm)] text-status-error bg-status-error/10 rounded-lg px-3 py-2 mb-3" role="alert">
-              {error}
-            </p>
-          )}
-          <div className="flex justify-end gap-2">
-            <button
-              type="button"
-              onClick={onClose}
-              disabled={saving}
-              className="px-4 py-1.5 text-[length:var(--text-sm)] font-medium text-text-secondary hover:text-text-primary rounded-lg disabled:opacity-50 transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-            >
-              Cancel
-            </button>
-            <button
-              type="submit"
-              data-testid="snippet-modal-save"
-              disabled={saving || !form.name.trim() || !form.command.trim()}
-              className="px-4 py-1.5 text-[length:var(--text-sm)] font-medium text-text-inverse bg-accent hover:bg-accent-hover disabled:opacity-50 rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-bg-overlay"
-            >
-              {saving ? "Saving\u2026" : "Save"}
-            </button>
-          </div>
-        </div>
-        </form>
-      </div>
-    </div>
+        {error && (
+          <p className="text-[length:var(--text-sm)] text-status-error bg-status-error/10 rounded-lg px-3 py-2" role="alert">
+            {error}
+          </p>
+        )}
+      </form>
+    </ModalShell>
   );
 }

--- a/src/components/snippets/SnippetFolderCard.tsx
+++ b/src/components/snippets/SnippetFolderCard.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Folder, Trash2 } from "lucide-react";
 import type { SnippetFolder } from "../../types";
 import { ContextMenu } from "../shared/ContextMenu";
+import { ConfirmDangerDialog } from "../shared/ConfirmDangerDialog";
 
 // ─── Folder colors ────────────────────────────────────────────────────────────
 
@@ -23,6 +24,7 @@ export function SnippetFolderCard({
   onDelete,
 }: SnippetFolderCardProps) {
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number } | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState(false);
 
   const handleContextMenu = (e: React.MouseEvent) => {
     e.preventDefault();
@@ -35,7 +37,7 @@ export function SnippetFolderCard({
       label: "Delete Folder",
       icon: Trash2,
       danger: true,
-      onClick: () => onDelete(folder.id),
+      onClick: () => setConfirmDelete(true),
     },
   ];
 
@@ -88,6 +90,17 @@ export function SnippetFolderCard({
           onClose={() => setContextMenu(null)}
         />
       )}
+
+      <ConfirmDangerDialog
+        open={confirmDelete}
+        title="Delete this folder?"
+        message="This folder will be permanently removed."
+        onCancel={() => setConfirmDelete(false)}
+        onConfirm={() => {
+          setConfirmDelete(false);
+          onDelete(folder.id);
+        }}
+      />
     </>
   );
 }

--- a/src/components/snippets/SnippetFolderModal.tsx
+++ b/src/components/snippets/SnippetFolderModal.tsx
@@ -78,14 +78,7 @@ export function SnippetFolderModal({ open, onClose, onSave }: SnippetFolderModal
       open={open}
       onClose={onClose}
       title="New Folder"
-      iconNode={
-        <div
-          className="flex items-center justify-center w-8 h-8 rounded-lg shrink-0"
-          style={{ backgroundColor: `${color}20` }}
-        >
-          <Folder size={16} strokeWidth={1.8} style={{ color }} aria-hidden="true" />
-        </div>
-      }
+      icon={Folder}
       maxWidth="sm"
       busy={saving}
       footer={

--- a/src/components/snippets/SnippetFolderModal.tsx
+++ b/src/components/snippets/SnippetFolderModal.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from "react";
-import { Folder } from "lucide-react";
+import { Folder, X } from "lucide-react";
 
 // ─── Folder colors ────────────────────────────────────────────────────────────
 
@@ -104,32 +104,45 @@ export function SnippetFolderModal({ open, onClose, onSave }: SnippetFolderModal
       ref={backdropRef}
       onClick={handleBackdropClick}
       className={[
-        "fixed inset-0 z-50 flex items-start justify-center pt-[12vh]",
+        "fixed inset-0 z-50 flex items-start justify-center pt-[8vh]",
         "transition-[background-color,backdrop-filter] duration-[var(--duration-base)]",
         visible ? "bg-black/50 backdrop-blur-sm" : "bg-black/0 backdrop-blur-none",
       ].join(" ")}
     >
-      <div
+      <form
+        onSubmit={handleSubmit}
         className={[
-          "w-full max-w-sm rounded-xl bg-bg-overlay border border-border p-6 shadow-[var(--shadow-lg)]",
+          "w-full max-w-sm rounded-xl bg-bg-overlay border border-border shadow-[var(--shadow-lg)] flex flex-col",
           "transition-[opacity,transform] duration-[var(--duration-slow)] ease-[var(--ease-expo-out)]",
           visible ? "opacity-100 translate-y-0" : "opacity-0 -translate-y-3",
         ].join(" ")}
       >
-        {/* Preview + title */}
-        <div className="flex items-center gap-3 mb-5">
-          <div
-            className="flex items-center justify-center w-10 h-10 rounded-lg shrink-0"
-            style={{ backgroundColor: `${color}20` }}
-          >
-            <Folder size={22} strokeWidth={1.8} style={{ color }} aria-hidden="true" />
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 pt-5 pb-4 border-b border-border shrink-0">
+          <div className="flex items-center gap-3">
+            <div
+              className="flex items-center justify-center w-8 h-8 rounded-lg shrink-0"
+              style={{ backgroundColor: `${color}20` }}
+            >
+              <Folder size={18} strokeWidth={1.8} style={{ color }} aria-hidden="true" />
+            </div>
+            <h2 className="text-[length:var(--text-lg)] font-semibold text-text-primary">
+              New Folder
+            </h2>
           </div>
-          <h2 className="text-[length:var(--text-lg)] font-semibold text-text-primary">
-            New Folder
-          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={saving}
+            aria-label="Close"
+            className="p-1.5 rounded-md text-text-muted hover:text-text-primary hover:bg-bg-subtle transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
+          >
+            <X size={14} strokeWidth={1.8} aria-hidden="true" />
+          </button>
         </div>
 
-        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+        {/* Body */}
+        <div className="px-6 py-5 flex flex-col gap-4">
           {/* Name */}
           <div>
             <label className={labelClass}>
@@ -174,46 +187,31 @@ export function SnippetFolderModal({ open, onClose, onSave }: SnippetFolderModal
 
           {/* Error */}
           {error && (
-            <p
-              className="text-[length:var(--text-sm)] text-status-error bg-status-error/10 rounded-lg px-3 py-2"
-              role="alert"
-            >
+            <p className="text-[length:var(--text-sm)] text-status-error bg-status-error/10 rounded-lg px-3 py-2" role="alert">
               {error}
             </p>
           )}
+        </div>
 
-          {/* Actions */}
-          <div className="flex justify-end gap-2 mt-1">
-            <button
-              type="button"
-              onClick={onClose}
-              disabled={saving}
-              className={[
-                "px-4 py-2 text-[length:var(--text-sm)] text-text-secondary",
-                "hover:text-text-primary rounded-lg",
-                "disabled:opacity-50 disabled:cursor-not-allowed",
-                "transition-colors duration-[var(--duration-fast)]",
-                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-              ].join(" ")}
-            >
-              Cancel
-            </button>
-            <button
-              type="submit"
-              disabled={saving || !name.trim()}
-              className={[
-                "px-4 py-2 text-[length:var(--text-sm)] font-medium rounded-lg",
-                "text-text-inverse bg-accent hover:bg-accent-hover",
-                "disabled:opacity-50 disabled:cursor-not-allowed",
-                "transition-colors duration-[var(--duration-fast)]",
-                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-bg-overlay",
-              ].join(" ")}
-            >
-              {saving ? "Creating\u2026" : "Create Folder"}
-            </button>
-          </div>
-        </form>
-      </div>
+        {/* Footer */}
+        <div className="px-6 py-3 flex items-center justify-end gap-2 border-t border-border shrink-0">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={saving}
+            className="px-4 py-1.5 text-[length:var(--text-sm)] font-medium text-text-secondary hover:text-text-primary rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={saving || !name.trim()}
+            className="px-4 py-1.5 text-[length:var(--text-sm)] font-medium text-text-inverse bg-accent hover:bg-accent-hover disabled:opacity-50 rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-bg-overlay"
+          >
+            {saving ? "Creating\u2026" : "Create Folder"}
+          </button>
+        </div>
+      </form>
     </div>
   );
 }

--- a/src/components/snippets/SnippetFolderModal.tsx
+++ b/src/components/snippets/SnippetFolderModal.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from "react";
-import { Folder, X } from "lucide-react";
+import { Folder } from "lucide-react";
+import { ModalShell, BTN_GHOST, BTN_PRIMARY } from "../shared/ModalShell";
 
 // ─── Folder colors ────────────────────────────────────────────────────────────
 
@@ -34,9 +35,6 @@ export function SnippetFolderModal({ open, onClose, onSave }: SnippetFolderModal
   const [color, setColor] = useState(FOLDER_COLORS[0]);
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
-  const [visible, setVisible] = useState(false);
-
-  const backdropRef = useRef<HTMLDivElement>(null);
   const nameRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -45,50 +43,26 @@ export function SnippetFolderModal({ open, onClose, onSave }: SnippetFolderModal
       setColor(FOLDER_COLORS[0]);
       setError(null);
       setSaving(false);
-      requestAnimationFrame(() => setVisible(true));
-    } else {
-      setVisible(false);
+      requestAnimationFrame(() => nameRef.current?.focus());
     }
   }, [open]);
 
-  useEffect(() => {
-    if (visible) requestAnimationFrame(() => nameRef.current?.focus());
-  }, [visible]);
-
-  useEffect(() => {
-    if (!open) return;
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-    };
-    document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [open, onClose]);
-
-  const handleBackdropClick = (e: React.MouseEvent) => {
-    if (e.target === backdropRef.current) onClose();
-  };
-
-  const handleSubmit = useCallback(
-    async (e: React.FormEvent) => {
-      e.preventDefault();
-      if (!name.trim()) { setError("Folder name is required"); return; }
-      setSaving(true);
-      setError(null);
-      try {
-        await onSave({ name: name.trim(), color });
-      } catch (err: unknown) {
-        setError(
-          err && typeof err === "object" && "message" in err
-            ? String((err as { message: string }).message)
-            : "Failed to save folder",
-        );
-        setSaving(false);
-      }
-    },
-    [name, color, onSave],
-  );
-
-  if (!open) return null;
+  const handleSubmit = useCallback(async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim()) { setError("Folder name is required"); return; }
+    setSaving(true);
+    setError(null);
+    try {
+      await onSave({ name: name.trim(), color });
+    } catch (err: unknown) {
+      setError(
+        err && typeof err === "object" && "message" in err
+          ? String((err as { message: string }).message)
+          : "Failed to save folder",
+      );
+      setSaving(false);
+    }
+  }, [name, color, onSave]);
 
   const inputClass = [
     "w-full rounded-lg bg-bg-base border border-border px-3 py-2",
@@ -100,118 +74,83 @@ export function SnippetFolderModal({ open, onClose, onSave }: SnippetFolderModal
   const labelClass = "block text-[length:var(--text-xs)] font-medium text-text-secondary mb-1.5";
 
   return (
-    <div
-      ref={backdropRef}
-      onClick={handleBackdropClick}
-      className={[
-        "fixed inset-0 z-50 flex items-start justify-center pt-[8vh]",
-        "transition-[background-color,backdrop-filter] duration-[var(--duration-base)]",
-        visible ? "bg-black/50 backdrop-blur-sm" : "bg-black/0 backdrop-blur-none",
-      ].join(" ")}
-    >
-      <form
-        onSubmit={handleSubmit}
-        className={[
-          "w-full max-w-sm rounded-xl bg-bg-overlay border border-border shadow-[var(--shadow-lg)] flex flex-col",
-          "transition-[opacity,transform] duration-[var(--duration-slow)] ease-[var(--ease-expo-out)]",
-          visible ? "opacity-100 translate-y-0" : "opacity-0 -translate-y-3",
-        ].join(" ")}
-      >
-        {/* Header */}
-        <div className="flex items-center justify-between px-6 pt-5 pb-4 border-b border-border shrink-0">
-          <div className="flex items-center gap-3">
-            <div
-              className="flex items-center justify-center w-8 h-8 rounded-lg shrink-0"
-              style={{ backgroundColor: `${color}20` }}
-            >
-              <Folder size={18} strokeWidth={1.8} style={{ color }} aria-hidden="true" />
-            </div>
-            <h2 className="text-[length:var(--text-lg)] font-semibold text-text-primary">
-              New Folder
-            </h2>
-          </div>
-          <button
-            type="button"
-            onClick={onClose}
-            disabled={saving}
-            aria-label="Close"
-            className="p-1.5 rounded-md text-text-muted hover:text-text-primary hover:bg-bg-subtle transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
-          >
-            <X size={14} strokeWidth={1.8} aria-hidden="true" />
-          </button>
+    <ModalShell
+      open={open}
+      onClose={onClose}
+      title="New Folder"
+      iconNode={
+        <div
+          className="flex items-center justify-center w-8 h-8 rounded-lg shrink-0"
+          style={{ backgroundColor: `${color}20` }}
+        >
+          <Folder size={16} strokeWidth={1.8} style={{ color }} aria-hidden="true" />
         </div>
-
-        {/* Body */}
-        <div className="px-6 py-5 flex flex-col gap-4">
-          {/* Name */}
-          <div>
-            <label className={labelClass}>
-              Name <span className="text-status-error">*</span>
-            </label>
-            <input
-              ref={nameRef}
-              type="text"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              placeholder="e.g., Web Servers, Docker, Database"
-              disabled={saving}
-              className={inputClass}
-            />
-          </div>
-
-          {/* Color picker */}
-          <div>
-            <span className={labelClass}>Color</span>
-            <div className="flex items-center gap-2 flex-wrap">
-              {FOLDER_COLORS.map((c) => (
-                <button
-                  key={c}
-                  type="button"
-                  onClick={() => setColor(c)}
-                  disabled={saving}
-                  aria-label={`Color ${c}`}
-                  aria-pressed={color === c}
-                  className={[
-                    "w-7 h-7 rounded-full border-2",
-                    "transition-[border-color,box-shadow,transform] duration-[var(--duration-fast)]",
-                    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-bg-overlay",
-                    color === c
-                      ? "border-white ring-2 ring-ring scale-110"
-                      : "border-transparent hover:border-white/60 hover:scale-105",
-                  ].join(" ")}
-                  style={{ backgroundColor: c }}
-                />
-              ))}
-            </div>
-          </div>
-
-          {/* Error */}
-          {error && (
-            <p className="text-[length:var(--text-sm)] text-status-error bg-status-error/10 rounded-lg px-3 py-2" role="alert">
-              {error}
-            </p>
-          )}
-        </div>
-
-        {/* Footer */}
-        <div className="px-6 py-3 flex items-center justify-end gap-2 border-t border-border shrink-0">
-          <button
-            type="button"
-            onClick={onClose}
-            disabled={saving}
-            className="px-4 py-1.5 text-[length:var(--text-sm)] font-medium text-text-secondary hover:text-text-primary rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
-          >
+      }
+      maxWidth="sm"
+      busy={saving}
+      footer={
+        <>
+          <button type="button" onClick={onClose} disabled={saving} className={BTN_GHOST}>
             Cancel
           </button>
           <button
+            form="snippet-folder-form"
             type="submit"
             disabled={saving || !name.trim()}
-            className="px-4 py-1.5 text-[length:var(--text-sm)] font-medium text-text-inverse bg-accent hover:bg-accent-hover disabled:opacity-50 rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-bg-overlay"
+            className={BTN_PRIMARY}
           >
-            {saving ? "Creating\u2026" : "Create Folder"}
+            {saving ? "Creating…" : "Create Folder"}
           </button>
+        </>
+      }
+    >
+      <form id="snippet-folder-form" onSubmit={handleSubmit} className="flex flex-col gap-4">
+        <div>
+          <label className={labelClass}>
+            Name <span className="text-status-error">*</span>
+          </label>
+          <input
+            ref={nameRef}
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="e.g., Web Servers, Docker, Database"
+            disabled={saving}
+            className={inputClass}
+          />
         </div>
+
+        <div>
+          <span className={labelClass}>Color</span>
+          <div className="flex items-center gap-2 flex-wrap">
+            {FOLDER_COLORS.map((c) => (
+              <button
+                key={c}
+                type="button"
+                onClick={() => setColor(c)}
+                disabled={saving}
+                aria-label={`Color ${c}`}
+                aria-pressed={color === c}
+                className={[
+                  "w-7 h-7 rounded-full border-2",
+                  "transition-[border-color,box-shadow,transform] duration-[var(--duration-fast)]",
+                  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-bg-overlay",
+                  color === c
+                    ? "border-white ring-2 ring-ring scale-110"
+                    : "border-transparent hover:border-white/60 hover:scale-105",
+                ].join(" ")}
+                style={{ backgroundColor: c }}
+              />
+            ))}
+          </div>
+        </div>
+
+        {error && (
+          <p className="text-[length:var(--text-sm)] text-status-error bg-status-error/10 rounded-lg px-3 py-2" role="alert">
+            {error}
+          </p>
+        )}
       </form>
-    </div>
+    </ModalShell>
   );
 }

--- a/src/components/snippets/VariableDialog.tsx
+++ b/src/components/snippets/VariableDialog.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from "react";
-import { AlertTriangle } from "lucide-react";
+import { AlertTriangle, X } from "lucide-react";
 import type { Snippet } from "../../types";
 import { useSessionStore } from "../../stores/session-store";
 import { CustomSelect } from "../shared/CustomSelect";
@@ -109,44 +109,51 @@ export function VariableDialog({ snippet, onExecute, onCancel }: VariableDialogP
       ref={backdropRef}
       onClick={handleBackdropClick}
       className={[
-        "fixed inset-0 z-50 flex items-start justify-center pt-[12vh]",
+        "fixed inset-0 z-50 flex items-start justify-center pt-[8vh]",
         "transition-[background-color,backdrop-filter] duration-[var(--duration-base)]",
         visible ? "bg-black/50 backdrop-blur-sm" : "bg-black/0 backdrop-blur-none",
       ].join(" ")}
     >
-      <div
+      <form
+        onSubmit={handleSubmit}
         className={[
-          "w-full max-w-md rounded-xl bg-bg-overlay border border-border p-6 shadow-[var(--shadow-lg)]",
+          "w-full max-w-md rounded-xl bg-bg-overlay border border-border shadow-[var(--shadow-lg)] flex flex-col max-h-[84vh]",
           "transition-[opacity,transform] duration-[var(--duration-slow)] ease-[var(--ease-expo-out)]",
           visible ? "opacity-100 translate-y-0" : "opacity-0 -translate-y-3",
         ].join(" ")}
       >
         {/* Header */}
-        <div className="mb-5">
-          <h2 className="text-[length:var(--text-lg)] font-semibold text-text-primary">
-            {snippet.name}
-          </h2>
-          <p className="text-[length:var(--text-xs)] text-text-muted mt-1 font-mono break-all line-clamp-2">
-            {snippet.command}
-          </p>
-        </div>
-
-        {/* Dangerous warning */}
-        {snippet.is_dangerous && (
-          <div className="flex items-start gap-2.5 p-3 mb-5 rounded-lg bg-status-error/10 border border-status-error/30">
-            <AlertTriangle
-              size={16}
-              strokeWidth={2}
-              className="text-status-error shrink-0 mt-0.5"
-              aria-hidden="true"
-            />
-            <p className="text-[length:var(--text-xs)] text-status-error leading-relaxed">
-              This snippet is flagged as dangerous. Review the resolved command carefully before execution.
+        <div className="flex items-center justify-between px-6 pt-5 pb-4 border-b border-border shrink-0">
+          <div className="min-w-0 flex-1">
+            <h2 className="text-[length:var(--text-lg)] font-semibold text-text-primary truncate">
+              {snippet.name}
+            </h2>
+            <p className="text-[length:var(--text-xs)] text-text-muted mt-0.5 font-mono truncate">
+              {snippet.command}
             </p>
           </div>
-        )}
+          <button
+            type="button"
+            onClick={onCancel}
+            aria-label="Close"
+            className="ml-3 p-1.5 rounded-md text-text-muted hover:text-text-primary hover:bg-bg-subtle transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring shrink-0"
+          >
+            <X size={14} strokeWidth={1.8} aria-hidden="true" />
+          </button>
+        </div>
 
-        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+        {/* Body */}
+        <div className="px-6 py-5 overflow-y-auto flex-1 min-h-0 flex flex-col gap-4">
+          {/* Dangerous warning */}
+          {snippet.is_dangerous && (
+            <div className="flex items-start gap-2.5 p-3 rounded-lg bg-status-error/10 border border-status-error/30">
+              <AlertTriangle size={16} strokeWidth={2} className="text-status-error shrink-0 mt-0.5" aria-hidden="true" />
+              <p className="text-[length:var(--text-xs)] text-status-error leading-relaxed">
+                This snippet is flagged as dangerous. Review the resolved command carefully before execution.
+              </p>
+            </div>
+          )}
+
           {/* Built-in variables (read-only) */}
           {builtinVars.length > 0 && (
             <div className="flex flex-col gap-3">
@@ -157,16 +164,11 @@ export function VariableDialog({ snippet, onExecute, onCancel }: VariableDialogP
                 const resolved = resolveBuiltin(name, session) ?? "(no active session)";
                 return (
                   <div key={name}>
-                    <label className={labelClass}>
-                      {`{{${name}}}`}
-                    </label>
-                    <div
-                      className={[
-                        "w-full rounded-lg bg-bg-base border border-border px-3 py-2",
-                        "text-[length:var(--text-sm)] text-text-muted font-mono",
-                        "cursor-default select-text",
-                      ].join(" ")}
-                    >
+                    <label className={labelClass}>{`{{${name}}}`}</label>
+                    <div className={[
+                      "w-full rounded-lg bg-bg-base border border-border px-3 py-2",
+                      "text-[length:var(--text-sm)] text-text-muted font-mono cursor-default select-text",
+                    ].join(" ")}>
                       {resolved}
                     </div>
                   </div>
@@ -175,15 +177,12 @@ export function VariableDialog({ snippet, onExecute, onCancel }: VariableDialogP
             </div>
           )}
 
-          {/* Divider if both sections present */}
-          {builtinVars.length > 0 && userVarNames.length > 0 && (
-            <hr className="border-border" />
-          )}
+          {builtinVars.length > 0 && userVarNames.length > 0 && <hr className="border-border" />}
 
           {/* User-defined variables */}
           {userVarNames.length > 0 && (
             <div className="flex flex-col gap-3">
-              {userVarNames.length > 0 && builtinVars.length > 0 && (
+              {builtinVars.length > 0 && (
                 <p className="text-[length:var(--text-xs)] font-semibold uppercase tracking-widest text-text-muted">
                   Variables
                 </p>
@@ -192,7 +191,6 @@ export function VariableDialog({ snippet, onExecute, onCancel }: VariableDialogP
                 const meta = variableMeta.find((v) => v.name === name);
                 const isFirst = inputIndex === 0;
                 inputIndex++;
-
                 const label = meta?.label ?? name;
                 const placeholder = meta?.placeholder ?? `Enter ${name}`;
                 const options = meta?.options ?? null;
@@ -202,20 +200,14 @@ export function VariableDialog({ snippet, onExecute, onCancel }: VariableDialogP
                   <div key={name}>
                     <label className={labelClass}>
                       {label}
-                      {required && (
-                        <span className="text-status-error ml-1" aria-label="required">*</span>
-                      )}
+                      {required && <span className="text-status-error ml-1" aria-label="required">*</span>}
                     </label>
-
                     {options && options.length > 0 ? (
                       <CustomSelect
                         value={values[name] ?? ""}
                         onChange={(v) => setValue(name, v)}
                         placeholder="— select —"
-                        options={[
-                          { value: "", label: "— select —" },
-                          ...options.map((opt) => ({ value: opt, label: opt })),
-                        ]}
+                        options={[{ value: "", label: "— select —" }, ...options.map((opt) => ({ value: opt, label: opt }))]}
                       />
                     ) : (
                       <input
@@ -234,43 +226,31 @@ export function VariableDialog({ snippet, onExecute, onCancel }: VariableDialogP
             </div>
           )}
 
-          {/* No variables — just confirm */}
           {allVarNames.length === 0 && (
             <p className="text-[length:var(--text-sm)] text-text-muted text-center py-2">
               No variables to fill in.
             </p>
           )}
+        </div>
 
-          {/* Actions */}
-          <div className="flex justify-end gap-2 mt-1">
-            <button
-              type="button"
-              onClick={onCancel}
-              className={[
-                "px-4 py-2 text-[length:var(--text-sm)] text-text-secondary",
-                "hover:text-text-primary rounded-lg",
-                "transition-colors duration-[var(--duration-fast)]",
-                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-              ].join(" ")}
-            >
-              Cancel
-            </button>
-            <button
-              type="submit"
-              disabled={hasUnmetRequired}
-              className={[
-                "px-4 py-2 text-[length:var(--text-sm)] font-medium rounded-lg",
-                "text-text-inverse bg-accent hover:bg-accent-hover",
-                "disabled:opacity-50 disabled:cursor-not-allowed",
-                "transition-colors duration-[var(--duration-fast)]",
-                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-bg-overlay",
-              ].join(" ")}
-            >
-              Execute
-            </button>
-          </div>
-        </form>
-      </div>
+        {/* Footer */}
+        <div className="px-6 py-3 flex items-center justify-end gap-2 border-t border-border shrink-0">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="px-4 py-1.5 text-[length:var(--text-sm)] font-medium text-text-secondary hover:text-text-primary rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={hasUnmetRequired}
+            className="px-4 py-1.5 text-[length:var(--text-sm)] font-medium text-text-inverse bg-accent hover:bg-accent-hover disabled:opacity-50 rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-bg-overlay"
+          >
+            Execute
+          </button>
+        </div>
+      </form>
     </div>
   );
 }

--- a/src/components/snippets/VariableDialog.tsx
+++ b/src/components/snippets/VariableDialog.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from "react";
-import { AlertTriangle, X } from "lucide-react";
+import { AlertTriangle, X, Braces } from "lucide-react";
 import type { Snippet } from "../../types";
 import { useSessionStore } from "../../stores/session-store";
 import { CustomSelect } from "../shared/CustomSelect";
@@ -124,13 +124,18 @@ export function VariableDialog({ snippet, onExecute, onCancel }: VariableDialogP
       >
         {/* Header */}
         <div className="flex items-center justify-between px-6 pt-5 pb-4 border-b border-border shrink-0">
-          <div className="min-w-0 flex-1">
-            <h2 className="text-[length:var(--text-lg)] font-semibold text-text-primary truncate">
-              {snippet.name}
-            </h2>
-            <p className="text-[length:var(--text-xs)] text-text-muted mt-0.5 font-mono truncate">
-              {snippet.command}
-            </p>
+          <div className="flex items-center gap-3 min-w-0 flex-1">
+            <div className="flex items-center justify-center w-8 h-8 rounded-lg shrink-0 bg-accent/10">
+              <Braces size={16} strokeWidth={1.8} className="text-accent" aria-hidden="true" />
+            </div>
+            <div className="min-w-0">
+              <h2 className="text-[length:var(--text-lg)] font-semibold text-text-primary truncate">
+                {snippet.name}
+              </h2>
+              <p className="text-[length:var(--text-xs)] text-text-muted mt-0.5 font-mono truncate">
+                {snippet.command}
+              </p>
+            </div>
           </div>
           <button
             type="button"

--- a/src/components/snippets/VariableDialog.tsx
+++ b/src/components/snippets/VariableDialog.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect, useRef, useCallback } from "react";
-import { AlertTriangle, X, Braces } from "lucide-react";
+import { useState, useCallback, useRef } from "react";
+import { AlertTriangle, Braces } from "lucide-react";
 import type { Snippet } from "../../types";
 import { useSessionStore } from "../../stores/session-store";
 import { CustomSelect } from "../shared/CustomSelect";
@@ -10,8 +10,7 @@ import {
   resolveBuiltin,
   BUILTIN_NAMES,
 } from "../../utils/snippet-resolve";
-
-// ─── Types ────────────────────────────────────────────────────────────────────
+import { ModalShell, BTN_GHOST, BTN_PRIMARY } from "../shared/ModalShell";
 
 interface VariableDialogProps {
   snippet: Snippet;
@@ -19,24 +18,16 @@ interface VariableDialogProps {
   onCancel: () => void;
 }
 
-// ─── Component ────────────────────────────────────────────────────────────────
-
 export function VariableDialog({ snippet, onExecute, onCancel }: VariableDialogProps) {
   const activeSessionId = useSessionStore((s) => s.activeSessionId);
   const sessions = useSessionStore((s) => s.sessions);
   const session = activeSessionId ? (sessions.get(activeSessionId) ?? null) : null;
 
-  // Parsed variable metadata from snippet.variables JSON
   const variableMeta = parseVariables(snippet.variables);
-
-  // All unique variable names extracted from the command
   const allVarNames = extractVariables(snippet.command);
-
-  // Separate built-ins from user-defined
   const builtinVars = allVarNames.filter((n) => BUILTIN_NAMES.includes(n));
   const userVarNames = allVarNames.filter((n) => !BUILTIN_NAMES.includes(n));
 
-  // Build initial values from defaults
   const initialValues = Object.fromEntries(
     userVarNames.map((name) => {
       const meta = variableMeta.find((v) => v.name === name);
@@ -45,49 +36,17 @@ export function VariableDialog({ snippet, onExecute, onCancel }: VariableDialogP
   );
 
   const [values, setValues] = useState<Record<string, string>>(initialValues);
-  const [visible, setVisible] = useState(false);
-  const backdropRef = useRef<HTMLDivElement>(null);
-  const firstInputRef = useRef<HTMLInputElement | HTMLSelectElement | null>(null);
-
-  useEffect(() => {
-    requestAnimationFrame(() => setVisible(true));
-  }, []);
-
-  useEffect(() => {
-    if (visible) {
-      requestAnimationFrame(() => {
-        if (firstInputRef.current) firstInputRef.current.focus();
-      });
-    }
-  }, [visible]);
-
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onCancel();
-    };
-    document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [onCancel]);
-
-  const handleBackdropClick = (e: React.MouseEvent) => {
-    if (e.target === backdropRef.current) onCancel();
-  };
+  const firstInputRef = useRef<HTMLInputElement | null>(null);
 
   const handleExecute = useCallback(() => {
     const resolved = resolveCommand(snippet.command, values, session);
     onExecute(resolved);
   }, [snippet.command, values, session, onExecute]);
 
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    handleExecute();
-  };
-
   const setValue = (name: string, value: string) => {
     setValues((prev) => ({ ...prev, [name]: value }));
   };
 
-  // Check required fields
   const hasUnmetRequired = userVarNames.some((name) => {
     const meta = variableMeta.find((v) => v.name === name);
     return meta?.required && !values[name]?.trim();
@@ -101,161 +60,112 @@ export function VariableDialog({ snippet, onExecute, onCancel }: VariableDialogP
   ].join(" ");
 
   const labelClass = "block text-[length:var(--text-xs)] font-medium text-text-secondary mb-1";
-
   let inputIndex = 0;
 
   return (
-    <div
-      ref={backdropRef}
-      onClick={handleBackdropClick}
-      className={[
-        "fixed inset-0 z-50 flex items-start justify-center pt-[8vh]",
-        "transition-[background-color,backdrop-filter] duration-[var(--duration-base)]",
-        visible ? "bg-black/50 backdrop-blur-sm" : "bg-black/0 backdrop-blur-none",
-      ].join(" ")}
-    >
-      <form
-        onSubmit={handleSubmit}
-        className={[
-          "w-full max-w-md rounded-xl bg-bg-overlay border border-border shadow-[var(--shadow-lg)] flex flex-col max-h-[84vh]",
-          "transition-[opacity,transform] duration-[var(--duration-slow)] ease-[var(--ease-expo-out)]",
-          visible ? "opacity-100 translate-y-0" : "opacity-0 -translate-y-3",
-        ].join(" ")}
-      >
-        {/* Header */}
-        <div className="flex items-center justify-between px-6 pt-5 pb-4 border-b border-border shrink-0">
-          <div className="flex items-center gap-3 min-w-0 flex-1">
-            <div className="flex items-center justify-center w-8 h-8 rounded-lg shrink-0 bg-accent/10">
-              <Braces size={16} strokeWidth={1.8} className="text-accent" aria-hidden="true" />
-            </div>
-            <div className="min-w-0">
-              <h2 className="text-[length:var(--text-lg)] font-semibold text-text-primary truncate">
-                {snippet.name}
-              </h2>
-              <p className="text-[length:var(--text-xs)] text-text-muted mt-0.5 font-mono truncate">
-                {snippet.command}
-              </p>
-            </div>
-          </div>
-          <button
-            type="button"
-            onClick={onCancel}
-            aria-label="Close"
-            className="ml-3 p-1.5 rounded-md text-text-muted hover:text-text-primary hover:bg-bg-subtle transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring shrink-0"
-          >
-            <X size={14} strokeWidth={1.8} aria-hidden="true" />
-          </button>
-        </div>
-
-        {/* Body */}
-        <div className="px-6 py-5 overflow-y-auto flex-1 min-h-0 flex flex-col gap-4">
-          {/* Dangerous warning */}
-          {snippet.is_dangerous && (
-            <div className="flex items-start gap-2.5 p-3 rounded-lg bg-status-error/10 border border-status-error/30">
-              <AlertTriangle size={16} strokeWidth={2} className="text-status-error shrink-0 mt-0.5" aria-hidden="true" />
-              <p className="text-[length:var(--text-xs)] text-status-error leading-relaxed">
-                This snippet is flagged as dangerous. Review the resolved command carefully before execution.
-              </p>
-            </div>
-          )}
-
-          {/* Built-in variables (read-only) */}
-          {builtinVars.length > 0 && (
-            <div className="flex flex-col gap-3">
-              <p className="text-[length:var(--text-xs)] font-semibold uppercase tracking-widest text-text-muted">
-                Auto-filled
-              </p>
-              {builtinVars.map((name) => {
-                const resolved = resolveBuiltin(name, session) ?? "(no active session)";
-                return (
-                  <div key={name}>
-                    <label className={labelClass}>{`{{${name}}}`}</label>
-                    <div className={[
-                      "w-full rounded-lg bg-bg-base border border-border px-3 py-2",
-                      "text-[length:var(--text-sm)] text-text-muted font-mono cursor-default select-text",
-                    ].join(" ")}>
-                      {resolved}
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
-          )}
-
-          {builtinVars.length > 0 && userVarNames.length > 0 && <hr className="border-border" />}
-
-          {/* User-defined variables */}
-          {userVarNames.length > 0 && (
-            <div className="flex flex-col gap-3">
-              {builtinVars.length > 0 && (
-                <p className="text-[length:var(--text-xs)] font-semibold uppercase tracking-widest text-text-muted">
-                  Variables
-                </p>
-              )}
-              {userVarNames.map((name) => {
-                const meta = variableMeta.find((v) => v.name === name);
-                const isFirst = inputIndex === 0;
-                inputIndex++;
-                const label = meta?.label ?? name;
-                const placeholder = meta?.placeholder ?? `Enter ${name}`;
-                const options = meta?.options ?? null;
-                const required = meta?.required ?? false;
-
-                return (
-                  <div key={name}>
-                    <label className={labelClass}>
-                      {label}
-                      {required && <span className="text-status-error ml-1" aria-label="required">*</span>}
-                    </label>
-                    {options && options.length > 0 ? (
-                      <CustomSelect
-                        value={values[name] ?? ""}
-                        onChange={(v) => setValue(name, v)}
-                        placeholder="— select —"
-                        options={[{ value: "", label: "— select —" }, ...options.map((opt) => ({ value: opt, label: opt }))]}
-                      />
-                    ) : (
-                      <input
-                        ref={isFirst ? (el) => { firstInputRef.current = el; } : undefined}
-                        type="text"
-                        value={values[name] ?? ""}
-                        onChange={(e) => setValue(name, e.target.value)}
-                        placeholder={placeholder}
-                        required={required}
-                        className={inputClass}
-                      />
-                    )}
-                  </div>
-                );
-              })}
-            </div>
-          )}
-
-          {allVarNames.length === 0 && (
-            <p className="text-[length:var(--text-sm)] text-text-muted text-center py-2">
-              No variables to fill in.
-            </p>
-          )}
-        </div>
-
-        {/* Footer */}
-        <div className="px-6 py-3 flex items-center justify-end gap-2 border-t border-border shrink-0">
-          <button
-            type="button"
-            onClick={onCancel}
-            className="px-4 py-1.5 text-[length:var(--text-sm)] font-medium text-text-secondary hover:text-text-primary rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-          >
+    <ModalShell
+      open
+      onClose={onCancel}
+      title={snippet.name}
+      subtitle={snippet.command}
+      icon={Braces}
+      maxWidth="md"
+      scrollable
+      footer={
+        <>
+          <button type="button" onClick={onCancel} className={BTN_GHOST}>
             Cancel
           </button>
           <button
+            form="variable-dialog-form"
             type="submit"
             disabled={hasUnmetRequired}
-            className="px-4 py-1.5 text-[length:var(--text-sm)] font-medium text-text-inverse bg-accent hover:bg-accent-hover disabled:opacity-50 rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-bg-overlay"
+            className={BTN_PRIMARY}
           >
             Execute
           </button>
-        </div>
+        </>
+      }
+    >
+      <form id="variable-dialog-form" onSubmit={(e) => { e.preventDefault(); handleExecute(); }} className="flex flex-col gap-4">
+        {snippet.is_dangerous && (
+          <div className="flex items-start gap-2.5 p-3 rounded-lg bg-status-error/10 border border-status-error/30">
+            <AlertTriangle size={16} strokeWidth={2} className="text-status-error shrink-0 mt-0.5" aria-hidden="true" />
+            <p className="text-[length:var(--text-xs)] text-status-error leading-relaxed">
+              This snippet is flagged as dangerous. Review the resolved command carefully before execution.
+            </p>
+          </div>
+        )}
+
+        {builtinVars.length > 0 && (
+          <div className="flex flex-col gap-3">
+            <p className="text-[length:var(--text-xs)] font-semibold uppercase tracking-widest text-text-muted">Auto-filled</p>
+            {builtinVars.map((name) => {
+              const resolved = resolveBuiltin(name, session) ?? "(no active session)";
+              return (
+                <div key={name}>
+                  <label className={labelClass}>{`{{${name}}}`}</label>
+                  <div className="w-full rounded-lg bg-bg-base border border-border px-3 py-2 text-[length:var(--text-sm)] text-text-muted font-mono cursor-default select-text">
+                    {resolved}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+
+        {builtinVars.length > 0 && userVarNames.length > 0 && <hr className="border-border" />}
+
+        {userVarNames.length > 0 && (
+          <div className="flex flex-col gap-3">
+            {builtinVars.length > 0 && (
+              <p className="text-[length:var(--text-xs)] font-semibold uppercase tracking-widest text-text-muted">Variables</p>
+            )}
+            {userVarNames.map((name) => {
+              const meta = variableMeta.find((v) => v.name === name);
+              const isFirst = inputIndex === 0;
+              inputIndex++;
+              const label = meta?.label ?? name;
+              const placeholder = meta?.placeholder ?? `Enter ${name}`;
+              const options = meta?.options ?? null;
+              const required = meta?.required ?? false;
+
+              return (
+                <div key={name}>
+                  <label className={labelClass}>
+                    {label}
+                    {required && <span className="text-status-error ml-1" aria-label="required">*</span>}
+                  </label>
+                  {options && options.length > 0 ? (
+                    <CustomSelect
+                      value={values[name] ?? ""}
+                      onChange={(v) => setValue(name, v)}
+                      placeholder="— select —"
+                      options={[{ value: "", label: "— select —" }, ...options.map((opt) => ({ value: opt, label: opt }))]}
+                    />
+                  ) : (
+                    <input
+                      ref={isFirst ? (el) => { firstInputRef.current = el; } : undefined}
+                      type="text"
+                      value={values[name] ?? ""}
+                      onChange={(e) => setValue(name, e.target.value)}
+                      placeholder={placeholder}
+                      required={required}
+                      className={inputClass}
+                    />
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+
+        {allVarNames.length === 0 && (
+          <p className="text-[length:var(--text-sm)] text-text-muted text-center py-2">
+            No variables to fill in.
+          </p>
+        )}
       </form>
-    </div>
+    </ModalShell>
   );
 }

--- a/src/components/updater/UpdateDialog.tsx
+++ b/src/components/updater/UpdateDialog.tsx
@@ -78,18 +78,18 @@ export function UpdateDialog() {
         </div>
 
         {/* Footer */}
-        <div className="px-6 pb-5 pt-3 flex items-center justify-end gap-2 border-t border-border shrink-0">
+        <div className="px-6 py-3 flex items-center justify-end gap-2 border-t border-border shrink-0">
           <button
             type="button"
             onClick={skip}
-            className="px-4 py-2 text-[length:var(--text-sm)] font-medium text-text-muted hover:text-text-primary rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            className="px-4 py-1.5 text-[length:var(--text-sm)] font-medium text-text-muted hover:text-text-primary rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
             Skip this version
           </button>
           <button
             type="button"
             onClick={dismiss}
-            className="px-4 py-2 text-[length:var(--text-sm)] font-medium text-text-secondary bg-bg-subtle border border-border hover:text-text-primary hover:border-border-focus rounded-lg transition-all duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            className="px-4 py-1.5 text-[length:var(--text-sm)] font-medium text-text-secondary bg-bg-subtle border border-border hover:text-text-primary hover:border-border-focus rounded-lg transition-all duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
             Later
           </button>
@@ -98,7 +98,7 @@ export function UpdateDialog() {
             autoFocus
             type="button"
             onClick={() => void install()}
-            className="px-4 py-2 text-[length:var(--text-sm)] font-medium text-text-inverse bg-accent hover:bg-accent-hover rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            className="px-4 py-1.5 text-[length:var(--text-sm)] font-medium text-text-inverse bg-accent hover:bg-accent-hover rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
             Install
           </button>

--- a/src/components/updater/UpdateDialog.tsx
+++ b/src/components/updater/UpdateDialog.tsx
@@ -1,13 +1,12 @@
-import { useEffect } from "react";
-import { ExternalLink, X } from "lucide-react";
+import { ExternalLink } from "lucide-react";
 import { useUpdaterStore } from "../../stores/updater-store";
+import { ModalShell, BTN_GHOST, BTN_SECONDARY, BTN_PRIMARY } from "../shared/ModalShell";
 
 const REPO_URL = "https://github.com/macnev2013/anySCP";
 
 /**
- * Shown when an update is available and automatic updates are off (or the user
- * triggered a manual check with auto off). Lets them install now, defer, or
- * skip the version. The changelog lives on the tagged GitHub release.
+ * Shown when an update is available. Lets users install now, defer, or skip.
+ * The changelog lives on the tagged GitHub release.
  */
 export function UpdateDialog() {
   const open = useUpdaterStore((s) => s.dialogOpen);
@@ -17,17 +16,6 @@ export function UpdateDialog() {
   const dismiss = useUpdaterStore((s) => s.dismissDialog);
   const skip = useUpdaterStore((s) => s.skipUpdate);
 
-  useEffect(() => {
-    if (!open) return;
-    const handler = (e: KeyboardEvent) => {
-      if (e.key === "Escape") { e.stopPropagation(); dismiss(); }
-    };
-    document.addEventListener("keydown", handler, true);
-    return () => document.removeEventListener("keydown", handler, true);
-  }, [open, dismiss]);
-
-  if (!open || !version) return null;
-
   const openChangelog = async () => {
     try {
       const { openUrl } = await import("@tauri-apps/plugin-opener");
@@ -36,74 +24,42 @@ export function UpdateDialog() {
   };
 
   return (
-    <div
-      className="fixed inset-0 z-[200] flex items-start justify-center pt-[8vh] bg-black/50 backdrop-blur-sm no-select"
-      onClick={(e) => e.target === e.currentTarget && dismiss()}
-    >
-      <div
-        role="dialog"
-        aria-modal="true"
-        aria-label="Update available"
-        className="w-full max-w-sm rounded-xl bg-bg-overlay border border-border shadow-[var(--shadow-lg)] flex flex-col animate-in fade-in slide-in-from-top-2 duration-[var(--duration-base)]"
-      >
-        {/* Header */}
-        <div className="flex items-center justify-between px-6 pt-5 pb-4 border-b border-border shrink-0">
-          <h2 className="text-[length:var(--text-lg)] font-semibold text-text-primary">
-            Update available
-          </h2>
-          <button
-            type="button"
-            onClick={dismiss}
-            aria-label="Close"
-            className="p-1.5 rounded-md text-text-muted hover:text-text-primary hover:bg-bg-subtle transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-          >
-            <X size={14} strokeWidth={1.8} aria-hidden="true" />
-          </button>
-        </div>
-
-        {/* Body */}
-        <div className="px-6 py-4 flex flex-col gap-3">
-          <p className="text-[length:var(--text-sm)] text-text-secondary">
-            anySCP <span className="font-medium text-text-primary">v{version}</span> is available
-            {appVersion ? <span className="text-text-muted"> — you have v{appVersion}</span> : null}.
-          </p>
-          <button
-            type="button"
-            onClick={() => void openChangelog()}
-            className="self-start inline-flex items-center gap-1.5 text-[length:var(--text-sm)] font-medium text-accent hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded"
-          >
-            View changelog on GitHub
-            <ExternalLink size={13} strokeWidth={2} />
-          </button>
-        </div>
-
-        {/* Footer */}
-        <div className="px-6 py-3 flex items-center justify-end gap-2 border-t border-border shrink-0">
-          <button
-            type="button"
-            onClick={skip}
-            className="px-4 py-1.5 text-[length:var(--text-sm)] font-medium text-text-muted hover:text-text-primary rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-          >
-            Skip this version
-          </button>
-          <button
-            type="button"
-            onClick={dismiss}
-            className="px-4 py-1.5 text-[length:var(--text-sm)] font-medium text-text-secondary bg-bg-subtle border border-border hover:text-text-primary hover:border-border-focus rounded-lg transition-all duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-          >
+    <ModalShell
+      open={open && !!version}
+      onClose={dismiss}
+      title="Update available"
+      maxWidth="sm"
+      footerStart={
+        <button type="button" onClick={skip} className={BTN_GHOST}>
+          Skip this version
+        </button>
+      }
+      footer={
+        <>
+          <button type="button" onClick={dismiss} className={BTN_SECONDARY}>
             Later
           </button>
-          <button
-            // eslint-disable-next-line jsx-a11y/no-autofocus
-            autoFocus
-            type="button"
-            onClick={() => void install()}
-            className="px-4 py-1.5 text-[length:var(--text-sm)] font-medium text-text-inverse bg-accent hover:bg-accent-hover rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-          >
+          {/* eslint-disable-next-line jsx-a11y/no-autofocus */}
+          <button autoFocus type="button" onClick={() => void install()} className={BTN_PRIMARY}>
             Install
           </button>
-        </div>
+        </>
+      }
+    >
+      <div className="flex flex-col gap-3 no-select">
+        <p className="text-[length:var(--text-sm)] text-text-secondary">
+          anySCP <span className="font-medium text-text-primary">v{version}</span> is available
+          {appVersion ? <span className="text-text-muted"> — you have v{appVersion}</span> : null}.
+        </p>
+        <button
+          type="button"
+          onClick={() => void openChangelog()}
+          className="self-start inline-flex items-center gap-1.5 text-[length:var(--text-sm)] font-medium text-accent hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded"
+        >
+          View changelog on GitHub
+          <ExternalLink size={13} strokeWidth={2} />
+        </button>
       </div>
-    </div>
+    </ModalShell>
   );
 }

--- a/src/components/updater/UpdateDialog.tsx
+++ b/src/components/updater/UpdateDialog.tsx
@@ -1,13 +1,8 @@
-import { ExternalLink } from "lucide-react";
+import { useEffect } from "react";
+import { ExternalLink, X } from "lucide-react";
 import { useUpdaterStore } from "../../stores/updater-store";
 
 const REPO_URL = "https://github.com/macnev2013/anySCP";
-
-const BTN_BASE = [
-  "px-3 py-1.5 rounded-lg text-[length:var(--text-sm)] font-medium",
-  "transition-all duration-[var(--duration-fast)]",
-  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-].join(" ");
 
 /**
  * Shown when an update is available and automatic updates are off (or the user
@@ -22,6 +17,15 @@ export function UpdateDialog() {
   const dismiss = useUpdaterStore((s) => s.dismissDialog);
   const skip = useUpdaterStore((s) => s.skipUpdate);
 
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") { e.stopPropagation(); dismiss(); }
+    };
+    document.addEventListener("keydown", handler, true);
+    return () => document.removeEventListener("keydown", handler, true);
+  }, [open, dismiss]);
+
   if (!open || !version) return null;
 
   const openChangelog = async () => {
@@ -32,49 +36,69 @@ export function UpdateDialog() {
   };
 
   return (
-    <div className="fixed inset-0 z-[200] flex items-center justify-center bg-black/50 p-4 no-select animate-[fadeIn_120ms_var(--ease-expo-out)_both]">
+    <div
+      className="fixed inset-0 z-[200] flex items-start justify-center pt-[8vh] bg-black/50 backdrop-blur-sm no-select"
+      onClick={(e) => e.target === e.currentTarget && dismiss()}
+    >
       <div
         role="dialog"
         aria-modal="true"
         aria-label="Update available"
-        className="w-full max-w-md rounded-2xl bg-bg-overlay border border-border shadow-[var(--shadow-lg)] p-5"
+        className="w-full max-w-sm rounded-xl bg-bg-overlay border border-border shadow-[var(--shadow-lg)] flex flex-col animate-in fade-in slide-in-from-top-2 duration-[var(--duration-base)]"
       >
-        <h2 className="text-[length:var(--text-lg)] font-semibold text-text-primary">
-          Update available
-        </h2>
-        <p className="mt-1 text-[length:var(--text-sm)] text-text-secondary">
-          anySCP <span className="font-medium text-text-primary">v{version}</span> is available
-          {appVersion ? <span className="text-text-muted"> — you have v{appVersion}</span> : null}.
-        </p>
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 pt-5 pb-4 border-b border-border shrink-0">
+          <h2 className="text-[length:var(--text-lg)] font-semibold text-text-primary">
+            Update available
+          </h2>
+          <button
+            type="button"
+            onClick={dismiss}
+            aria-label="Close"
+            className="p-1.5 rounded-md text-text-muted hover:text-text-primary hover:bg-bg-subtle transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <X size={14} strokeWidth={1.8} aria-hidden="true" />
+          </button>
+        </div>
 
-        <button
-          type="button"
-          onClick={() => void openChangelog()}
-          className="mt-3 inline-flex items-center gap-1.5 text-[length:var(--text-sm)] font-medium text-accent hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded"
-        >
-          View changelog on GitHub
-          <ExternalLink size={13} strokeWidth={2} />
-        </button>
+        {/* Body */}
+        <div className="px-6 py-4 flex flex-col gap-3">
+          <p className="text-[length:var(--text-sm)] text-text-secondary">
+            anySCP <span className="font-medium text-text-primary">v{version}</span> is available
+            {appVersion ? <span className="text-text-muted"> — you have v{appVersion}</span> : null}.
+          </p>
+          <button
+            type="button"
+            onClick={() => void openChangelog()}
+            className="self-start inline-flex items-center gap-1.5 text-[length:var(--text-sm)] font-medium text-accent hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded"
+          >
+            View changelog on GitHub
+            <ExternalLink size={13} strokeWidth={2} />
+          </button>
+        </div>
 
-        <div className="mt-5 flex items-center justify-end gap-2">
+        {/* Footer */}
+        <div className="px-6 pb-5 pt-3 flex items-center justify-end gap-2 border-t border-border shrink-0">
           <button
             type="button"
             onClick={skip}
-            className={`${BTN_BASE} text-text-muted hover:text-text-primary`}
+            className="px-4 py-2 text-[length:var(--text-sm)] font-medium text-text-muted hover:text-text-primary rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
             Skip this version
           </button>
           <button
             type="button"
             onClick={dismiss}
-            className={`${BTN_BASE} bg-bg-base border border-border text-text-secondary hover:text-text-primary hover:border-border-focus`}
+            className="px-4 py-2 text-[length:var(--text-sm)] font-medium text-text-secondary bg-bg-subtle border border-border hover:text-text-primary hover:border-border-focus rounded-lg transition-all duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
             Later
           </button>
           <button
+            // eslint-disable-next-line jsx-a11y/no-autofocus
+            autoFocus
             type="button"
             onClick={() => void install()}
-            className={`${BTN_BASE} bg-accent text-text-inverse hover:bg-accent-hover`}
+            className="px-4 py-2 text-[length:var(--text-sm)] font-medium text-text-inverse bg-accent hover:bg-accent-hover rounded-lg transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
             Install
           </button>


### PR DESCRIPTION

## Background

Several pages in the project support delete actions, but confirmation behavior is inconsistent:

- Some pages delete immediately
- Some pages use system-level confirm
- Some pages use custom confirmation dialogs

This change standardizes delete confirmations with one in-app confirmation dialog pattern to reduce accidental deletions and improve UX consistency.

## What Changed

### 1) Added a shared danger confirmation dialog

- Added `src/components/shared/ConfirmDangerDialog.tsx`
- Unified dangerous action dialog style and button behavior (`Cancel` / `Confirm`)

### 2) History page

- Added per-entry delete (`Delete` from context menu)
- Added in-app confirmation before deletion
- No “clear all history” entry point

### 3) Unified delete confirmations on Dashboard

- Added confirmation before host deletion
  - `src/components/dashboard/HostCard.tsx`
- Added confirmation before S3 connection deletion
  - `src/components/dashboard/S3Card.tsx`

### 4) Port Forwarding page

- Added confirmation before tunnel rule deletion
  - `src/components/port-forwarding/PortForwardingPage.tsx`

### 5) S3 page

- Added confirmation before deleting saved connections
  - `src/components/s3/S3Page.tsx`

### 6) Snippets page

- Added confirmation before snippet deletion
  - `src/components/snippets/SnippetCard.tsx`
- Added confirmation before snippet folder deletion
  - `src/components/snippets/SnippetFolderCard.tsx`

### 7) Backend delete API status

- Added the command chain for per-entry History deletion:
  - `src-tauri/src/db/mod.rs`
  - `src-tauri/src/db/commands.rs`
  - `src-tauri/src/lib.rs`
- Did not expose a “clear all history” command

## Scope

- Frontend: delete interaction flows
- Backend: History per-entry delete command registration/retention
- No database schema changes

## Risk and Compatibility

- Low risk: changes are mostly in UI interaction flow
- Behavior change: delete actions now require explicit user confirmation

## Validation Checklist

Please verify the following flows:

1. History context menu `Delete` -> dialog -> `Confirm` deletes only the selected entry.
2. Host context menu `Delete` -> dialog -> `Confirm` deletes the host.
3. S3 card/saved connection `Delete` -> dialog -> `Confirm` deletes the connection.
4. Port Forward rule `Delete` -> dialog -> `Confirm` deletes the rule.
5. Snippet / Snippet Folder `Delete` -> dialog -> `Confirm` deletes the target.
6. `Cancel` or clicking the backdrop does not perform deletion.

## Changed Files

- `src/components/shared/ConfirmDangerDialog.tsx`
- `src/components/history/HistoryPage.tsx`
- `src/components/dashboard/HostCard.tsx`
- `src/components/dashboard/S3Card.tsx`
- `src/components/port-forwarding/PortForwardingPage.tsx`
- `src/components/s3/S3Page.tsx`
- `src/components/snippets/SnippetCard.tsx`
- `src/components/snippets/SnippetFolderCard.tsx`
- `src-tauri/src/db/mod.rs`
- `src-tauri/src/db/commands.rs`
- `src-tauri/src/lib.rs`
