### PR TITLE
fix(editors): stage external edits per-remote-file to avoid clobbering (#76)

### DIFF
--- a/src-tauri/src/editors/mod.rs
+++ b/src-tauri/src/editors/mod.rs
@@ -501,6 +501,34 @@ pub fn resolve_default() -> Option<EditorConfig> {
         .or_else(|| detected.into_iter().next())
 }
 
+// ─── Temp staging ─────────────────────────────────────────────────────────────
+
+/// Build a collision-free local path for editing a remote file.
+///
+/// `key` uniquely identifies the remote file (e.g. session id + remote path or
+/// S3 bucket + key); `file_name` is the basename shown to the editor.
+///
+/// All edits used to land in a flat `anyscp-edit/<file_name>`, so two remote
+/// files sharing a basename — `a/compose.yml` and `b/compose.yml` — mapped to
+/// the same local file. With both open in an editor, saving one re-uploaded its
+/// contents to the *other's* remote path (#76). We namespace each download under
+/// an intermediate directory derived from a stable hash of `key`, keeping the
+/// original `file_name` inside so the editor still shows the right name and
+/// syntax highlighting.
+pub fn edit_temp_path(key: &str, file_name: &str) -> PathBuf {
+    use std::hash::{Hash, Hasher};
+    // DefaultHasher (SipHash with fixed keys) is deterministic within and across
+    // runs — we only need a stable, collision-resistant directory name, not a
+    // cryptographic digest.
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    key.hash(&mut hasher);
+    let hash = format!("{:016x}", hasher.finish());
+    std::env::temp_dir()
+        .join("anyscp-edit")
+        .join(hash)
+        .join(file_name)
+}
+
 // ─── Launching ──────────────────────────────────────────────────────────────
 
 /// Launch `editor` against `file`. Spawns and returns immediately (the caller's
@@ -665,6 +693,19 @@ mod tests {
         assert!(none.is_empty());
 
         std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn edit_temp_path_separates_same_basename() {
+        // Same basename under different remote dirs must not collide (#76).
+        let a = edit_temp_path("sess1\0/a/compose.yml", "compose.yml");
+        let b = edit_temp_path("sess1\0/b/compose.yml", "compose.yml");
+        assert_ne!(a, b);
+        assert_eq!(a.file_name().unwrap(), "compose.yml");
+        assert_eq!(b.file_name().unwrap(), "compose.yml");
+        // Stable for the same key, and namespaced under anyscp-edit.
+        assert_eq!(a, edit_temp_path("sess1\0/a/compose.yml", "compose.yml"));
+        assert!(a.parent().unwrap().parent().unwrap().ends_with("anyscp-edit"));
     }
 
     #[test]

--- a/src-tauri/src/editors/mod.rs
+++ b/src-tauri/src/editors/mod.rs
@@ -511,22 +511,45 @@ pub fn resolve_default() -> Option<EditorConfig> {
 /// All edits used to land in a flat `anyscp-edit/<file_name>`, so two remote
 /// files sharing a basename — `a/compose.yml` and `b/compose.yml` — mapped to
 /// the same local file. With both open in an editor, saving one re-uploaded its
-/// contents to the *other's* remote path (#76). We namespace each download under
-/// an intermediate directory derived from a stable hash of `key`, keeping the
-/// original `file_name` inside so the editor still shows the right name and
-/// syntax highlighting.
+/// contents to the *other's* remote path (#76). We namespace each download as
+/// `anyscp-edit/<group>/<unique>/<file_name>`:
+///
+/// - `<group>` is a hash of `key`, so all edits of one remote file land in the
+///   same readable group dir (useful when debugging the temp tree).
+/// - `<unique>` is a fresh UUID per call. It isolates every edit session, which
+///   buys two things the hash alone can't: a second edit of the *same* remote
+///   file gets its own dir (so one save-watcher's cleanup can't delete the file
+///   out from under another), and two distinct keys that happen to collide in
+///   the 64-bit group hash still never share a file.
+///
+/// The original `file_name` is kept innermost so the editor shows the right name
+/// and syntax highlighting.
 pub fn edit_temp_path(key: &str, file_name: &str) -> PathBuf {
     use std::hash::{Hash, Hasher};
-    // DefaultHasher (SipHash with fixed keys) is deterministic within and across
-    // runs — we only need a stable, collision-resistant directory name, not a
-    // cryptographic digest.
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
     key.hash(&mut hasher);
-    let hash = format!("{:016x}", hasher.finish());
+    let group = format!("{:016x}", hasher.finish());
+    let unique = uuid::Uuid::new_v4().to_string();
     std::env::temp_dir()
         .join("anyscp-edit")
-        .join(hash)
+        .join(group)
+        .join(unique)
         .join(file_name)
+}
+
+/// Remove a staged edit file and prune the now-empty directories it lived in,
+/// stopping at (and never removing) the shared `anyscp-edit` root. Best-effort:
+/// a non-empty dir — e.g. a concurrent edit of the same remote file still in its
+/// own sibling dir — simply halts the walk, leaving the rest in place.
+pub fn edit_temp_cleanup(local_path: &Path) {
+    let _ = std::fs::remove_file(local_path);
+    let mut dir = local_path.parent();
+    while let Some(d) = dir {
+        if d.ends_with("anyscp-edit") || std::fs::remove_dir(d).is_err() {
+            break;
+        }
+        dir = d.parent();
+    }
 }
 
 // ─── Launching ──────────────────────────────────────────────────────────────
@@ -703,9 +726,60 @@ mod tests {
         assert_ne!(a, b);
         assert_eq!(a.file_name().unwrap(), "compose.yml");
         assert_eq!(b.file_name().unwrap(), "compose.yml");
-        // Stable for the same key, and namespaced under anyscp-edit.
-        assert_eq!(a, edit_temp_path("sess1\0/a/compose.yml", "compose.yml"));
-        assert!(a.parent().unwrap().parent().unwrap().ends_with("anyscp-edit"));
+        // Every call is isolated, so even the *same* key yields a distinct dir
+        // (a second edit of one file can't clobber the first, and a hash
+        // collision can't make two files share a file path).
+        let a2 = edit_temp_path("sess1\0/a/compose.yml", "compose.yml");
+        assert_ne!(a, a2);
+        assert_eq!(a2.file_name().unwrap(), "compose.yml");
+        // Namespaced under anyscp-edit/<group>/<unique>/<file>.
+        let group = a.parent().unwrap().parent().unwrap();
+        assert!(group.parent().unwrap().ends_with("anyscp-edit"));
+        // The two edits of the same key share a group dir but differ in <unique>.
+        assert_eq!(group, a2.parent().unwrap().parent().unwrap());
+        assert_ne!(a.parent().unwrap(), a2.parent().unwrap());
+    }
+
+    #[test]
+    fn edit_temp_cleanup_prunes_dirs_but_keeps_root() {
+        let path = edit_temp_path("sess-cleanup\0/x/file.txt", "file.txt");
+        let unique_dir = path.parent().unwrap().to_path_buf();
+        let group_dir = unique_dir.parent().unwrap().to_path_buf();
+        let root = group_dir.parent().unwrap().to_path_buf();
+        std::fs::create_dir_all(&unique_dir).unwrap();
+        std::fs::write(&path, b"hi").unwrap();
+
+        edit_temp_cleanup(&path);
+
+        assert!(!path.exists(), "file removed");
+        assert!(!unique_dir.exists(), "per-edit dir pruned");
+        assert!(!group_dir.exists(), "empty group dir pruned");
+        assert!(root.ends_with("anyscp-edit"));
+        // Root is never removed even once emptied.
+        std::fs::create_dir_all(&root).unwrap();
+        assert!(root.exists());
+    }
+
+    #[test]
+    fn edit_temp_cleanup_halts_at_nonempty_group() {
+        // Two concurrent edits of the same remote file share a group dir.
+        let a = edit_temp_path("sess-concurrent\0/y/file.txt", "file.txt");
+        let b = edit_temp_path("sess-concurrent\0/y/file.txt", "file.txt");
+        let group = a.parent().unwrap().parent().unwrap().to_path_buf();
+        assert_eq!(group, b.parent().unwrap().parent().unwrap());
+        std::fs::create_dir_all(a.parent().unwrap()).unwrap();
+        std::fs::create_dir_all(b.parent().unwrap()).unwrap();
+        std::fs::write(&a, b"a").unwrap();
+        std::fs::write(&b, b"b").unwrap();
+
+        // Cleaning up edit A must not touch edit B's still-live file.
+        edit_temp_cleanup(&a);
+        assert!(!a.exists(), "A's file removed");
+        assert!(!a.parent().unwrap().exists(), "A's per-edit dir pruned");
+        assert!(b.exists(), "B's file untouched");
+        assert!(group.exists(), "shared group dir kept while B lives");
+
+        std::fs::remove_dir_all(&group).ok();
     }
 
     #[test]

--- a/src-tauri/src/s3/commands.rs
+++ b/src-tauri/src/s3/commands.rs
@@ -1060,11 +1060,8 @@ pub async fn s3_edit_external(
             }
         }
 
-        // Cleanup: remove the file and its now-empty per-object staging dir.
-        let _ = std::fs::remove_file(&local_path_bg);
-        if let Some(parent) = local_path_bg.parent() {
-            let _ = std::fs::remove_dir(parent);
-        }
+        // Cleanup: remove the file and prune its now-empty per-edit staging dirs.
+        crate::editors::edit_temp_cleanup(&local_path_bg);
     });
 
     Ok(())

