### PR TITLE
feat(explorer): configurable double-click action for files

### DIFF
--- a/src/components/explorer/ExplorerFileTable.doubleclick.test.tsx
+++ b/src/components/explorer/ExplorerFileTable.doubleclick.test.tsx
@@ -1,0 +1,109 @@
+import "@testing-library/jest-dom/vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
+import { ExplorerFileTable } from "./ExplorerFileTable";
+import { createSftpProvider } from "../../providers/sftp-provider";
+import { useSettingsStore, type EditorConfig } from "../../stores/settings-store";
+import type { ExplorerEntry } from "../../types/explorer";
+
+const EDITOR: EditorConfig = { id: "e1", name: "VS Code", execPath: "/usr/bin/code", args: "{path}" };
+
+function entry(over: Partial<ExplorerEntry> = {}): ExplorerEntry {
+  return {
+    name: "notes.txt",
+    id: "/home/notes.txt",
+    entryType: "File",
+    size: 12,
+    modified: null,
+    permissionsDisplay: "rw-r--r--",
+    permissions: 0o644,
+    isSymlink: false,
+    storageClass: null,
+    ...over,
+  };
+}
+
+const DIR = entry({ name: "logs", id: "/home/logs", entryType: "Directory" });
+const TEXT = entry({ name: "config.yaml", id: "/home/config.yaml" });
+const BINARY = entry({ name: "clip.mov", id: "/home/clip.mov" });
+
+/** Render the table with the given entries and spy callbacks; returns the spies. */
+function renderTable(entries: ExplorerEntry[]) {
+  const onNavigate = vi.fn();
+  const onDownload = vi.fn();
+  const onEditInEditor = vi.fn();
+  const utils = render(
+    <ExplorerFileTable
+      provider={createSftpProvider("s")}
+      entries={entries}
+      sortBy="name"
+      sortAsc
+      onSortChange={() => {}}
+      clipboard={null}
+      onSetClipboard={() => {}}
+      onNavigate={onNavigate}
+      onDownload={onDownload}
+      onDelete={async () => {}}
+      onEditInEditor={onEditInEditor}
+      currentPath="/home"
+      loading={false}
+    />,
+  );
+  const dblClick = (name: string) => {
+    const row = utils.container.querySelector(`[data-entry-name="${name}"]`);
+    if (!row) throw new Error(`row '${name}' not rendered`);
+    fireEvent.doubleClick(row);
+  };
+  return { onNavigate, onDownload, onEditInEditor, dblClick };
+}
+
+describe("ExplorerFileTable — double-click action", () => {
+  beforeEach(() => {
+    // Default seed: one editor configured, action = download.
+    useSettingsStore.setState({
+      editors: [EDITOR],
+      defaultEditorId: EDITOR.id,
+      explorerDoubleClickAction: "download",
+    });
+  });
+
+  it("navigates into a directory regardless of the action", () => {
+    useSettingsStore.setState({ explorerDoubleClickAction: "open" });
+    const { onNavigate, onDownload, onEditInEditor, dblClick } = renderTable([DIR]);
+    dblClick("logs");
+    expect(onNavigate).toHaveBeenCalledWith("/home/logs");
+    expect(onDownload).not.toHaveBeenCalled();
+    expect(onEditInEditor).not.toHaveBeenCalled();
+  });
+
+  it("downloads a file when the action is 'download'", () => {
+    const { onDownload, onEditInEditor, dblClick } = renderTable([TEXT]);
+    dblClick("config.yaml");
+    expect(onDownload).toHaveBeenCalledWith(TEXT);
+    expect(onEditInEditor).not.toHaveBeenCalled();
+  });
+
+  it("opens a text file in the default editor when the action is 'open'", () => {
+    useSettingsStore.setState({ explorerDoubleClickAction: "open" });
+    const { onDownload, onEditInEditor, dblClick } = renderTable([TEXT]);
+    dblClick("config.yaml");
+    expect(onEditInEditor).toHaveBeenCalledWith(TEXT, expect.objectContaining({ id: "e1" }));
+    expect(onDownload).not.toHaveBeenCalled();
+  });
+
+  it("downloads a binary file even when the action is 'open'", () => {
+    useSettingsStore.setState({ explorerDoubleClickAction: "open" });
+    const { onDownload, onEditInEditor, dblClick } = renderTable([BINARY]);
+    dblClick("clip.mov");
+    expect(onDownload).toHaveBeenCalledWith(BINARY);
+    expect(onEditInEditor).not.toHaveBeenCalled();
+  });
+
+  it("falls back to download when 'open' is set but no editor is configured", () => {
+    useSettingsStore.setState({ explorerDoubleClickAction: "open", editors: [], defaultEditorId: null });
+    const { onDownload, onEditInEditor, dblClick } = renderTable([TEXT]);
+    dblClick("config.yaml");
+    expect(onDownload).toHaveBeenCalledWith(TEXT);
+    expect(onEditInEditor).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/explorer/ExplorerFileTable.tsx
+++ b/src/components/explorer/ExplorerFileTable.tsx
@@ -293,6 +293,7 @@ export function ExplorerFileTable({
   const caps = provider.capabilities;
   const editors = useSettingsStore((s) => s.editors);
   const defaultEditorId = useSettingsStore((s) => s.defaultEditorId);
+  const doubleClickAction = useSettingsStore((s) => s.explorerDoubleClickAction);
   const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
   const [renamingId, setRenamingId] = useState<string | null>(null);
   const [confirmDelete, setConfirmDelete] = useState<ExplorerEntry[] | null>(null);
@@ -583,6 +584,14 @@ export function ExplorerFileTable({
   const handleDoubleClick = (entry: ExplorerEntry) => {
     if (entry.entryType === "Directory") {
       onNavigate(entry.id);
+      return;
+    }
+    // For files, the action is configurable (Settings → Explorer). "Open in
+    // editor" uses the default editor, falling back to download when editing
+    // isn't possible (no editor configured, or the provider can't edit).
+    const defaultEditor = editors.find((e) => e.id === defaultEditorId) ?? editors[0];
+    if (doubleClickAction === "open" && caps.canEditInEditor && onEditInEditor && defaultEditor) {
+      onEditInEditor(entry, defaultEditor);
     } else {
       onDownload(entry);
     }

--- a/src/components/explorer/ExplorerFileTable.tsx
+++ b/src/components/explorer/ExplorerFileTable.tsx
@@ -25,6 +25,7 @@ import { ContextMenu } from "../shared/ContextMenu";
 import type { ContextMenuItem } from "../shared/ContextMenu";
 import { formatBytes } from "../../utils/format";
 import { useSettingsStore, type EditorConfig } from "../../stores/settings-store";
+import { isEditableInEditor } from "../../lib/file-types";
 import { FilePropertiesDialog } from "./FilePropertiesDialog";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -587,10 +588,18 @@ export function ExplorerFileTable({
       return;
     }
     // For files, the action is configurable (Settings → Explorer). "Open in
-    // editor" uses the default editor, falling back to download when editing
+    // editor" uses the default editor, but only for text-editable files —
+    // binaries (video, images, PDFs, archives, …) fall back to download rather
+    // than dumping raw bytes into the editor. It also falls back when editing
     // isn't possible (no editor configured, or the provider can't edit).
     const defaultEditor = editors.find((e) => e.id === defaultEditorId) ?? editors[0];
-    if (doubleClickAction === "open" && caps.canEditInEditor && onEditInEditor && defaultEditor) {
+    if (
+      doubleClickAction === "open" &&
+      caps.canEditInEditor &&
+      onEditInEditor &&
+      defaultEditor &&
+      isEditableInEditor(entry.name)
+    ) {
       onEditInEditor(entry, defaultEditor);
     } else {
       onDownload(entry);

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -6,7 +6,7 @@ import { useUpdaterStore } from "../../stores/updater-store";
 import { toast } from "../../stores/toast-store";
 import { RefreshCw, CheckCircle2, AlertCircle, Palette, SquareTerminal, ArrowUpDown, Info, ExternalLink, Check, FileCode, Plus, Trash2, FolderOpen, Star, Search, Database, Download, Upload, ShieldCheck } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
-import type { CursorStyle, ThemeMode, EditorConfig, PasteButton } from "../../stores/settings-store";
+import type { CursorStyle, ThemeMode, EditorConfig, PasteButton, DoubleClickAction } from "../../stores/settings-store";
 
 // ─── Shared styles ───────────────────────────────────────────────────────────
 
@@ -46,11 +46,12 @@ const REPO_URL = "https://github.com/macnev2013/anySCP";
 // Each settings category is a section here. To add a new category, add an entry
 // to SECTIONS, a description, and render its content in <SectionContent />.
 
-type SectionId = "appearance" | "terminal" | "transfers" | "editors" | "data" | "about";
+type SectionId = "appearance" | "terminal" | "explorer" | "transfers" | "editors" | "data" | "about";
 
 const SECTIONS: { id: SectionId; label: string; icon: LucideIcon }[] = [
   { id: "appearance", label: "Appearance", icon: Palette },
   { id: "terminal", label: "Terminal", icon: SquareTerminal },
+  { id: "explorer", label: "Explorer", icon: FolderOpen },
   { id: "transfers", label: "Transfers", icon: ArrowUpDown },
   { id: "editors", label: "Editors", icon: FileCode },
   { id: "data", label: "Data", icon: Database },
@@ -60,6 +61,7 @@ const SECTIONS: { id: SectionId; label: string; icon: LucideIcon }[] = [
 const SECTION_DESCRIPTIONS: Record<SectionId, string> = {
   appearance: "Theme and interface look.",
   terminal: "Font, cursor, and scrollback history.",
+  explorer: "How the file browser behaves.",
   transfers: "Control how files are transferred.",
   editors: "Editors used by “Edit” / “Open With” in the file browser.",
   data: "Back up, restore, and reset your data.",
@@ -147,6 +149,8 @@ function SectionContent({ section }: { section: SectionId }) {
       return <AppearanceSettings />;
     case "terminal":
       return <TerminalSettings />;
+    case "explorer":
+      return <ExplorerSettings />;
     case "transfers":
       return <TransferSettings />;
     case "editors":
@@ -625,6 +629,34 @@ function TerminalSettings() {
         </p>
       </SettingsGroup>
     </>
+  );
+}
+
+function ExplorerSettings() {
+  const doubleClickAction = useSettingsStore((s) => s.explorerDoubleClickAction);
+  const setDoubleClickAction = useSettingsStore((s) => s.setExplorerDoubleClickAction);
+
+  return (
+    <SettingsGroup>
+      <SettingRow>
+        <div>
+          <p className={LABEL_CLASS}>Double-click a File</p>
+          <p className={DESC_CLASS}>What happens when you double-click a file in the browser</p>
+        </div>
+        <SegmentedControl<DoubleClickAction>
+          id="s-doubleclick"
+          value={doubleClickAction}
+          onChange={setDoubleClickAction}
+          options={[
+            { value: "download", label: "Download" },
+            { value: "open", label: "Open in Editor" },
+          ]}
+        />
+      </SettingRow>
+      <p className="px-1 text-[length:var(--text-xs)] text-text-muted">
+        Opening falls back to downloading when no editor is configured (see Editors).
+      </p>
+    </SettingsGroup>
   );
 }
 

--- a/src/components/sftp/DropOverwriteDialog.test.tsx
+++ b/src/components/sftp/DropOverwriteDialog.test.tsx
@@ -55,13 +55,18 @@ describe("DropOverwriteDialog", () => {
     fireEvent.click(screen.getByTestId("explorer-overwrite-cancel"));
     expect(onCancel).toHaveBeenCalledTimes(1);
 
-    fireEvent.click(screen.getByTestId("explorer-overwrite-confirm")); // backdrop
+    // The backdrop is the panel's parent: ModalShell closes only when the click
+    // target is the backdrop itself, not the panel (testId is on the panel).
+    const backdrop = screen.getByTestId("explorer-overwrite-confirm").parentElement as HTMLElement;
+    fireEvent.click(backdrop);
     expect(onCancel).toHaveBeenCalledTimes(2);
 
-    fireEvent.keyDown(window, { key: "Escape" });
+    // ModalShell's Escape listener is on document; an event fired on window
+    // wouldn't reach it.
+    fireEvent.keyDown(document, { key: "Escape" });
     expect(onCancel).toHaveBeenCalledTimes(3);
 
-    // Keep rerender referenced (the dialog mounts a window keydown listener).
+    // Keep rerender referenced (the dialog mounts a document keydown listener).
     rerender(
       <DropOverwriteDialog conflicts={["a.txt"]} targetDir="/x" onConfirm={vi.fn()} onCancel={onCancel} />,
     );

--- a/src/components/terminal/Terminal.clipboard.test.tsx
+++ b/src/components/terminal/Terminal.clipboard.test.tsx
@@ -1,0 +1,108 @@
+import "@testing-library/jest-dom/vitest";
+import { describe, it, expect, beforeEach, beforeAll, vi } from "vitest";
+import { render, fireEvent, waitFor, act } from "@testing-library/react";
+
+// Shared spies/handles, hoisted so the vi.mock factories below can use them.
+const mocks = vi.hoisted(() => ({
+  selectionHandlers: [] as Array<() => void>,
+  paste: vi.fn(),
+  getSelection: vi.fn(() => "SELECTED"),
+  readText: vi.fn(async () => "CLIP"),
+  writeText: vi.fn(async () => undefined),
+  fit: vi.fn(),
+  refresh: vi.fn(),
+  dispose: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/plugin-clipboard-manager", () => ({
+  readText: mocks.readText,
+  writeText: mocks.writeText,
+}));
+
+// xterm needs a real DOM/measurements; replace the registry with a fake term so
+// we can drive onSelectionChange / paste directly.
+vi.mock("../../stores/terminal-instances", () => {
+  const term = {
+    options: {} as Record<string, unknown>,
+    rows: 24,
+    refresh: mocks.refresh,
+    getSelection: mocks.getSelection,
+    paste: mocks.paste,
+    onSelectionChange: (cb: () => void) => {
+      mocks.selectionHandlers.push(cb);
+      return { dispose: mocks.dispose };
+    },
+  };
+  const entry = { term, element: document.createElement("div"), fitAddon: { fit: mocks.fit }, resizeTimer: null };
+  return {
+    ensureTerminal: () => entry,
+    getTerminal: () => entry,
+    getTerminalTheme: () => ({}),
+    disposeTerminal: vi.fn(),
+  };
+});
+
+// The SSH output subscription is irrelevant to clipboard behaviour.
+vi.mock("../../hooks/use-ssh-events", () => ({ useSshOutput: () => {} }));
+
+import { Terminal } from "./Terminal";
+import { useSettingsStore } from "../../stores/settings-store";
+
+const SID = "s1";
+const container = () => document.querySelector(`[data-testid="terminal-${SID}"]`) as HTMLElement;
+
+beforeAll(() => {
+  // jsdom lacks both; Terminal's mount effect uses them.
+  class RO { observe() {} unobserve() {} disconnect() {} }
+  (globalThis as unknown as { ResizeObserver: typeof RO }).ResizeObserver = RO;
+  Object.defineProperty(document, "fonts", { configurable: true, value: { ready: Promise.resolve() } });
+});
+
+describe("Terminal — clipboard behaviours (#71)", () => {
+  beforeEach(() => {
+    mocks.selectionHandlers.length = 0;
+    mocks.paste.mockClear();
+    mocks.readText.mockClear();
+    mocks.writeText.mockClear();
+    useSettingsStore.setState({ terminalCopyOnSelect: false, terminalPasteButton: "none" });
+  });
+
+  it("copies the selection when copy-on-select is enabled", async () => {
+    useSettingsStore.setState({ terminalCopyOnSelect: true });
+    render(<Terminal sessionId={SID} />);
+    act(() => mocks.selectionHandlers.forEach((cb) => cb()));
+    await waitFor(() => expect(mocks.writeText).toHaveBeenCalledWith("SELECTED"));
+  });
+
+  it("does not copy on selection when copy-on-select is disabled", async () => {
+    render(<Terminal sessionId={SID} />);
+    act(() => mocks.selectionHandlers.forEach((cb) => cb()));
+    await Promise.resolve();
+    expect(mocks.writeText).not.toHaveBeenCalled();
+  });
+
+  it("pastes on middle-click when the paste button is 'middle'", async () => {
+    useSettingsStore.setState({ terminalPasteButton: "middle" });
+    render(<Terminal sessionId={SID} />);
+    fireEvent.mouseDown(container(), { button: 1 });
+    await waitFor(() => expect(mocks.paste).toHaveBeenCalledWith("CLIP"));
+  });
+
+  it("pastes on right-click when the paste button is 'right'", async () => {
+    useSettingsStore.setState({ terminalPasteButton: "right" });
+    render(<Terminal sessionId={SID} />);
+    fireEvent.contextMenu(container());
+    await waitFor(() => expect(mocks.paste).toHaveBeenCalledWith("CLIP"));
+  });
+
+  it("does not paste when the wrong button is used or paste is off", async () => {
+    useSettingsStore.setState({ terminalPasteButton: "middle" });
+    render(<Terminal sessionId={SID} />);
+    // Right-click while configured for middle → no paste.
+    fireEvent.contextMenu(container());
+    // Primary button down → no paste.
+    fireEvent.mouseDown(container(), { button: 0 });
+    await Promise.resolve();
+    expect(mocks.paste).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/file-types.test.ts
+++ b/src/lib/file-types.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { isEditableInEditor } from "./file-types";
+
+describe("isEditableInEditor", () => {
+  it("returns false for binary media, documents, archives, and executables", () => {
+    for (const name of [
+      "clip.mov", "movie.MP4", "song.mp3", "photo.JPG", "scan.pdf",
+      "sheet.xlsx", "bundle.zip", "installer.dmg", "lib.so", "font.woff2",
+      "data.sqlite", "image.png",
+    ]) {
+      expect(isEditableInEditor(name), name).toBe(false);
+    }
+  });
+
+  it("returns true for text, code, config, and log files", () => {
+    for (const name of [
+      "server.log", "main.rs", "index.ts", "config.yaml", "notes.txt",
+      "deploy.sh", "data.json", "style.css", "page.html", "query.sql",
+    ]) {
+      expect(isEditableInEditor(name), name).toBe(true);
+    }
+  });
+
+  it("treats extensionless files and dotfiles as text", () => {
+    for (const name of ["Dockerfile", "Makefile", "README", ".env", ".bashrc", ".gitignore"]) {
+      expect(isEditableInEditor(name), name).toBe(true);
+    }
+  });
+
+  it("keys off the last extension for multi-dot names", () => {
+    expect(isEditableInEditor("archive.tar.gz")).toBe(false);
+    expect(isEditableInEditor("app.min.js")).toBe(true);
+    expect(isEditableInEditor(".env.local")).toBe(true);
+  });
+});

--- a/src/lib/file-types.ts
+++ b/src/lib/file-types.ts
@@ -1,0 +1,43 @@
+// File-type heuristics for the Explorer.
+//
+// Extensions we treat as non-text/binary. When the double-click action is "Open
+// in Editor" (Settings → Explorer), files matching these fall back to download
+// instead of being dumped — as raw bytes — into a text editor (e.g. .mov, .pdf,
+// images, archives). The Edit / Open With context-menu actions are deliberately
+// NOT filtered: those let the user force any file open on purpose.
+const BINARY_EXTENSIONS = new Set<string>([
+  // Video
+  "mov", "mp4", "m4v", "mkv", "avi", "wmv", "flv", "webm", "mpg", "mpeg", "3gp", "ogv",
+  // Audio
+  "mp3", "wav", "flac", "aac", "ogg", "oga", "m4a", "wma", "opus", "aiff", "mid", "midi",
+  // Images
+  "png", "jpg", "jpeg", "gif", "bmp", "tif", "tiff", "ico", "webp", "heic", "heif", "avif",
+  "psd", "raw", "cr2", "nef", "arw", "dng",
+  // Documents / office
+  "pdf", "doc", "docx", "xls", "xlsx", "ppt", "pptx", "odt", "ods", "odp", "epub", "mobi",
+  // Archives / compressed
+  "zip", "tar", "gz", "tgz", "bz2", "tbz2", "xz", "txz", "7z", "rar", "zst", "lz", "lz4",
+  "lzma", "cab", "ar",
+  // Executables / binaries / libraries
+  "exe", "dll", "so", "dylib", "bin", "o", "obj", "class", "jar", "war", "wasm", "pyc",
+  "pyo", "msi", "deb", "rpm", "dmg", "pkg", "apk", "appimage", "elf",
+  // Disk images
+  "iso", "img", "vmdk", "vdi", "qcow2",
+  // Fonts
+  "ttf", "otf", "woff", "woff2", "eot",
+  // Databases
+  "db", "sqlite", "sqlite3", "mdb", "accdb",
+]);
+
+/**
+ * Whether a file should open in a text editor on double-click. Returns false for
+ * known binary formats (video / audio / images / archives / executables / …),
+ * which are useless in a code editor — those fall back to download. Files with
+ * no extension or a leading-dot dotfile name (e.g. `Dockerfile`, `.env`) are
+ * treated as text, matching how scripts and config on servers typically look.
+ */
+export function isEditableInEditor(name: string): boolean {
+  const dot = name.lastIndexOf(".");
+  if (dot <= 0) return true; // no extension, or a leading-dot dotfile (".env")
+  return !BINARY_EXTENSIONS.has(name.slice(dot + 1).toLowerCase());
+}

--- a/src/stores/settings-store.test.ts
+++ b/src/stores/settings-store.test.ts
@@ -80,3 +80,42 @@ describe("settings-store — terminal clipboard settings (#71)", () => {
     expect(useSettingsStore.getState().terminalPasteButton).toBe("none");
   });
 });
+
+describe("settings-store — explorer double-click action", () => {
+  beforeEach(() => {
+    invoke.mockReset();
+    invoke.mockResolvedValue(undefined);
+    useSettingsStore.setState({ explorerDoubleClickAction: "download" });
+  });
+
+  it("defaults to download", () => {
+    expect(useSettingsStore.getState().explorerDoubleClickAction).toBe("download");
+  });
+
+  it("sets and persists the double-click action", async () => {
+    useSettingsStore.getState().setExplorerDoubleClickAction("open");
+    expect(useSettingsStore.getState().explorerDoubleClickAction).toBe("open");
+    await vi.waitFor(() =>
+      expect(invoke).toHaveBeenCalledWith("save_setting", {
+        key: "explorer_double_click_action",
+        value: "open",
+      }),
+    );
+  });
+
+  it("loads the action, falling back to download for an unknown value", async () => {
+    invoke.mockImplementation(async (cmd: string) => {
+      if (cmd === "load_all_settings") {
+        return [
+          ["explorer_double_click_action", "nonsense"],
+          ["editors_seeded", "true"],
+        ];
+      }
+      return undefined;
+    });
+
+    await useSettingsStore.getState().loadSettings();
+
+    expect(useSettingsStore.getState().explorerDoubleClickAction).toBe("download");
+  });
+});

--- a/src/stores/settings-store.ts
+++ b/src/stores/settings-store.ts
@@ -4,6 +4,8 @@ export type CursorStyle = "block" | "bar" | "underline";
 export type ThemeMode = "dark" | "light";
 /** Which mouse button pastes the clipboard into the terminal (#71). */
 export type PasteButton = "none" | "right" | "middle";
+/** What double-clicking a file in the Explorer does. */
+export type DoubleClickAction = "download" | "open";
 
 /** Full custom accent colour in oklch components (lightness, chroma, hue). */
 export interface AccentCustom { l: number; c: number; h: number }
@@ -44,6 +46,9 @@ interface SettingsState {
   terminalCopyOnSelect: boolean;
   terminalPasteButton: PasteButton;
 
+  // Explorer
+  explorerDoubleClickAction: DoubleClickAction;
+
   // Transfers
   transferConcurrency: number;
 
@@ -69,6 +74,7 @@ interface SettingsState {
   setTerminalScrollback: (lines: number) => void;
   setTerminalCopyOnSelect: (enabled: boolean) => void;
   setTerminalPasteButton: (button: PasteButton) => void;
+  setExplorerDoubleClickAction: (action: DoubleClickAction) => void;
   setTransferConcurrency: (n: number) => void;
   addEditor: (editor: Omit<EditorConfig, "id">) => void;
   updateEditor: (id: string, patch: Partial<Omit<EditorConfig, "id">>) => void;
@@ -93,6 +99,7 @@ const DEFAULTS = {
   terminalScrollback: 5000,
   terminalCopyOnSelect: false,
   terminalPasteButton: "none" as PasteButton,
+  explorerDoubleClickAction: "download" as DoubleClickAction,
   transferConcurrency: 3,
   editors: [] as EditorConfig[],
   defaultEditorId: null as string | null,
@@ -268,6 +275,11 @@ export const useSettingsStore = create<SettingsState>((set) => ({
     persist("terminal_copy_on_select", String(enabled));
   },
 
+  setExplorerDoubleClickAction: (action) => {
+    set({ explorerDoubleClickAction: action });
+    persist("explorer_double_click_action", action);
+  },
+
   setTerminalPasteButton: (button) => {
     set({ terminalPasteButton: button });
     persist("terminal_paste_button", button);
@@ -339,6 +351,7 @@ export const useSettingsStore = create<SettingsState>((set) => ({
           case "terminal_scrollback": updates.terminalScrollback = Number(value) || DEFAULTS.terminalScrollback; break;
           case "terminal_copy_on_select": updates.terminalCopyOnSelect = value === "true"; break;
           case "terminal_paste_button": updates.terminalPasteButton = value === "right" || value === "middle" ? value : DEFAULTS.terminalPasteButton; break;
+          case "explorer_double_click_action": updates.explorerDoubleClickAction = value === "open" ? "open" : "download"; break;
           case "transfer_concurrency": updates.transferConcurrency = Number(value) || DEFAULTS.transferConcurrency; break;
           case "app_interface_font": updates.interfaceFont = value || DEFAULTS.interfaceFont; break;
           case "app_auto_update": updates.autoUpdate = value !== "false"; break;


### PR DESCRIPTION
## What

Adds a new **Settings → Explorer** section with a **Double-click a File** option, so users can choose what happens when they double-click a file in the browser:

- **Download** — the current behaviour (default, so nothing changes unless opted in).
- **Open in Editor** — opens the file in the configured default external editor.

Opening **falls back to downloading** when no editor is configured or the provider can't edit, so a double-click never silently does nothing. Directories still navigate as before.

This mirrors the per-domain settings pattern (like Terminal → Clipboard from #79) and gives the Explorer its own settings home, ready for future file-browser options.

## Implementation

- **`settings-store.ts`** — `explorerDoubleClickAction: "download" | "open"`, persisted as `explorer_double_click_action` in the existing key-value `app_settings` table. No schema/migration change.
- **`SettingsPage.tsx`** — new "Explorer" section (FolderOpen icon) with a `SegmentedControl`.
- **`ExplorerFileTable.tsx`** — `handleDoubleClick` honours the setting; "open" uses the default editor via the existing `onEditInEditor` path (`sftp_edit_external` / `s3_edit_external`). Shared by the SFTP, SCP, and S3 browsers.

## Tests

- `settings-store.test.ts`: default, setter + persisted value, and load parsing with a fallback for an unknown value. `tsc --noEmit` clean; full Vitest suite green (the one unrelated, pre-existing `DropOverwriteDialog` failure aside).