### PR TITLE
fix(explorer): make SFTP/SCP upload button open the file picker (#69)

### DIFF
--- a/src/components/sftp/ExplorerView.tsx
+++ b/src/components/sftp/ExplorerView.tsx
@@ -456,28 +456,28 @@ export function ExplorerView({ sessionId, transport = "sftp", isActive = true }:
   const handleUpload = useCallback(async () => {
     if (!session) return;
     try {
-      let localPath: string | null = null;
-      try {
-        const specifier = ["@tauri-apps", "plugin-dialog"].join("/");
-        const dialog = await (Function("s", "return import(s)")(specifier) as Promise<{ open: (opts: { multiple: boolean }) => Promise<string | null> }>);
-        const result = await dialog.open({ multiple: false });
-        if (result) localPath = result;
-      } catch {
-        localPath = window.prompt("Enter local file path to upload:");
-      }
-      if (!localPath) return;
+      // A plain dynamic import is required here: the dialog plugin's `open`
+      // must run inside the module's resolution scope. (An earlier attempt at
+      // `Function("s","return import(s)")` resolved the bare specifier against
+      // the document base URL, threw, and silently fell back to a no-op
+      // `window.prompt` in the macOS webview — see issue #69.)
+      const { open } = await import("@tauri-apps/plugin-dialog");
+      const selection = await open({ multiple: true, title: "Upload file" });
+      if (!selection) return;
+      const localPaths = Array.isArray(selection) ? selection : [selection];
+      if (localPaths.length === 0) return;
 
-      const fileName = localPath.split("/").pop() ?? localPath.split("\\").pop() ?? "file";
-      const remotePath = session.currentPath.endsWith("/")
-        ? `${session.currentPath}${fileName}`
-        : `${session.currentPath}/${fileName}`;
-
-      await explorerInvoke(transport, "upload", sessionId, { localPath, remotePath });
-      void loadDirectory(session.currentPath);
+      // Route through the transfer queue (same path as drag-and-drop): it
+      // walks directories, reports progress in the transfer overlay, and the
+      // completion listener above refreshes the listing once each file lands.
+      await explorerInvoke(transport, "enqueue_upload", sessionId, {
+        localPaths,
+        remoteDir: session.currentPath,
+      });
     } catch {
-      // Upload errors show in transfer overlay
+      // Upload errors surface in the transfer overlay
     }
-  }, [sessionId, transport, session, loadDirectory]);
+  }, [sessionId, transport, session]);
 
   // ─── New folder/file (inline) ─────────────────────────────────────────────
 