--- a/src-tauri/src/s3/commands.rs
+++ b/src-tauri/src/s3/commands.rs
@@ -919,13 +919,15 @@ pub async fn s3_edit_external(
         .map(|n| n.to_string_lossy().to_string())
         .unwrap_or_else(|| "file".to_string());
 
-    // Create temp directory.
-    let temp_dir = std::env::temp_dir().join("anyscp-edit");
-    tokio::fs::create_dir_all(&temp_dir)
-        .await
-        .map_err(|e| S3Error::IoError(e.to_string()))?;
-
-    let local_path = temp_dir.join(&file_name);
+    // Stage under a per-object subdir so two objects sharing a basename
+    // (e.g. a/compose.yml and b/compose.yml) don't clobber each other (#76).
+    let edit_key = format!("{s3_session_id}\0{key}");
+    let local_path = crate::editors::edit_temp_path(&edit_key, &file_name);
+    if let Some(parent) = local_path.parent() {
+        tokio::fs::create_dir_all(parent)
+            .await
+            .map_err(|e| S3Error::IoError(e.to_string()))?;
+    }
 
     // 1. Download the object from S3.
     {
@@ -1058,8 +1060,11 @@ pub async fn s3_edit_external(
             }
         }
 
-        // Cleanup temp file.
+        // Cleanup: remove the file and its now-empty per-object staging dir.
         let _ = std::fs::remove_file(&local_path_bg);
+        if let Some(parent) = local_path_bg.parent() {
+            let _ = std::fs::remove_dir(parent);
+        }
     });
 
     Ok(())

--- a/src-tauri/src/scp/commands.rs
+++ b/src-tauri/src/scp/commands.rs
@@ -570,10 +570,8 @@ pub async fn scp_edit_external(
                 Err(mpsc::RecvTimeoutError::Disconnected) => break,
             }
         }
-        let _ = std::fs::remove_file(&local_path_bg);
-        if let Some(parent) = local_path_bg.parent() {
-            let _ = std::fs::remove_dir(parent);
-        }
+        // Cleanup: remove the file and prune its now-empty per-edit staging dirs.
+        crate::editors::edit_temp_cleanup(&local_path_bg);
     });
 
     Ok(())

--- a/src-tauri/src/scp/commands.rs
+++ b/src-tauri/src/scp/commands.rs
@@ -474,11 +474,15 @@ pub async fn scp_edit_external(
         .map(|n| n.to_string_lossy().to_string())
         .unwrap_or_else(|| "file".to_string());
 
-    let temp_dir = std::env::temp_dir().join("anyscp-edit");
-    tokio::fs::create_dir_all(&temp_dir)
-        .await
-        .map_err(|e| ScpError::LocalIoError(e.to_string()))?;
-    let local_path = temp_dir.join(&file_name);
+    // Stage under a per-remote-file subdir so two files sharing a basename
+    // (e.g. a/compose.yml and b/compose.yml) don't clobber each other (#76).
+    let key = format!("{scp_session_id}\0{remote_path}");
+    let local_path = crate::editors::edit_temp_path(&key, &file_name);
+    if let Some(parent) = local_path.parent() {
+        tokio::fs::create_dir_all(parent)
+            .await
+            .map_err(|e| ScpError::LocalIoError(e.to_string()))?;
+    }
 
     // 1. Download the file.
     let token = CancellationToken::new();
@@ -567,6 +571,9 @@ pub async fn scp_edit_external(
             }
         }
         let _ = std::fs::remove_file(&local_path_bg);