--- a/src/components/sftp/ExplorerView.upload.test.tsx
+++ b/src/components/sftp/ExplorerView.upload.test.tsx
@@ -1,0 +1,97 @@
+import "@testing-library/jest-dom/vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+// ── Tauri module mocks ───────────────────────────────────────────────────────
+// ExplorerView imports `invoke` at module level and lazily imports the dialog
+// plugin, the event channel, and the drag-drop webview API. Mock them all so
+// the component mounts in jsdom without a real Tauri runtime.
+
+const { invoke, dialogOpen } = vi.hoisted(() => ({
+  invoke: vi.fn(async (..._args: unknown[]) => [] as unknown),
+  dialogOpen: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke }));
+vi.mock("@tauri-apps/plugin-dialog", () => ({ open: dialogOpen }));
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(async () => () => {}),
+}));
+vi.mock("@tauri-apps/api/webviewWindow", () => ({
+  getCurrentWebviewWindow: () => ({
+    onDragDropEvent: vi.fn(async () => () => {}),
+  }),
+}));
+
+import { ExplorerView } from "./ExplorerView";
+import { useSftpStore } from "../../stores/sftp-store";
+
+const SESSION_ID = "sess-1";
+const CURRENT_PATH = "/home/user";
+
+function seedSession(): void {
+  const store = useSftpStore.getState();
+  store.openSession(SESSION_ID, "ssh-1", "Test host", "user");
+  // Drive currentPath to a non-root dir so we can assert remoteDir precisely.
+  store.setEntries(SESSION_ID, CURRENT_PATH, []);
+}
+
+/** Find the enqueue_upload invoke call, if any. */
+function enqueueCall(): unknown[] | undefined {
+  return invoke.mock.calls.find((c) => c[0] === "sftp_enqueue_upload");
+}
+
+describe("ExplorerView — upload button", () => {
+  beforeEach(() => {
+    invoke.mockClear();
+    invoke.mockResolvedValue([]);
+    dialogOpen.mockReset();
+    // Fresh store between tests.
+    useSftpStore.setState({ sessions: new Map(), activeSftpSessionId: null, clipboard: null });
+    seedSession();
+  });
+
+  it("opens the native file picker and enqueues the selected files (issue #69)", async () => {
+    dialogOpen.mockResolvedValue(["/local/a.txt", "/local/b.txt"]);
+
+    render(<ExplorerView sessionId={SESSION_ID} />);
+    fireEvent.click(await screen.findByTestId("explorer-upload"));
+
+    await waitFor(() => expect(dialogOpen).toHaveBeenCalledTimes(1));
+    expect(dialogOpen).toHaveBeenCalledWith(
+      expect.objectContaining({ multiple: true }),
+    );
+
+    await waitFor(() => expect(enqueueCall()).toBeDefined());
+    expect(enqueueCall()?.[1]).toEqual({
+      sftpSessionId: SESSION_ID,
+      localPaths: ["/local/a.txt", "/local/b.txt"],
+      remoteDir: CURRENT_PATH,
+    });
+  });
+
+  it("normalizes a single-path selection into a one-element array", async () => {
+    dialogOpen.mockResolvedValue("/local/only.txt");
+
+    render(<ExplorerView sessionId={SESSION_ID} />);
+    fireEvent.click(await screen.findByTestId("explorer-upload"));
+
+    await waitFor(() => expect(enqueueCall()).toBeDefined());
+    expect(enqueueCall()?.[1]).toMatchObject({
+      localPaths: ["/local/only.txt"],
+      remoteDir: CURRENT_PATH,
+    });
+  });
+
+  it("enqueues nothing when the picker is cancelled", async () => {
+    dialogOpen.mockResolvedValue(null);
+
+    render(<ExplorerView sessionId={SESSION_ID} />);
+    fireEvent.click(await screen.findByTestId("explorer-upload"));
+
+    await waitFor(() => expect(dialogOpen).toHaveBeenCalledTimes(1));
+    // Give any (incorrect) follow-up invoke a chance to fire before asserting.
+    await Promise.resolve();
+    expect(enqueueCall()).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Problem

Clicking **Explorer → Upload file** did nothing (#69).

The SFTP/SCP upload handler loaded the dialog plugin via `Function("s","return import(s)")(specifier)`. A `Function`-eval'd `import()` resolves its bare specifier (`@tauri-apps/plugin-dialog`) against the **document base URL** rather than the module's resolution scope, so it throws. The `catch` then fell back to `window.prompt(...)` — a **no-op in Tauri's macOS WKWebView** — so the click produced no visible result.

The S3 browser and the SFTP drag-and-drop path both already use the correct `await import("@tauri-apps/plugin-dialog")`, which is why those worked (and why drag-drop was the maintainer's suggested workaround).

This slipped past CI because the e2e upload specs invoke the backend command directly — the native OS file picker can't be driven by WebdriverIO.

## Fix

- Use a plain `await import("@tauri-apps/plugin-dialog")` with `open({ multiple: true })`, so multiple files can be selected at once.
- Route the selection through `enqueue_upload` (same path as drag-and-drop) instead of the single-file `upload` command: it walks directories (so folders work too), reports progress in the transfer overlay, and the existing completion listener refreshes the listing — so the premature immediate reload is dropped.
- Works for both SFTP and SCP (the view is shared); both `sftp_enqueue_upload` and `scp_enqueue_upload` exist with matching arg shapes, and `dialog:default` already grants `allow-open`.

## Tests

- New `ExplorerView.upload.test.tsx`: picker→enqueue flow, single-path normalization, and the cancelled-picker case.
- `tsc --noEmit` clean; full Vitest suite passing.

Addresses #69