+        if let Some(parent) = local_path_bg.parent() {
+            let _ = std::fs::remove_dir(parent);
+        }
     });
 
     Ok(())

--- a/src-tauri/src/sftp/commands.rs
+++ b/src-tauri/src/sftp/commands.rs
@@ -1546,11 +1546,8 @@ pub async fn sftp_edit_external(
             }
         }
 
-        // Cleanup: remove the file and its now-empty per-file staging dir.
-        let _ = std::fs::remove_file(&local_path_bg);
-        if let Some(parent) = local_path_bg.parent() {
-            let _ = std::fs::remove_dir(parent);
-        }
+        // Cleanup: remove the file and prune its now-empty per-edit staging dirs.
+        crate::editors::edit_temp_cleanup(&local_path_bg);
     });
 
     Ok(())

--- a/src-tauri/src/sftp/commands.rs
+++ b/src-tauri/src/sftp/commands.rs
@@ -1390,13 +1390,15 @@ pub async fn sftp_edit_external(
         .map(|n| n.to_string_lossy().to_string())
         .unwrap_or_else(|| "file".to_string());
 
-    // Create temp directory
-    let temp_dir = std::env::temp_dir().join("anyscp-edit");
-    tokio::fs::create_dir_all(&temp_dir)
-        .await
-        .map_err(|e| SftpError::LocalIoError(e.to_string()))?;
-
-    let local_path = temp_dir.join(&file_name);
+    // Stage under a per-remote-file subdir so two files sharing a basename
+    // (e.g. a/compose.yml and b/compose.yml) don't clobber each other (#76).
+    let key = format!("{sftp_session_id}\0{remote_path}");
+    let local_path = crate::editors::edit_temp_path(&key, &file_name);
+    if let Some(parent) = local_path.parent() {
+        tokio::fs::create_dir_all(parent)
+            .await
+            .map_err(|e| SftpError::LocalIoError(e.to_string()))?;
+    }
 
     // 1. Download the file
     {
@@ -1544,8 +1546,11 @@ pub async fn sftp_edit_external(
             }
         }
 
-        // Cleanup
+        // Cleanup: remove the file and its now-empty per-file staging dir.
         let _ = std::fs::remove_file(&local_path_bg);
+        if let Some(parent) = local_path_bg.parent() {
+            let _ = std::fs::remove_dir(parent);
+        }
     });
 
     Ok(())

--- a/src/components/dashboard/HostEditModal.tsx
+++ b/src/components/dashboard/HostEditModal.tsx
@@ -458,6 +458,7 @@ export function HostEditModal() {
       scrollable
       busy={isBusy}
       testId="host-modal"
+      dataAttributes={{ "data-host-modal-mode": isNewHost ? "new" : "edit" }}
       footerStart={
         !isNewHost ? (
           deleteConfirm ? (

--- a/src/components/shared/ModalShell.tsx
+++ b/src/components/shared/ModalShell.tsx
@@ -62,6 +62,12 @@ export interface ModalShellProps {
   children: React.ReactNode;
   /** data-testid applied to the panel div. */
   testId?: string;
+  /**
+   * Extra `data-*` attributes spread onto the panel div. Use for state that
+   * tests or styling need to read off the dialog root (e.g. the host modal's
+   * `data-host-modal-mode`), which ModalShell otherwise has no way to expose.
+   */
+  dataAttributes?: Record<string, string>;
 }
 
 export function ModalShell({
@@ -79,6 +85,7 @@ export function ModalShell({
   footerStart,
   children,
   testId,
+  dataAttributes,
 }: ModalShellProps) {
   const titleId = useId();
   const [visible, setVisible] = useState(false);
@@ -129,6 +136,7 @@ export function ModalShell({
     >
       <div
         data-testid={testId}
+        {...dataAttributes}
         aria-modal="true"
         role="dialog"
         aria-labelledby={titleId}


### PR DESCRIPTION
## Problem

Refs #76.

"Edit in editor" downloaded every remote file to a flat `temp/anyscp-edit/<filename>`. Two remote files sharing a basename — `a/compose.yml` and `b/compose.yml` — therefore mapped to the **same** local path. With both open in an editor, saving one re-uploaded its contents to the *other's* remote path, silently overwriting it. The flaw was duplicated across all three transports: `sftp_edit_external`, `scp_edit_external`, and `s3_edit_external`.

## Fix

Namespace every edit session under a unique staging directory:

```
anyscp-edit/<group>/<unique>/<filename>
```

- **`<group>`** — a stable `DefaultHasher` digest of `key` (`session_id + "\0" + remote_path/key`), so all edits of one remote file share a readable group dir. The same path on different servers also stays separate.
- **`<unique>`** — a fresh UUID per call. This isolates every edit session, which closes two gaps a per-file hash alone couldn't:
  - Two distinct keys colliding in the 64-bit group hash still never share a file.
  - A second edit of the *same* remote file gets its own dir, so one save-watcher's 30-min cleanup can't delete the file out from under another live editor session.
- The original filename is kept innermost so the editor keeps the correct name and syntax highlighting.

Teardown is centralized in a shared `edit_temp_cleanup(local_path)` (replacing the three duplicated cleanup blocks). It removes the file and prunes empty per-edit dirs, **walking up but stopping at — and never removing — the `anyscp-edit` root**. A still-live concurrent edit's staging dir is non-empty, so the walk halts there and leaves it intact.

### Implementation

- **`editors/mod.rs`** — `edit_temp_path(key, file_name)` now appends the per-invocation UUID; new `edit_temp_cleanup(path)` helper.
- **SFTP / SCP / S3 callers** — build `key`, create the per-edit parent dir, and call `edit_temp_cleanup` on teardown.

### Trade-off

This intentionally drops the determinism the first cut had (same key → same path) — that property was the *cause* of the concurrent-edit race, and nothing relied on it (each caller captures the returned `local_path` directly and never reconstructs it).

## Testing

- `cargo test --lib editors::` — 10 passed, including:
  - `edit_temp_path_separates_same_basename` — distinct dirs even for the same key, while sharing a group dir.
  - `edit_temp_cleanup_prunes_dirs_but_keeps_root` — pruning stops at the root.
  - `edit_temp_cleanup_halts_at_nonempty_group` — cleaning up edit A doesn't touch concurrent edit B's live file.
- `cargo check --lib` — clean.
