### PR TITLE
feat(tunnels): import SSH forwards as tunnels + working per-tunnel au…

### DIFF
--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -1566,6 +1566,44 @@ impl HostDb {
         Ok(())
     }
 
+    /// Look up an existing rule id by its natural key (host + type + listen
+    /// bind/port + destination). Used by the SSH-config import to make
+    /// re-importing the same host idempotent: a matching rule is left untouched
+    /// rather than duplicated. Returns `None` when no rule matches.
+    #[allow(clippy::too_many_arguments)]
+    pub fn find_pf_rule_id_by_natural_key(
+        &self,
+        host_id: &str,
+        forward_type: &str,
+        bind_address: &str,
+        local_port: u32,
+        remote_host: &str,
+        remote_port: u32,
+    ) -> Result<Option<String>, DbError> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| DbError::InitError(format!("db lock poisoned: {e}")))?;
+        let id = conn
+            .query_row(
+                "SELECT id FROM port_forwarding_rules
+                 WHERE host_id = ?1 AND forward_type = ?2 AND bind_address = ?3
+                   AND local_port = ?4 AND remote_host = ?5 AND remote_port = ?6
+                 LIMIT 1",
+                params![
+                    host_id,
+                    forward_type,
+                    bind_address,
+                    local_port as i64,
+                    remote_host,
+                    remote_port as i64
+                ],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?;
+        Ok(id)
+    }
+
     /// Update last_used_at timestamp for a rule.
     pub fn touch_pf_rule(&self, id: &str) -> Result<(), DbError> {
         let conn = self
@@ -1614,6 +1652,26 @@ impl HostDb {
             let rows = stmt.query_map([], Self::map_pf_row)?;
             Ok(rows.collect::<Result<Vec<_>, _>>()?)
         }
+    }
+
+    /// Look up a single port-forwarding rule by id. Returns `None` when absent.
+    pub fn get_pf_rule(
+        &self,
+        id: &str,
+    ) -> Result<Option<crate::portforward::PortForwardRule>, DbError> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| DbError::InitError(format!("db lock poisoned: {e}")))?;
+        let rule = conn
+            .query_row(
+                "SELECT id, host_id, label, forward_type, bind_address, local_port, remote_host, remote_port, auto_start, enabled, created_at, description, last_used_at, total_bytes
+                 FROM port_forwarding_rules WHERE id = ?1",
+                params![id],
+                Self::map_pf_row,
+            )
+            .optional()?;
+        Ok(rule)
     }
 
     fn map_pf_row(row: &rusqlite::Row) -> rusqlite::Result<crate::portforward::PortForwardRule> {
@@ -2896,5 +2954,43 @@ mod tests {
             .map(|g| g.id)
             .collect::<Vec<_>>();
         assert_eq!(ids, vec!["a", "b"], "order unchanged after rollback");
+    }
+
+    #[test]
+    fn pf_rule_natural_key_lookup_and_get() {
+        let (db, _dir) = test_db();
+        db.save_host(&sample_host("h1")).expect("host");
+        db.create_pf_rule(
+            "r1",
+            Some("h1"),
+            Some("DB"),
+            None,
+            "local",
+            "127.0.0.1",
+            5432,
+            "localhost",
+            5432,
+            true,
+        )
+        .expect("create rule");
+
+        // Exact natural-key match returns the id; a differing port does not.
+        assert_eq!(
+            db.find_pf_rule_id_by_natural_key("h1", "local", "127.0.0.1", 5432, "localhost", 5432)
+                .unwrap()
+                .as_deref(),
+            Some("r1")
+        );
+        assert_eq!(
+            db.find_pf_rule_id_by_natural_key("h1", "local", "127.0.0.1", 9999, "localhost", 5432)
+                .unwrap(),
+            None
+        );
+
+        // get_pf_rule round-trips the auto_start flag and forward type.
+        let rule = db.get_pf_rule("r1").unwrap().expect("rule present");
+        assert!(rule.auto_start);
+        assert_eq!(rule.forward_type, crate::portforward::ForwardType::Local);
+        assert!(db.get_pf_rule("nope").unwrap().is_none());
     }
 }

--- a/src-tauri/src/import/commands.rs
+++ b/src-tauri/src/import/commands.rs
@@ -48,59 +48,97 @@ pub async fn import_save_ssh_hosts(
         let mut skipped = 0u32;
         let mut errors = Vec::new();
 
-        // alias (Host block name) → generated host id, for ProxyJump resolution.
+        // alias (Host block name) → host id, for ProxyJump resolution.
         let mut alias_to_id: std::collections::HashMap<String, String> =
             std::collections::HashMap::new();
         // (host id, alias, raw ProxyJump value) tuples that still need resolving.
         let mut pending_jumps: Vec<(String, String, String)> = Vec::new();
 
+        // Whether imported forwards should default to auto-start. OpenSSH
+        // auto-activates LocalForward on connect, so the global default is
+        // `true` unless the user turned it off in Settings.
+        let auto_start_default = auto_start_default(&db);
+
+        // Snapshot of pre-existing hosts so re-importing the same config reuses
+        // the existing host (keyed by host+user+port) instead of piling up
+        // duplicate host rows — which also makes tunnel import idempotent.
+        let preexisting = db.list_hosts().unwrap_or_default();
+
         for entry in &entries {
-            let now = timestamp_now();
-            let id = uuid::Uuid::new_v4().to_string();
+            // Reuse an existing host with the same (host, user, port); otherwise
+            // create a fresh one. Either way `host_id` is what tunnels bind to.
+            let existing = preexisting.iter().find(|h| {
+                h.host == entry.hostname && h.username == entry.user && h.port == entry.port
+            });
 
-            let host = SavedHost {
-                id: id.clone(),
-                label: entry.host_alias.clone(),
-                host: entry.hostname.clone(),
-                port: entry.port as _,
-                username: entry.user.clone(),
-                auth_type: if entry.identity_file.is_some() {
-                    "privateKey".to_string()
-                } else {
-                    "password".to_string()
-                },
-                key_path: entry.identity_file.clone(),
-                group_id: None,
-                color: None,
-                notes: None,
-                environment: None,
-                os_type: None,
-                startup_command: None,
-                proxy_jump: entry.proxy_jump.clone(),
-                proxy_jump_host_id: None,
-                start_directory: None,
-                keep_alive_interval: entry.keep_alive_interval,
-                default_shell: None,
-                font_size: None,
-                last_connected_at: None,
-                connection_count: None,
-                created_at: now.clone(),
-                updated_at: now,
-            };
+            let host_id = if let Some(h) = existing {
+                // Host already present — don't duplicate it, but still attach any
+                // newly-added forwards below. Counts as skipped at the host level.
+                skipped += 1;
+                alias_to_id.insert(entry.host_alias.clone(), h.id.clone());
+                h.id.clone()
+            } else {
+                let now = timestamp_now();
+                let id = uuid::Uuid::new_v4().to_string();
 
-            match db.save_host(&host) {
-                Ok(()) => {
-                    imported += 1;
-                    alias_to_id.insert(entry.host_alias.clone(), id.clone());
-                    if let Some(pj) = entry.proxy_jump.as_ref().filter(|s| !s.trim().is_empty()) {
-                        pending_jumps.push((id, entry.host_alias.clone(), pj.clone()));
+                let host = SavedHost {
+                    id: id.clone(),
+                    label: entry.host_alias.clone(),
+                    host: entry.hostname.clone(),
+                    port: entry.port as _,
+                    username: entry.user.clone(),
+                    auth_type: if entry.identity_file.is_some() {
+                        "privateKey".to_string()
+                    } else {
+                        "password".to_string()
+                    },
+                    key_path: entry.identity_file.clone(),
+                    group_id: None,
+                    color: None,
+                    notes: None,
+                    environment: None,
+                    os_type: None,
+                    startup_command: None,
+                    proxy_jump: entry.proxy_jump.clone(),
+                    proxy_jump_host_id: None,
+                    start_directory: None,
+                    keep_alive_interval: entry.keep_alive_interval,
+                    default_shell: None,
+                    font_size: None,
+                    last_connected_at: None,
+                    connection_count: None,
+                    created_at: now.clone(),
+                    updated_at: now,
+                };
+
+                match db.save_host(&host) {
+                    Ok(()) => {
+                        imported += 1;
+                        alias_to_id.insert(entry.host_alias.clone(), id.clone());
+                        if let Some(pj) = entry.proxy_jump.as_ref().filter(|s| !s.trim().is_empty())
+                        {
+                            pending_jumps.push((id.clone(), entry.host_alias.clone(), pj.clone()));
+                        }
+                        id
+                    }
+                    Err(e) => {
+                        errors.push(format!("{}: {e}", entry.host_alias));
+                        skipped += 1;
+                        continue;
                     }
                 }
-                Err(e) => {
-                    errors.push(format!("{}: {e}", entry.host_alias));
-                    skipped += 1;
-                }
-            }
+            };
+
+            // Materialise the host's forward directives as tunnel records,
+            // skipping any that already exist (idempotent re-import).
+            import_forwards_for_host(
+                &db,
+                &host_id,
+                &entry.host_alias,
+                &entry.forwards,
+                auto_start_default,
+                &mut errors,
+            );
         }
 
         // Second pass: resolve each parsed ProxyJump value against the imported
@@ -149,6 +187,74 @@ pub async fn import_save_ssh_hosts(
 fn timestamp_now() -> String {
     // SQLite-compatible datetime string
     "datetime('now')".to_string()
+}
+
+/// Read the global "auto-start tunnels by default" preference. Defaults to
+/// `true` (matching OpenSSH, which auto-activates forwards on connect) when the
+/// setting was never written.
+fn auto_start_default(db: &HostDb) -> bool {
+    !matches!(
+        db.get_setting(crate::portforward::AUTO_START_DEFAULT_SETTING_KEY)
+            .ok()
+            .flatten()
+            .as_deref(),
+        Some("false")
+    )
+}
+
+/// Create one tunnel record per forward directive for `host_id`, skipping any
+/// that already exist (matched on the natural key) so re-importing the same
+/// config never duplicates tunnels. Failures are recorded per-forward and do
+/// not abort the import.
+fn import_forwards_for_host(
+    db: &HostDb,
+    host_id: &str,
+    alias: &str,
+    forwards: &[super::SshForward],
+    auto_start_default: bool,
+    errors: &mut Vec<String>,
+) {
+    for fwd in forwards {
+        match db.find_pf_rule_id_by_natural_key(
+            host_id,
+            &fwd.forward_type,
+            &fwd.bind_address,
+            fwd.listen_port as u32,
+            &fwd.dest_host,
+            fwd.dest_port as u32,
+        ) {
+            Ok(Some(_)) => continue, // already imported — idempotent skip
+            Ok(None) => {}
+            Err(e) => {
+                errors.push(format!("{alias}: tunnel lookup failed: {e}"));
+                continue;
+            }
+        }
+
+        let id = uuid::Uuid::new_v4().to_string();
+        let label = format!(
+            "{} {}",
+            fwd.forward_type
+                .get(0..1)
+                .map(|c| c.to_uppercase() + &fwd.forward_type[1..])
+                .unwrap_or_else(|| fwd.forward_type.clone()),
+            fwd.listen_port
+        );
+        if let Err(e) = db.create_pf_rule(
+            &id,
+            Some(host_id),
+            Some(&label),
+            None,
+            &fwd.forward_type,
+            &fwd.bind_address,
+            fwd.listen_port as u32,
+            &fwd.dest_host,
+            fwd.dest_port as u32,
+            auto_start_default,
+        ) {
+            errors.push(format!("{alias}: tunnel not created: {e}"));
+        }
+    }
 }
 
 /// Resolve a single-hop `ProxyJump` directive value to a saved-host id.
@@ -311,5 +417,44 @@ mod tests {
     #[test]
     fn unmatched_value_returns_none() {
         assert_eq!(resolve_jump_target("nope", &HashMap::new(), &[]), None);
+    }
+
+    #[test]
+    fn import_forwards_is_idempotent() {
+        let dir = std::env::temp_dir().join(format!("anyscp-imp-{}", uuid::Uuid::new_v4()));
+        let db = HostDb::new(&dir).expect("db");
+        let mut h = host("h1", "web", "10.0.0.1");
+        h.created_at = "t".into();
+        h.updated_at = "t".into();
+        db.save_host(&h).expect("save host");
+
+        let forwards = vec![
+            super::super::SshForward {
+                forward_type: "local".into(),
+                bind_address: "127.0.0.1".into(),
+                listen_port: 81,
+                dest_host: "localhost".into(),
+                dest_port: 81,
+            },
+            super::super::SshForward {
+                forward_type: "dynamic".into(),
+                bind_address: "127.0.0.1".into(),
+                listen_port: 1080,
+                dest_host: String::new(),
+                dest_port: 0,
+            },
+        ];
+
+        let mut errors = Vec::new();
+        import_forwards_for_host(&db, "h1", "web", &forwards, true, &mut errors);
+        // Re-import the same forwards: must NOT create duplicates.
+        import_forwards_for_host(&db, "h1", "web", &forwards, true, &mut errors);
+
+        assert!(errors.is_empty(), "no errors expected: {errors:?}");
+        let rules = db.list_pf_rules(Some("h1")).expect("list");
+        assert_eq!(rules.len(), 2, "exactly one tunnel per forward, no dupes");
+        assert!(rules.iter().all(|r| r.auto_start), "auto_start seeded true");
+
+        std::fs::remove_dir_all(&dir).ok();
     }
 }

--- a/src-tauri/src/import/mod.rs
+++ b/src-tauri/src/import/mod.rs
@@ -2,13 +2,37 @@ pub mod commands;
 
 use serde::{Deserialize, Serialize};
 use ssh2_config::{ParseRule, SshConfig};
+use std::collections::HashMap;
 use std::io::BufReader;
 use std::path::{Path, PathBuf};
 use tracing::info;
 
 use crate::types::SshError;
 
+/// Default bind address used when a forward directive omits one. Mirrors
+/// OpenSSH's behaviour (LocalForward/DynamicForward bind the loopback by
+/// default) and the project's own port-forwarding default.
+const DEFAULT_FORWARD_BIND: &str = "127.0.0.1";
+
 // ─── Types ───────────────────────────────────────────────────────────────────
+
+/// A single SSH port-forwarding directive parsed out of an `ssh_config` host
+/// block (`LocalForward` / `RemoteForward` / `DynamicForward`). Mapped onto a
+/// tunnel record on import.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SshForward {
+    /// Forward kind: `"local"`, `"remote"`, or `"dynamic"` — matches the
+    /// strings understood by [`crate::portforward::ForwardType::from_str`].
+    pub forward_type: String,
+    /// Local/remote bind address the listener is bound to.
+    pub bind_address: String,
+    /// Listening port.
+    pub listen_port: u16,
+    /// Destination host (empty for `DynamicForward`, which is a SOCKS proxy).
+    pub dest_host: String,
+    /// Destination port (0 for `DynamicForward`).
+    pub dest_port: u16,
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SshConfigEntry {
@@ -19,6 +43,9 @@ pub struct SshConfigEntry {
     pub identity_file: Option<String>,
     pub proxy_jump: Option<String>,
     pub keep_alive_interval: Option<u32>,
+    /// Port-forwarding directives found in this host block (may be empty).
+    #[serde(default)]
+    pub forwards: Vec<SshForward>,
     pub is_pattern: bool,
     pub already_exists: bool,
 }
@@ -32,6 +59,9 @@ pub struct SshConfigImportEntry {
     pub identity_file: Option<String>,
     pub proxy_jump: Option<String>,
     pub keep_alive_interval: Option<u32>,
+    /// Port-forwarding directives to materialise as tunnel records on import.
+    #[serde(default)]
+    pub forwards: Vec<SshForward>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -71,6 +101,11 @@ pub fn parse_ssh_config(
 
     // Pre-scan for Host block names
     let host_aliases = extract_host_aliases(&config_path)?;
+
+    // Pre-scan for port-forwarding directives, grouped by the Host alias they
+    // belong to. ssh2-config doesn't surface LocalForward/RemoteForward/
+    // DynamicForward, so this is a line-level scan mirroring the alias scan.
+    let forwards_by_alias = extract_forwards_by_alias(&config_path)?;
 
     info!(
         path = %config_path.display(),
@@ -126,6 +161,8 @@ pub fn parse_ssh_config(
             .iter()
             .any(|(h, u, p)| h == resolved_host && u == resolved_user && *p == resolved_port);
 
+        let forwards = forwards_by_alias.get(alias).cloned().unwrap_or_default();
+
         entries.push(SshConfigEntry {
             host_alias: alias.clone(),
             hostname,
@@ -134,6 +171,7 @@ pub fn parse_ssh_config(
             identity_file,
             proxy_jump,
             keep_alive_interval,
+            forwards,
             is_pattern,
             already_exists,
         });
@@ -209,4 +247,235 @@ fn resolve_key_path(path: &Path, home: &str) -> String {
 
     // Relative path — resolve relative to ~/.ssh/
     format!("{}/.ssh/{}", home, path_str)
+}
+
+// ─── Forward directive parsing ─────────────────────────────────────────────────
+
+/// Scan the config file for `LocalForward` / `RemoteForward` / `DynamicForward`
+/// directives, grouping each by the `Host` alias(es) of the block it sits in.
+///
+/// Mirrors the tolerance of the rest of the parser: keywords are matched
+/// case-insensitively and accept either `Keyword value` or `Keyword = value`
+/// syntax. Pattern aliases (`*`, `?`) and `Match` blocks are ignored — forwards
+/// are only attached to concrete host blocks the importer can turn into hosts.
+/// Directives that can't be cleanly mapped (e.g. unix-socket paths) are logged
+/// and skipped rather than aborting the whole import.
+fn extract_forwards_by_alias(path: &Path) -> Result<HashMap<String, Vec<SshForward>>, SshError> {
+    let content = std::fs::read_to_string(path)
+        .map_err(|e| SshError::IoError(format!("Cannot read {}: {e}", path.display())))?;
+
+    let mut map: HashMap<String, Vec<SshForward>> = HashMap::new();
+    // Concrete (non-pattern) aliases of the host block currently being scanned.
+    let mut current: Vec<String> = Vec::new();
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+
+        // Split "Keyword rest" or "Keyword=rest" into a lowercased keyword and
+        // the remaining argument string.
+        let mut split = trimmed.splitn(2, |c: char| c.is_whitespace() || c == '=');
+        let keyword = split.next().unwrap_or("").to_ascii_lowercase();
+        let rest = split.next().unwrap_or("").trim_start_matches('=').trim();
+
+        match keyword.as_str() {
+            "host" => {
+                current = rest
+                    .split_whitespace()
+                    .filter(|a| !a.is_empty() && !a.contains('*') && !a.contains('?'))
+                    .map(String::from)
+                    .collect();
+            }
+            // A `Match` block changes scope away from a named host; don't attach
+            // forwards to whatever host preceded it.
+            "match" => current.clear(),
+            "localforward" | "remoteforward" | "dynamicforward" => {
+                if current.is_empty() {
+                    continue;
+                }
+                match parse_forward_line(&keyword, rest) {
+                    Some(fwd) => {
+                        for alias in &current {
+                            map.entry(alias.clone()).or_default().push(fwd.clone());
+                        }
+                    }
+                    None => {
+                        info!(directive = %trimmed, "skipping unparseable forward directive");
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    Ok(map)
+}
+
+/// Parse a single forward directive's argument string into an [`SshForward`].
+/// `keyword` is the already-lowercased directive name. Returns `None` for forms
+/// that can't be mapped (missing/garbled ports, unix-socket destinations, …).
+fn parse_forward_line(keyword: &str, args: &str) -> Option<SshForward> {
+    let mut parts = args.split_whitespace();
+    let first = parts.next()?;
+
+    match keyword {
+        "dynamicforward" => {
+            let (bind_address, listen_port) = parse_listen_endpoint(first)?;
+            Some(SshForward {
+                forward_type: "dynamic".to_string(),
+                bind_address,
+                listen_port,
+                dest_host: String::new(),
+                dest_port: 0,
+            })
+        }
+        "localforward" | "remoteforward" => {
+            let (bind_address, listen_port) = parse_listen_endpoint(first)?;
+            let (dest_host, dest_port) = parse_dest_endpoint(parts.next()?)?;
+            let forward_type = if keyword == "remoteforward" {
+                "remote"
+            } else {
+                "local"
+            };
+            Some(SshForward {
+                forward_type: forward_type.to_string(),
+                bind_address,
+                listen_port,
+                dest_host,
+                dest_port,
+            })
+        }
+        _ => None,
+    }
+}
+
+/// Parse the listen endpoint (first argument): `port`, `bind:port`, or
+/// `[ipv6]:port`. Falls back to the loopback bind address when none is given.
+fn parse_listen_endpoint(token: &str) -> Option<(String, u16)> {
+    // `[ipv6]:port`
+    if let Some(rest) = token.strip_prefix('[') {
+        let (addr, port) = rest.split_once("]:")?;
+        return Some((addr.to_string(), port.parse().ok()?));
+    }
+    // `bind:port`
+    if let Some((addr, port)) = token.rsplit_once(':') {
+        let port: u16 = port.parse().ok()?;
+        let bind = if addr.is_empty() {
+            DEFAULT_FORWARD_BIND.to_string()
+        } else {
+            addr.to_string()
+        };
+        return Some((bind, port));
+    }
+    // bare `port`
+    Some((DEFAULT_FORWARD_BIND.to_string(), token.parse().ok()?))
+}
+
+/// Parse the destination endpoint (`host:hostport` or `[ipv6]:hostport`). Unix
+/// socket paths and other non `host:port` forms return `None`.
+fn parse_dest_endpoint(token: &str) -> Option<(String, u16)> {
+    if let Some(rest) = token.strip_prefix('[') {
+        let (host, port) = rest.split_once("]:")?;
+        if host.is_empty() {
+            return None;
+        }
+        return Some((host.to_string(), port.parse().ok()?));
+    }
+    let (host, port) = token.rsplit_once(':')?;
+    if host.is_empty() {
+        return None;
+    }
+    Some((host.to_string(), port.parse().ok()?))
+}
+
+#[cfg(test)]
+mod forward_tests {
+    use super::*;
+
+    fn fwd(t: &str, bind: &str, lp: u16, dh: &str, dp: u16) -> SshForward {
+        SshForward {
+            forward_type: t.to_string(),
+            bind_address: bind.to_string(),
+            listen_port: lp,
+            dest_host: dh.to_string(),
+            dest_port: dp,
+        }
+    }
+
+    #[test]
+    fn parses_local_forward_bare_port() {
+        assert_eq!(
+            parse_forward_line("localforward", "81 localhost:81"),
+            Some(fwd("local", "127.0.0.1", 81, "localhost", 81))
+        );
+    }
+
+    #[test]
+    fn parses_local_forward_with_bind_address() {
+        assert_eq!(
+            parse_forward_line("localforward", "0.0.0.0:5432 db.internal:5432"),
+            Some(fwd("local", "0.0.0.0", 5432, "db.internal", 5432))
+        );
+    }
+
+    #[test]
+    fn parses_remote_forward() {
+        assert_eq!(
+            parse_forward_line("remoteforward", "8080 localhost:3000"),
+            Some(fwd("remote", "127.0.0.1", 8080, "localhost", 3000))
+        );
+    }
+
+    #[test]
+    fn parses_dynamic_forward_no_destination() {
+        assert_eq!(
+            parse_forward_line("dynamicforward", "1080"),
+            Some(fwd("dynamic", "127.0.0.1", 1080, "", 0))
+        );
+    }
+
+    #[test]
+    fn parses_ipv6_listen_endpoint() {
+        assert_eq!(
+            parse_forward_line("dynamicforward", "[::1]:1080"),
+            Some(fwd("dynamic", "::1", 1080, "", 0))
+        );
+    }
+
+    #[test]
+    fn skips_unix_socket_destination() {
+        assert_eq!(
+            parse_forward_line("localforward", "/tmp/sock localhost:22"),
+            None
+        );
+    }
+
+    #[test]
+    fn skips_local_forward_missing_destination() {
+        assert_eq!(parse_forward_line("localforward", "81"), None);
+    }
+
+    #[test]
+    fn groups_multiple_forwards_per_host() {
+        let dir = std::env::temp_dir().join(format!("anyscp-fwd-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("config");
+        std::fs::write(
+            &path,
+            "Host web\n  HostName 10.0.0.1\n  LocalForward 81 localhost:81\n  LocalForward 8888 localhost:8888\n  DynamicForward 1080\n\nHost *\n  LocalForward 9999 localhost:9999\n",
+        )
+        .unwrap();
+
+        let map = extract_forwards_by_alias(&path).unwrap();
+        let web = map.get("web").unwrap();
+        assert_eq!(web.len(), 3);
+        assert_eq!(web[0], fwd("local", "127.0.0.1", 81, "localhost", 81));
+        assert_eq!(web[2], fwd("dynamic", "127.0.0.1", 1080, "", 0));
+        // The `Host *` pattern block is ignored entirely.
+        assert!(!map.contains_key("*"));
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
 }

--- a/src-tauri/src/portforward/commands.rs
+++ b/src-tauri/src/portforward/commands.rs
@@ -1,13 +1,13 @@
 use std::sync::Arc;
 
-use tauri::State;
+use tauri::{AppHandle, Emitter, Manager, State};
 use tokio::task;
-use tracing::instrument;
+use tracing::{instrument, warn};
 
 use crate::db::{DbError, HostDb};
-use crate::ssh::manager::SshManager;
+use crate::types::{HostConfig, SshError};
 
-use super::{manager::PortForwardManager, ForwardType, PortForwardRule, TunnelStatus};
+use super::{manager::PortForwardManager, ForwardType, PortForwardRule, TunnelState, TunnelStatus};
 
 // ─── CRUD ────────────────────────────────────────────────────────────────────
 
@@ -28,6 +28,10 @@ pub async fn pf_create_rule(
 ) -> Result<PortForwardRule, DbError> {
     let id = uuid::Uuid::new_v4().to_string();
     let db = Arc::clone(&db);
+
+    // Store the canonical lowercase form (matches imported rules) regardless of
+    // the casing the frontend sent ("Local" vs "local").
+    let forward_type = forward_type.to_ascii_lowercase();
 
     let c_id = id.clone();
     let c_host_id = host_id.clone();
@@ -134,106 +138,138 @@ pub async fn pf_list_rules(
 
 // ─── Tunnel control ──────────────────────────────────────────────────────────
 
-#[tauri::command]
-#[instrument(skip(pf_manager, ssh_manager, db))]
-#[allow(clippy::too_many_arguments)]
-pub async fn pf_start_tunnel(
-    rule_id: String,
+/// Resolve a saved host into a [`HostConfig`] for a tunnel's dedicated SSH
+/// connection, including its full ProxyJump chain so a tunnel for a host that's
+/// only reachable through a bastion connects the same way the terminal does.
+/// Reuses the connect path's resolver (credentials from the vault, cycle-guarded
+/// jump chain) and runs the blocking DB/keychain work off the async runtime.
+async fn resolve_tunnel_host_config(
+    db: Arc<HostDb>,
     host_id: String,
-    bind_address: String,
-    local_port: u32,
-    remote_host: String,
-    remote_port: u32,
-    pf_manager: State<'_, Arc<PortForwardManager>>,
-    ssh_manager: State<'_, SshManager>,
-    db: State<'_, Arc<HostDb>>,
-) -> Result<TunnelStatus, crate::types::SshError> {
-    use crate::types::AuthMethod;
-
-    // Load host from DB
-    let db_clone = Arc::clone(&db);
-    let hid = host_id.clone();
-    let saved_host = task::spawn_blocking(move || db_clone.get_host(&hid))
-        .await
-        .map_err(|e| crate::types::SshError::IoError(format!("task panicked: {e}")))?
-        .map_err(|e| crate::types::SshError::IoError(e.to_string()))?
-        .ok_or_else(|| {
-            crate::types::SshError::SessionNotFound(format!("host not found: {host_id}"))
-        })?;
-
-    // Resolve credentials from vault
-    let vid = host_id.clone();
-    let auth_type = saved_host.auth_type.clone();
-    let key_path = saved_host.key_path.clone();
-
-    let auth_method = task::spawn_blocking(move || -> AuthMethod {
-        match auth_type.as_str() {
-            "privateKey" => {
-                let path = key_path.unwrap_or_default();
-                let passphrase = match crate::vault::get_credential(&vid) {
-                    Ok(crate::vault::StoredCredential::KeyPassphrase { passphrase }) => {
-                        Some(passphrase)
-                    }
-                    _ => None,
-                };
-                AuthMethod::PrivateKey {
-                    key_path: path,
-                    passphrase,
-                }
-            }
-            _ => {
-                let password = match crate::vault::get_credential(&vid) {
-                    Ok(crate::vault::StoredCredential::Password { password }) => password,
-                    _ => String::new(),
-                };
-                AuthMethod::Password { password }
-            }
-        }
+) -> Result<HostConfig, SshError> {
+    task::spawn_blocking(move || {
+        crate::ssh::commands::build_host_config_blocking(&host_id, &db, &mut Vec::new())
     })
     .await
-    .map_err(|e| crate::types::SshError::IoError(format!("task panicked: {e}")))?;
+    .map_err(|e| SshError::IoError(format!("task panicked: {e}")))?
+}
 
-    // Connect SSH (no PTY needed for tunnels)
-    let config = crate::types::HostConfig {
-        host: saved_host.host,
-        port: saved_host.port,
-        username: saved_host.username,
-        auth_method,
-        label: if saved_host.label.is_empty() {
-            None
-        } else {
-            Some(saved_host.label)
-        },
-        keep_alive_interval: None,
-        default_shell: None,
-        startup_command: None,
-        // Port-forwarding connects directly; ProxyJump tunnelling is handled by
-        // the terminal/SFTP connect paths.
-        jump_host: None,
+/// Start the tunnel described by `rule`, establishing its own dedicated SSH
+/// connection. `auto_started` marks tunnels brought up automatically on host
+/// connect so they can be torn down when the host disconnects.
+async fn start_rule(
+    app_handle: AppHandle,
+    rule: PortForwardRule,
+    auto_started: bool,
+) -> Result<TunnelStatus, SshError> {
+    let host_id = rule
+        .host_id
+        .clone()
+        .ok_or_else(|| SshError::SessionNotFound("tunnel has no host".to_string()))?;
+
+    let db = app_handle.state::<Arc<HostDb>>().inner().clone();
+    let pf_manager = app_handle
+        .state::<Arc<PortForwardManager>>()
+        .inner()
+        .clone();
+
+    let config = resolve_tunnel_host_config(db.clone(), host_id.clone()).await?;
+
+    // Record last_used_at (best effort).
+    let dbc = db.clone();
+    let rid = rule.id.clone();
+    let _ = task::spawn_blocking(move || dbc.touch_pf_rule(&rid)).await;
+
+    pf_manager
+        .start_tunnel(
+            rule.id,
+            rule.forward_type,
+            config,
+            rule.bind_address,
+            rule.local_port,
+            rule.remote_host,
+            rule.remote_port,
+            Some(host_id),
+            auto_started,
+        )
+        .await
+}
+
+/// Start a single tunnel on demand (manual toggle from the UI). The rule is
+/// loaded from the DB so its forward type and parameters are authoritative.
+#[tauri::command]
+#[instrument(skip(db))]
+pub async fn pf_start_tunnel(
+    rule_id: String,
+    app_handle: AppHandle,
+    db: State<'_, Arc<HostDb>>,
+) -> Result<TunnelStatus, SshError> {
+    let dbc = Arc::clone(&db);
+    let rid = rule_id.clone();
+    let rule = task::spawn_blocking(move || dbc.get_pf_rule(&rid))
+        .await
+        .map_err(|e| SshError::IoError(format!("task panicked: {e}")))?
+        .map_err(|e| SshError::IoError(e.to_string()))?
+        .ok_or_else(|| SshError::SessionNotFound(format!("tunnel rule not found: {rule_id}")))?;
+
+    let status = start_rule(app_handle, rule, false).await?;
+    crate::telemetry::capture("tunnel_started", serde_json::json!({}));
+    Ok(status)
+}
+
+/// Start every `auto_start` tunnel bound to `host_id`. Invoked in the background
+/// right after a host's SSH session is established. Each tunnel gets its own
+/// connection; a failure to bring one up surfaces as a non-fatal `pf:status`
+/// error and never aborts the others or the host connection.
+pub async fn start_auto_tunnels_for_host(app_handle: AppHandle, host_id: String) {
+    let db = app_handle.state::<Arc<HostDb>>().inner().clone();
+
+    let hid = host_id.clone();
+    let rules = match task::spawn_blocking(move || db.list_pf_rules(Some(&hid))).await {
+        Ok(Ok(rules)) => rules,
+        Ok(Err(e)) => {
+            warn!(host_id = %host_id, error = %e, "auto-start: failed to list tunnels");
+            return;
+        }
+        Err(e) => {
+            warn!(host_id = %host_id, error = %e, "auto-start: list task panicked");
+            return;
+        }
     };
 
-    let session_id = ssh_manager.connect_no_pty(config, None).await?;
-    let handle = ssh_manager.get_handle(&session_id.0)?;
+    for rule in rules.into_iter().filter(|r| r.auto_start) {
+        let rule_id = rule.id.clone();
+        let local_port = rule.local_port;
+        match start_rule(app_handle.clone(), rule, true).await {
+            Ok(_) => {
+                info_started(&rule_id);
+            }
+            Err(e) => {
+                warn!(rule_id = %rule_id, error = %e, "auto-start: tunnel failed");
+                // Surface a non-fatal error to the UI without stopping the rest.
+                let _ = app_handle.emit(
+                    "pf:status",
+                    &TunnelStatus {
+                        rule_id,
+                        status: TunnelState::Error,
+                        local_port,
+                        connections: 0,
+                        error: Some(e.to_string()),
+                    },
+                );
+            }
+        }
+    }
+}
 
-    // Record last_used_at
-    let db_clone = Arc::clone(&db);
-    let rid = rule_id.clone();
-    let _ = task::spawn_blocking(move || db_clone.touch_pf_rule(&rid)).await;
+/// Stop all auto-started tunnels for a host (called when the host disconnects).
+pub fn stop_auto_tunnels_for_host(app_handle: &AppHandle, host_id: &str) {
+    let pf_manager = app_handle.state::<Arc<PortForwardManager>>();
+    pf_manager.stop_auto_started_for_host(host_id);
+}
 
-    let status = pf_manager
-        .start_tunnel(
-            rule_id,
-            handle,
-            bind_address,
-            local_port,
-            remote_host,
-            remote_port,
-        )
-        .await?;
-
-    crate::telemetry::capture("tunnel_started", serde_json::json!({}));
-
-    Ok(status)
+fn info_started(rule_id: &str) {
+    tracing::info!(rule_id = %rule_id, "auto-start: tunnel active");
 }
 
 #[tauri::command]

--- a/src-tauri/src/portforward/manager.rs
+++ b/src-tauri/src/portforward/manager.rs
@@ -1,25 +1,45 @@
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 use std::sync::Arc;
 
+use async_trait::async_trait;
 use dashmap::DashMap;
+use russh::client;
 use tauri::{AppHandle, Emitter};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::net::TcpListener;
+use tokio::net::{TcpListener, TcpStream};
 use tokio_util::sync::CancellationToken;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 use crate::ssh::handler::SshClientHandler;
-use crate::types::SshError;
+use crate::ssh::manager::SshManager;
+use crate::types::{HostConfig, SshError};
 
-use super::{TunnelState, TunnelStatus};
+use super::{ForwardType, TunnelState, TunnelStatus};
+
+/// Monotonic id distinguishing successive tunnel instances for the same rule.
+/// Lets a stale listener task tell whether the map entry under its rule id is
+/// still *its own* instance before touching it — so restarting a tunnel (e.g.
+/// on reconnect) can't have the previous instance's teardown clobber the new
+/// one's status/event.
+static INSTANCE_SEQ: AtomicU64 = AtomicU64::new(1);
+
+fn next_instance_id() -> u64 {
+    INSTANCE_SEQ.fetch_add(1, Ordering::Relaxed)
+}
 
 struct ActiveTunnel {
     rule_id: String,
+    instance_id: u64,
     local_port: u32,
     cancel_token: CancellationToken,
     connection_count: Arc<AtomicU32>,
     status: TunnelState,
     error: Option<String>,
+    /// Host this tunnel belongs to (if any). Used to tear down auto-started
+    /// tunnels when their host disconnects.
+    host_id: Option<String>,
+    /// Whether this tunnel was started automatically on host connect.
+    auto_started: bool,
 }
 
 pub struct PortForwardManager {
@@ -35,49 +55,137 @@ impl PortForwardManager {
         }
     }
 
+    /// Start a tunnel for `rule_id`. Establishes a dedicated SSH connection from
+    /// `config` (owned for the tunnel's lifetime) and brings up the appropriate
+    /// forwarding for `forward_type`:
+    ///
+    /// * `Local` — bind a local listener, proxy each connection to
+    ///   `remote_host:remote_port` over a `direct-tcpip` channel.
+    /// * `Dynamic` — bind a local SOCKS5 proxy; the destination of each
+    ///   connection is negotiated per-request (`remote_host`/`remote_port` are
+    ///   ignored).
+    /// * `Remote` — ask the server to listen on `bind_address:local_port` and
+    ///   forward back to `remote_host:remote_port` on this machine.
+    ///
+    /// Any previously-active tunnel for the same `rule_id` is stopped first, so
+    /// re-starting (e.g. on reconnect) never collides with its own leftover
+    /// listener.
+    #[allow(clippy::too_many_arguments)]
     pub async fn start_tunnel(
         &self,
         rule_id: String,
-        handle: Arc<tokio::sync::Mutex<russh::client::Handle<SshClientHandler>>>,
+        forward_type: ForwardType,
+        config: HostConfig,
         bind_address: String,
         local_port: u32,
         remote_host: String,
         remote_port: u32,
+        host_id: Option<String>,
+        auto_started: bool,
     ) -> Result<TunnelStatus, SshError> {
-        // Stop existing tunnel for this rule if any
+        // Stop existing tunnel for this rule if any (clean slate).
         let _ = self.stop_tunnel(&rule_id);
 
-        // Bind local TCP listener
+        match forward_type {
+            ForwardType::Local | ForwardType::Dynamic => {
+                self.start_listener_tunnel(
+                    rule_id,
+                    forward_type,
+                    config,
+                    bind_address,
+                    local_port,
+                    remote_host,
+                    remote_port,
+                    host_id,
+                    auto_started,
+                )
+                .await
+            }
+            ForwardType::Remote => {
+                self.start_remote_tunnel(
+                    rule_id,
+                    config,
+                    bind_address,
+                    local_port,
+                    remote_host,
+                    remote_port,
+                    host_id,
+                    auto_started,
+                )
+                .await
+            }
+        }
+    }
+
+    /// Local & Dynamic forwarding: bind a local TCP listener and proxy each
+    /// accepted connection over the SSH connection.
+    #[allow(clippy::too_many_arguments)]
+    async fn start_listener_tunnel(
+        &self,
+        rule_id: String,
+        forward_type: ForwardType,
+        config: HostConfig,
+        bind_address: String,
+        local_port: u32,
+        remote_host: String,
+        remote_port: u32,
+        host_id: Option<String>,
+        auto_started: bool,
+    ) -> Result<TunnelStatus, SshError> {
+        // Bind the local listener BEFORE connecting so a port conflict fails fast
+        // and surfaces the familiar "already in use" message.
         let addr = format!("{bind_address}:{local_port}");
         let listener = TcpListener::bind(&addr).await.map_err(|e| {
             if e.kind() == std::io::ErrorKind::AddrInUse {
                 SshError::IoError(format!("Port {local_port} is already in use"))
+            } else if e.kind() == std::io::ErrorKind::PermissionDenied {
+                // Ports below 1024 are privileged on most OSes and can't be bound
+                // without elevated rights — the common cause of this failure.
+                if local_port < 1024 {
+                    SshError::IoError(format!(
+                        "Port {local_port} requires elevated privileges (ports below 1024). \
+                         Pick a higher local port for this tunnel."
+                    ))
+                } else {
+                    SshError::IoError(format!("Permission denied binding {addr}"))
+                }
             } else {
                 SshError::IoError(format!("Failed to bind {addr}: {e}"))
             }
         })?;
-
-        // Get the actual bound port (may differ if local_port was 0)
         let actual_port = listener
             .local_addr()
             .map(|a| a.port() as u32)
             .unwrap_or(local_port);
 
+        // Establish the dedicated SSH connection used by this tunnel.
+        let russh_config = Arc::new(client::Config {
+            keepalive_interval: Some(std::time::Duration::from_secs(30)),
+            keepalive_max: 3,
+            ..Default::default()
+        });
+        let (handle, jump_handles) = SshManager::establish(&config, russh_config).await?;
+        let handle = Arc::new(tokio::sync::Mutex::new(handle));
+
         let cancel_token = CancellationToken::new();
         let connection_count = Arc::new(AtomicU32::new(0));
+        let instance_id = next_instance_id();
 
-        let tunnel = ActiveTunnel {
-            rule_id: rule_id.clone(),
-            local_port: actual_port,
-            cancel_token: cancel_token.clone(),
-            connection_count: connection_count.clone(),
-            status: TunnelState::Active,
-            error: None,
-        };
+        self.tunnels.insert(
+            rule_id.clone(),
+            ActiveTunnel {
+                rule_id: rule_id.clone(),
+                instance_id,
+                local_port: actual_port,
+                cancel_token: cancel_token.clone(),
+                connection_count: connection_count.clone(),
+                status: TunnelState::Active,
+                error: None,
+                host_id,
+                auto_started,
+            },
+        );
 
-        self.tunnels.insert(rule_id.clone(), tunnel);
-
-        // Emit status
         let status = TunnelStatus {
             rule_id: rule_id.clone(),
             status: TunnelState::Active,
@@ -86,15 +194,15 @@ impl PortForwardManager {
             error: None,
         };
         let _ = self.app_handle.emit("pf:status", &status);
+        info!(rule_id = %rule_id, addr = %addr, actual_port, ?forward_type, "Tunnel started");
 
-        info!(rule_id = %rule_id, addr = %addr, actual_port = actual_port, "Tunnel started");
-
-        // Spawn the listener task
         let app_handle = self.app_handle.clone();
         let rid = rule_id.clone();
         let tunnels = Arc::clone(&self.tunnels);
 
         tokio::spawn(async move {
+            // Hold the jump-host chain alive for the tunnel's lifetime.
+            let _jump_handles = jump_handles;
             loop {
                 tokio::select! {
                     _ = cancel_token.cancelled() => {
@@ -116,16 +224,23 @@ impl PortForwardManager {
                                 let rule_id_inner = rid.clone();
 
                                 tokio::spawn(async move {
-                                    let result = proxy_connection(
-                                        tcp_stream,
-                                        handle,
-                                        &rhost,
-                                        rport,
-                                        &peer_addr.to_string(),
-                                        peer_addr.port() as u32,
-                                        cancel,
-                                    )
-                                    .await;
+                                    let result = match forward_type {
+                                        ForwardType::Dynamic => {
+                                            handle_socks_connection(tcp_stream, handle, peer_addr, cancel).await
+                                        }
+                                        _ => {
+                                            proxy_to_remote(
+                                                tcp_stream,
+                                                handle,
+                                                &rhost,
+                                                rport,
+                                                &peer_addr.to_string(),
+                                                peer_addr.port() as u32,
+                                                cancel,
+                                            )
+                                            .await
+                                        }
+                                    };
 
                                     let remaining = conn_count.fetch_sub(1, Ordering::Relaxed) - 1;
                                     if let Err(e) = result {
@@ -149,20 +264,143 @@ impl PortForwardManager {
                 }
             }
 
-            // Cleanup: update tunnel status
-            if let Some(mut tunnel) = tunnels.get_mut(&rid) {
-                tunnel.status = TunnelState::Stopped;
+            // Only remove + announce Stopped if the map entry is still *this*
+            // instance. If `stop_tunnel` already removed it, or a restart
+            // replaced it with a newer instance, leave that newer state intact
+            // (it owns its own Active/Stopped events).
+            if tunnels
+                .remove_if(&rid, |_, t| t.instance_id == instance_id)
+                .is_some()
+            {
+                let _ = app_handle.emit(
+                    "pf:status",
+                    &TunnelStatus {
+                        rule_id: rid,
+                        status: TunnelState::Stopped,
+                        local_port: actual_port,
+                        connections: 0,
+                        error: None,
+                    },
+                );
             }
-            let _ = app_handle.emit(
-                "pf:status",
-                &TunnelStatus {
-                    rule_id: rid,
-                    status: TunnelState::Stopped,
-                    local_port: actual_port,
-                    connections: 0,
-                    error: None,
-                },
-            );
+        });
+
+        Ok(status)
+    }
+
+    /// Remote forwarding: open a dedicated SSH connection whose handler routes
+    /// server-initiated `forwarded-tcpip` channels to a local destination, then
+    /// ask the server to listen on `bind_address:listen_port`.
+    #[allow(clippy::too_many_arguments)]
+    async fn start_remote_tunnel(
+        &self,
+        rule_id: String,
+        config: HostConfig,
+        bind_address: String,
+        listen_port: u32,
+        dest_host: String,
+        dest_port: u32,
+        host_id: Option<String>,
+        auto_started: bool,
+    ) -> Result<TunnelStatus, SshError> {
+        if config.jump_host.is_some() {
+            return Err(SshError::IoError(
+                "Remote forwarding through a ProxyJump host is not supported".to_string(),
+            ));
+        }
+
+        let russh_config = Arc::new(client::Config {
+            keepalive_interval: Some(std::time::Duration::from_secs(30)),
+            keepalive_max: 3,
+            ..Default::default()
+        });
+
+        let handler = RemoteForwardHandler {
+            dest_host: dest_host.clone(),
+            dest_port,
+            rule_id: rule_id.clone(),
+        };
+
+        let addr = format!("{}:{}", config.host, config.port);
+        let mut handle = client::connect(russh_config, &addr, handler)
+            .await
+            .map_err(|e| SshError::ConnectionFailed(e.to_string()))?;
+        SshManager::authenticate_handle(&mut handle, &config).await?;
+
+        // Ask the server to start listening. A bind conflict on the *server* is
+        // reported here as a request denial.
+        handle
+            .tcpip_forward(bind_address.clone(), listen_port)
+            .await
+            .map_err(|e| {
+                SshError::IoError(format!(
+                    "server refused to forward {bind_address}:{listen_port}: {e}"
+                ))
+            })?;
+
+        let cancel_token = CancellationToken::new();
+        let connection_count = Arc::new(AtomicU32::new(0));
+        let instance_id = next_instance_id();
+
+        self.tunnels.insert(
+            rule_id.clone(),
+            ActiveTunnel {
+                rule_id: rule_id.clone(),
+                instance_id,
+                local_port: listen_port,
+                cancel_token: cancel_token.clone(),
+                connection_count: connection_count.clone(),
+                status: TunnelState::Active,
+                error: None,
+                host_id,
+                auto_started,
+            },
+        );
+
+        let status = TunnelStatus {
+            rule_id: rule_id.clone(),
+            status: TunnelState::Active,
+            local_port: listen_port,
+            connections: 0,
+            error: None,
+        };
+        let _ = self.app_handle.emit("pf:status", &status);
+        info!(rule_id = %rule_id, bind = %bind_address, listen_port, "Remote tunnel started");
+
+        let app_handle = self.app_handle.clone();
+        let rid = rule_id.clone();
+        let tunnels = Arc::clone(&self.tunnels);
+        let bind_for_cancel = bind_address.clone();
+
+        // Keep the connection (and thus the server-side listener) alive until the
+        // tunnel is cancelled; the handler drives forwarded channels meanwhile.
+        tokio::spawn(async move {
+            cancel_token.cancelled().await;
+            let _ = handle
+                .cancel_tcpip_forward(bind_for_cancel, listen_port)
+                .await;
+            let _ = handle
+                .disconnect(russh::Disconnect::ByApplication, "", "en")
+                .await;
+            drop(handle);
+
+            // Only announce Stopped if this instance is still the live one (see
+            // the listener-tunnel teardown for the reasoning).
+            if tunnels
+                .remove_if(&rid, |_, t| t.instance_id == instance_id)
+                .is_some()
+            {
+                let _ = app_handle.emit(
+                    "pf:status",
+                    &TunnelStatus {
+                        rule_id: rid,
+                        status: TunnelState::Stopped,
+                        local_port: listen_port,
+                        connections: 0,
+                        error: None,
+                    },
+                );
+            }
         });
 
         Ok(status)
@@ -186,6 +424,22 @@ impl PortForwardManager {
         Ok(())
     }
 
+    /// Stop every auto-started tunnel belonging to `host_id`. Called when the
+    /// host disconnects so auto-activated tunnels are torn down cleanly with no
+    /// orphaned listeners. Manually-started tunnels (or tunnels for other hosts)
+    /// are left running.
+    pub fn stop_auto_started_for_host(&self, host_id: &str) {
+        let to_stop: Vec<String> = self
+            .tunnels
+            .iter()
+            .filter(|e| e.value().auto_started && e.value().host_id.as_deref() == Some(host_id))
+            .map(|e| e.key().clone())
+            .collect();
+        for rule_id in to_stop {
+            let _ = self.stop_tunnel(&rule_id);
+        }
+    }
+
     pub fn list_active(&self) -> Vec<TunnelStatus> {
         self.tunnels
             .iter()
@@ -203,17 +457,17 @@ impl PortForwardManager {
     }
 }
 
-/// Proxy data bidirectionally between a local TCP connection and an SSH direct-tcpip channel.
-async fn proxy_connection(
-    mut tcp_stream: tokio::net::TcpStream,
-    handle: Arc<tokio::sync::Mutex<russh::client::Handle<SshClientHandler>>>,
+/// Proxy data bidirectionally between a local TCP connection and an SSH
+/// `direct-tcpip` channel to a fixed `remote_host:remote_port` (Local forward).
+async fn proxy_to_remote(
+    tcp_stream: TcpStream,
+    handle: Arc<tokio::sync::Mutex<client::Handle<SshClientHandler>>>,
     remote_host: &str,
     remote_port: u32,
     originator_address: &str,
     originator_port: u32,
     cancel: CancellationToken,
 ) -> Result<(), SshError> {
-    // Open a direct-tcpip channel
     let channel = {
         let h = handle.lock().await;
         h.channel_open_direct_tcpip(
@@ -225,36 +479,180 @@ async fn proxy_connection(
         .await
         .map_err(|e| SshError::ChannelError(format!("direct-tcpip failed: {e}")))?
     };
+    pump(tcp_stream, channel.into_stream(), cancel).await;
+    Ok(())
+}
 
-    let mut ssh_stream = channel.into_stream();
-    let (mut tcp_read, mut tcp_write) = tcp_stream.split();
+/// Handle a single SOCKS5 client connection (Dynamic forward): negotiate the
+/// target, open a `direct-tcpip` channel to it, and proxy.
+async fn handle_socks_connection(
+    mut tcp_stream: TcpStream,
+    handle: Arc<tokio::sync::Mutex<client::Handle<SshClientHandler>>>,
+    peer_addr: std::net::SocketAddr,
+    cancel: CancellationToken,
+) -> Result<(), SshError> {
+    let (host, port) = socks5_negotiate(&mut tcp_stream).await?;
 
-    let mut buf_ssh = vec![0u8; 32 * 1024];
-    let mut buf_tcp = vec![0u8; 32 * 1024];
+    let channel = {
+        let h = handle.lock().await;
+        h.channel_open_direct_tcpip(
+            host.clone(),
+            port as u32,
+            peer_addr.ip().to_string(),
+            peer_addr.port() as u32,
+        )
+        .await
+    };
 
-    loop {
-        tokio::select! {
-            _ = cancel.cancelled() => break,
-
-            n = tcp_read.read(&mut buf_tcp) => {
-                match n {
-                    Ok(0) | Err(_) => break,
-                    Ok(n) => {
-                        if ssh_stream.write_all(&buf_tcp[..n]).await.is_err() { break; }
-                    }
-                }
-            }
-
-            n = ssh_stream.read(&mut buf_ssh) => {
-                match n {
-                    Ok(0) | Err(_) => break,
-                    Ok(n) => {
-                        if tcp_write.write_all(&buf_ssh[..n]).await.is_err() { break; }
-                    }
-                }
-            }
+    // Reply to the SOCKS client based on whether the channel opened.
+    match channel {
+        Ok(channel) => {
+            // Success reply (bound address reported as 0.0.0.0:0 — clients ignore it).
+            tcp_stream
+                .write_all(&[0x05, 0x00, 0x00, 0x01, 0, 0, 0, 0, 0, 0])
+                .await
+                .map_err(|e| SshError::IoError(e.to_string()))?;
+            pump(tcp_stream, channel.into_stream(), cancel).await;
+            Ok(())
+        }
+        Err(e) => {
+            // 0x05 = connection refused (general failure mapping).
+            let _ = tcp_stream
+                .write_all(&[0x05, 0x05, 0x00, 0x01, 0, 0, 0, 0, 0, 0])
+                .await;
+            Err(SshError::ChannelError(format!(
+                "SOCKS direct-tcpip to {host}:{port} failed: {e}"
+            )))
         }
     }
+}
 
-    Ok(())
+/// Minimal SOCKS5 negotiation: greeting (no-auth only) + CONNECT request.
+/// Returns the requested `(host, port)`. BIND/UDP and authenticated greetings
+/// are rejected.
+async fn socks5_negotiate(stream: &mut TcpStream) -> Result<(String, u16), SshError> {
+    let io = |e: std::io::Error| SshError::IoError(e.to_string());
+
+    // ── Greeting: VER, NMETHODS, METHODS… ──
+    let mut head = [0u8; 2];
+    stream.read_exact(&mut head).await.map_err(io)?;
+    if head[0] != 0x05 {
+        return Err(SshError::IoError("not a SOCKS5 client".to_string()));
+    }
+    let mut methods = vec![0u8; head[1] as usize];
+    stream.read_exact(&mut methods).await.map_err(io)?;
+    if !methods.contains(&0x00) {
+        // No acceptable methods.
+        let _ = stream.write_all(&[0x05, 0xff]).await;
+        return Err(SshError::IoError(
+            "SOCKS5 client requires authentication (unsupported)".to_string(),
+        ));
+    }
+    // Select "no authentication required".
+    stream.write_all(&[0x05, 0x00]).await.map_err(io)?;
+
+    // ── Request: VER, CMD, RSV, ATYP, ADDR, PORT ──
+    let mut req = [0u8; 4];
+    stream.read_exact(&mut req).await.map_err(io)?;
+    if req[0] != 0x05 {
+        return Err(SshError::IoError("bad SOCKS5 request".to_string()));
+    }
+    if req[1] != 0x01 {
+        // Only CONNECT is supported.
+        let _ = stream
+            .write_all(&[0x05, 0x07, 0x00, 0x01, 0, 0, 0, 0, 0, 0])
+            .await;
+        return Err(SshError::IoError(
+            "only SOCKS5 CONNECT is supported".to_string(),
+        ));
+    }
+
+    let host = match req[3] {
+        0x01 => {
+            let mut a = [0u8; 4];
+            stream.read_exact(&mut a).await.map_err(io)?;
+            std::net::Ipv4Addr::new(a[0], a[1], a[2], a[3]).to_string()
+        }
+        0x03 => {
+            let mut len = [0u8; 1];
+            stream.read_exact(&mut len).await.map_err(io)?;
+            let mut name = vec![0u8; len[0] as usize];
+            stream.read_exact(&mut name).await.map_err(io)?;
+            String::from_utf8(name)
+                .map_err(|_| SshError::IoError("invalid SOCKS5 hostname".to_string()))?
+        }
+        0x04 => {
+            let mut a = [0u8; 16];
+            stream.read_exact(&mut a).await.map_err(io)?;
+            std::net::Ipv6Addr::from(a).to_string()
+        }
+        other => {
+            return Err(SshError::IoError(format!(
+                "unsupported SOCKS5 address type {other}"
+            )));
+        }
+    };
+
+    let mut port = [0u8; 2];
+    stream.read_exact(&mut port).await.map_err(io)?;
+    Ok((host, u16::from_be_bytes(port)))
+}
+
+/// Pump bytes bidirectionally between a TCP stream and an SSH channel stream
+/// until either side closes or the tunnel is cancelled.
+async fn pump<S>(mut tcp_stream: TcpStream, mut ssh_stream: S, cancel: CancellationToken)
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
+{
+    tokio::select! {
+        _ = cancel.cancelled() => {}
+        _ = tokio::io::copy_bidirectional(&mut tcp_stream, &mut ssh_stream) => {}
+    }
+}
+
+// ─── Remote forwarding handler ─────────────────────────────────────────────────
+
+/// SSH client handler for a Remote-forward connection. When the server opens a
+/// `forwarded-tcpip` channel (a connection arrived on the server's listener), it
+/// connects to the configured local destination and proxies the two together.
+struct RemoteForwardHandler {
+    dest_host: String,
+    dest_port: u32,
+    rule_id: String,
+}
+
+#[async_trait]
+impl client::Handler for RemoteForwardHandler {
+    type Error = russh::Error;
+
+    async fn check_server_key(
+        &mut self,
+        _server_public_key: &russh_keys::key::PublicKey,
+    ) -> Result<bool, Self::Error> {
+        Ok(true)
+    }
+
+    async fn server_channel_open_forwarded_tcpip(
+        &mut self,
+        channel: russh::Channel<client::Msg>,
+        _connected_address: &str,
+        _connected_port: u32,
+        _originator_address: &str,
+        _originator_port: u32,
+        _session: &mut client::Session,
+    ) -> Result<(), Self::Error> {
+        let dest = format!("{}:{}", self.dest_host, self.dest_port);
+        let rule_id = self.rule_id.clone();
+        tokio::spawn(async move {
+            match TcpStream::connect(&dest).await {
+                Ok(tcp) => {
+                    pump(tcp, channel.into_stream(), CancellationToken::new()).await;
+                }
+                Err(e) => {
+                    warn!(rule_id = %rule_id, dest = %dest, error = %e, "remote forward: local connect failed");
+                }
+            }
+        });
+        Ok(())
+    }
 }

--- a/src-tauri/src/portforward/mod.rs
+++ b/src-tauri/src/portforward/mod.rs
@@ -3,6 +3,10 @@ pub mod manager;
 
 use serde::{Deserialize, Serialize};
 
+/// `app_settings` key for the global "auto-start tunnels by default" toggle.
+/// Stored as the string `"true"` / `"false"`; absent means the default (`true`).
+pub const AUTO_START_DEFAULT_SETTING_KEY: &str = "tunnels_auto_start_default";
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PortForwardRule {
     pub id: String,
@@ -21,10 +25,16 @@ pub struct PortForwardRule {
     pub created_at: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 pub enum ForwardType {
+    /// Local forward (`ssh -L`): a local listener proxies to a remote
+    /// destination over a `direct-tcpip` channel.
     Local,
+    /// Remote forward (`ssh -R`): the server listens and forwards back to a
+    /// destination reachable from this client.
     Remote,
+    /// Dynamic forward (`ssh -D`): a local SOCKS proxy. No fixed destination.
+    Dynamic,
 }
 
 impl ForwardType {
@@ -33,14 +43,34 @@ impl ForwardType {
         match self {
             ForwardType::Local => "local",
             ForwardType::Remote => "remote",
+            ForwardType::Dynamic => "dynamic",
         }
     }
 
+    /// Parse from the stored/transmitted string. Case-insensitive so it accepts
+    /// both the canonical lowercase form (`"remote"`) and the frontend's
+    /// PascalCase enum form (`"Remote"`).
     pub fn from_str(s: &str) -> Self {
-        match s {
+        match s.to_ascii_lowercase().as_str() {
             "remote" => ForwardType::Remote,
+            "dynamic" => ForwardType::Dynamic,
             _ => ForwardType::Local,
         }
+    }
+}
+
+#[cfg(test)]
+mod forward_type_tests {
+    use super::ForwardType;
+
+    #[test]
+    fn from_str_is_case_insensitive() {
+        assert_eq!(ForwardType::from_str("Remote"), ForwardType::Remote);
+        assert_eq!(ForwardType::from_str("remote"), ForwardType::Remote);
+        assert_eq!(ForwardType::from_str("Dynamic"), ForwardType::Dynamic);
+        assert_eq!(ForwardType::from_str("DYNAMIC"), ForwardType::Dynamic);
+        assert_eq!(ForwardType::from_str("Local"), ForwardType::Local);
+        assert_eq!(ForwardType::from_str("anything"), ForwardType::Local);
     }
 }
 

--- a/src-tauri/src/ssh/commands.rs
+++ b/src-tauri/src/ssh/commands.rs
@@ -37,7 +37,9 @@ pub async fn ssh_connect(
     state: State<'_, SshManager>,
     app_handle: AppHandle,
 ) -> Result<SessionId, SshError> {
-    state.connect(host_config, app_handle, attempt_id).await
+    state
+        .connect(host_config, app_handle, attempt_id, None)
+        .await
 }
 
 /// Abort an in-flight connection attempt identified by the frontend-supplied
@@ -553,7 +555,14 @@ pub async fn connect_saved_host(
     .map_err(|e| SshError::IoError(format!("task panicked: {e}")))??;
 
     let auth_type = auth_method_label(&config.auth_method).to_string();
-    let session_id = state.connect(config, app_handle, attempt_id).await?;
+    let session_id = state
+        .connect(
+            config,
+            app_handle.clone(),
+            attempt_id,
+            Some(host_id.clone()),
+        )
+        .await?;
 
     crate::telemetry::capture(
         "ssh_connected",
@@ -561,6 +570,16 @@ pub async fn connect_saved_host(
             "auth_type": auth_type,
         }),
     );
+
+    // Auto-start tunnels flagged `auto_start` for this host, once the SSH
+    // session is established. Runs in the background so it never delays (or
+    // fails) the connection; per-tunnel failures surface via `pf:status`.
+    {
+        let app = app_handle.clone();
+        tokio::spawn(async move {
+            crate::portforward::commands::start_auto_tunnels_for_host(app, host_id).await;
+        });
+    }
 
     Ok(session_id)
 }
@@ -608,7 +627,7 @@ fn resolve_auth_method(host_id: &str, auth_type: &str, key_path: Option<String>)
 ///
 /// A missing jump host surfaces as a clear `"tunnel host ... not found"` error
 /// rather than the generic not-found message used for the top-level host.
-fn build_host_config_blocking(
+pub(crate) fn build_host_config_blocking(
     host_id: &str,
     db: &HostDb,
     visited: &mut Vec<String>,
@@ -677,5 +696,7 @@ pub async fn connect_saved_host_no_pty(
     .await
     .map_err(|e| SshError::IoError(format!("task panicked: {e}")))??;
 
-    state.connect_no_pty(config, attempt_id).await
+    state
+        .connect_no_pty(config, attempt_id, Some(host_id))
+        .await
 }

--- a/src-tauri/src/ssh/manager.rs
+++ b/src-tauri/src/ssh/manager.rs
@@ -46,6 +46,10 @@ pub struct SshManager {
     /// running; cancelling its token aborts the attempt before any session is
     /// registered, so no ghost session or lingering handle is left behind.
     pending_connects: DashMap<String, CancellationToken>,
+    /// session_id → saved-host id, for every session opened against a saved
+    /// host (PTY or bare/SFTP). Lets `disconnect` tear down auto-started tunnels
+    /// once the *last* session for a host goes away.
+    session_hosts: DashMap<String, String>,
 }
 
 impl SshManager {
@@ -54,6 +58,7 @@ impl SshManager {
             sessions: DashMap::new(),
             bare_handles: DashMap::new(),
             pending_connects: DashMap::new(),
+            session_hosts: DashMap::new(),
         }
     }
 
@@ -90,6 +95,7 @@ impl SshManager {
         config: HostConfig,
         app_handle: AppHandle,
         attempt_id: Option<String>,
+        host_id: Option<String>,
     ) -> Result<SessionId, SshError> {
         let session_id = SessionId::new();
         let sid = session_id.0.clone();
@@ -168,6 +174,9 @@ impl SshManager {
 
         let session = outcome?;
         self.sessions.insert(sid.clone(), session);
+        if let Some(hid) = host_id {
+            self.session_hosts.insert(sid.clone(), hid);
+        }
 
         Ok(session_id)
     }
@@ -179,6 +188,7 @@ impl SshManager {
         &self,
         config: HostConfig,
         attempt_id: Option<String>,
+        host_id: Option<String>,
     ) -> Result<SessionId, SshError> {
         let session_id = SessionId::new();
         let sid = session_id.0.clone();
@@ -219,6 +229,9 @@ impl SshManager {
                 _jump_handles: jump_handles,
             },
         );
+        if let Some(hid) = host_id {
+            self.session_hosts.insert(sid.clone(), hid);
+        }
 
         Ok(session_id)
     }
@@ -301,8 +314,8 @@ impl SshManager {
     /// Authenticate an already-connected handle using the config's auth method.
     /// Shared by direct and tunnelled connection paths (and the health-check
     /// probe, which authenticates the jump host before tunnelling to the target).
-    pub(crate) async fn authenticate_handle(
-        handle: &mut client::Handle<SshClientHandler>,
+    pub(crate) async fn authenticate_handle<H: client::Handler<Error = russh::Error>>(
+        handle: &mut client::Handle<H>,
         config: &HostConfig,
     ) -> Result<(), SshError> {
         let authenticated = match &config.auth_method {
@@ -351,8 +364,8 @@ impl SshManager {
         Ok(())
     }
 
-    async fn auth_with_key_data(
-        handle: &mut client::Handle<SshClientHandler>,
+    async fn auth_with_key_data<H: client::Handler<Error = russh::Error>>(
+        handle: &mut client::Handle<H>,
         username: &str,
         key_data: &str,
         passphrase: Option<&str>,
@@ -485,6 +498,15 @@ impl SshManager {
                 status: ConnectionStatus::Disconnected,
             },
         );
+
+        // If this was the last live session for its host, tear down any tunnels
+        // that were auto-started on connect so they don't outlive the host.
+        if let Some((_, host_id)) = self.session_hosts.remove(session_id) {
+            let host_still_connected = self.session_hosts.iter().any(|e| *e.value() == host_id);
+            if !host_still_connected {
+                crate::portforward::commands::stop_auto_tunnels_for_host(&app_handle, &host_id);
+            }
+        }
 
         info!(session_id = %session_id, "SSH disconnected");
         Ok(())

--- a/src/components/dashboard/ImportSshConfigModal.tsx
+++ b/src/components/dashboard/ImportSshConfigModal.tsx
@@ -88,6 +88,7 @@ export function ImportSshConfigModal({ onClose, onImported }: ImportSshConfigMod
           identity_file: e.identity_file,
           proxy_jump: e.proxy_jump,
           keep_alive_interval: e.keep_alive_interval,
+          forwards: e.forwards ?? [],
         }));
 
       const importResult = await invoke<ImportResult>("import_save_ssh_hosts", {

--- a/src/components/port-forwarding/PortForwardingPage.tsx
+++ b/src/components/port-forwarding/PortForwardingPage.tsx
@@ -3,11 +3,12 @@ import { Plus, Trash2, ArrowRight, Search, Wifi, Pencil, Copy, Clock, Plug } fro
 import { CustomSelect } from "../shared/CustomSelect";
 import { usePortForwardStore } from "../../stores/port-forward-store";
 import { useHostsStore } from "../../stores/hosts-store";
+import { useSettingsStore } from "../../stores/settings-store";
 import { ContextMenu } from "../shared/ContextMenu";
 import { ConfirmDangerDialog } from "../shared/ConfirmDangerDialog";
 import { ModalShell, BTN_GHOST, BTN_PRIMARY } from "../shared/ModalShell";
 import type { ContextMenuItem } from "../shared/ContextMenu";
-import type { PortForwardRule, SavedHost } from "../../types";
+import type { ForwardType, PortForwardRule, SavedHost } from "../../types";
 
 // ─── Component ───────────────────────────────────────────────────────────────
 
@@ -251,8 +252,14 @@ export function PortForwardingPage() {
                           <div className="flex items-center gap-1.5">
                             <span className="flex items-center gap-1.5 text-[length:var(--text-2xs)] font-mono text-text-muted">
                               <span>:{tunnel?.local_port ?? rule.local_port}</span>
-                              <ArrowRight size={10} strokeWidth={2} className="text-text-muted/40" />
-                              <span>:{rule.remote_port}</span>
+                              {rule.forward_type === "Dynamic" ? (
+                                <span className="text-text-muted/60">SOCKS</span>
+                              ) : (
+                                <>
+                                  <ArrowRight size={10} strokeWidth={2} className="text-text-muted/40" />
+                                  <span>:{rule.remote_port}</span>
+                                </>
+                              )}
                             </span>
                             <button
                               onClick={(e) => {
@@ -276,6 +283,11 @@ export function PortForwardingPage() {
                               <span className="flex items-center gap-1">
                                 <Clock size={10} strokeWidth={2} />
                                 {new Date(rule.last_used_at).toLocaleDateString()}
+                              </span>
+                            )}
+                            {rule.forward_type !== "Local" && (
+                              <span className="px-1 py-px rounded bg-bg-subtle text-[9px] uppercase tracking-wide font-semibold">
+                                {rule.forward_type === "Remote" ? "remote" : "socks"}
                               </span>
                             )}
                             {rule.auto_start && (
@@ -407,15 +419,25 @@ function RuleDialog({
   onCancel: () => void;
 }) {
   const isEdit = !!rule;
+  // New tunnels inherit the global "auto-start by default" preference.
+  const autoStartDefault = useSettingsStore((s) => s.tunnelsAutoStartDefault);
   const [hostId, setHostId] = useState(rule?.host_id ?? hosts[0]?.id ?? "");
+  const [forwardType, setForwardType] = useState<ForwardType>(rule?.forward_type ?? "Local");
   const [label, setLabel] = useState(rule?.label ?? "");
   const [description, setDescription] = useState(rule?.description ?? "");
   const [localPort, setLocalPort] = useState(rule ? String(rule.local_port) : "");
   const [remotePort, setRemotePort] = useState(rule ? String(rule.remote_port) : "");
   const [bindAddress, setBindAddress] = useState(rule?.bind_address ?? "127.0.0.1");
-  const [autoStart, setAutoStart] = useState(rule?.auto_start ?? false);
+  const [autoStart, setAutoStart] = useState(rule?.auto_start ?? autoStartDefault);
 
-  const canSubmit = hostId && localPort && remotePort && Number(localPort) > 0 && Number(remotePort) > 0;
+  // Dynamic (SOCKS) tunnels have no fixed destination, so the remote port is
+  // not required for them.
+  const isDynamic = forwardType === "Dynamic";
+  const canSubmit =
+    !!hostId &&
+    !!localPort &&
+    Number(localPort) > 0 &&
+    (isDynamic || (!!remotePort && Number(remotePort) > 0));
 
   const applyPreset = (port: number, presetLabel: string) => {
     setLocalPort(String(port));
@@ -430,16 +452,21 @@ function RuleDialog({
       host_id: hostId || null,
       label: label.trim() || null,
       description: description.trim() || null,
-      forward_type: "Local",
+      forward_type: forwardType,
       bind_address: bindAddress,
       local_port: Number(localPort),
-      remote_host: "localhost",
-      remote_port: Number(remotePort),
+      remote_host: isDynamic ? "" : "localhost",
+      remote_port: isDynamic ? 0 : Number(remotePort),
       auto_start: autoStart,
       last_used_at: rule?.last_used_at ?? null,
       total_bytes: rule?.total_bytes ?? 0,
     });
   };
+
+  // Per-type labels for the two port fields.
+  const localPortLabel =
+    forwardType === "Remote" ? "Remote Listen Port" : isDynamic ? "Local SOCKS Port" : "Local Port";
+  const remotePortLabel = forwardType === "Remote" ? "Local Dest Port" : "Remote Port";
 
 
   const inputClass =
@@ -486,6 +513,27 @@ function RuleDialog({
             ) : (
               <p className="text-[length:var(--text-xs)] text-text-muted py-1.5">
                 No saved hosts. Add a host first.
+              </p>
+            )}
+          </div>
+
+          {/* Forward type */}
+          <div>
+            <label htmlFor="pf-type" className={labelClass}>Type</label>
+            <CustomSelect
+              id="pf-type"
+              value={forwardType}
+              onChange={(v) => setForwardType(v as ForwardType)}
+              disabled={isEdit}
+              options={[
+                { value: "Local", label: "Local (-L) — forward a local port to a remote service" },
+                { value: "Remote", label: "Remote (-R) — forward a remote port back to this machine" },
+                { value: "Dynamic", label: "Dynamic (-D) — local SOCKS5 proxy" },
+              ]}
+            />
+            {isEdit && (
+              <p className="text-[length:var(--text-2xs)] text-text-muted mt-1">
+                Type can't be changed after creation.
               </p>
             )}
           </div>
@@ -550,7 +598,7 @@ function RuleDialog({
           {/* Port inputs */}
           <div className="flex gap-3 items-end">
             <div className="flex-1">
-              <label htmlFor="pf-local-port" className={labelClass}>Local Port</label>
+              <label htmlFor="pf-local-port" className={labelClass}>{localPortLabel}</label>
               <input
                 id="pf-local-port"
                 data-testid="rule-local-port"
@@ -564,22 +612,26 @@ function RuleDialog({
               />
             </div>
 
-            <ArrowRight size={15} strokeWidth={2} className="text-text-muted/40 mb-3 shrink-0" />
+            {!isDynamic && (
+              <>
+                <ArrowRight size={15} strokeWidth={2} className="text-text-muted/40 mb-3 shrink-0" />
 
-            <div className="flex-1">
-              <label htmlFor="pf-remote-port" className={labelClass}>Remote Port</label>
-              <input
-                id="pf-remote-port"
-                data-testid="rule-remote-port"
-                type="number"
-                value={remotePort}
-                onChange={(e) => setRemotePort(e.target.value)}
-                placeholder="5432"
-                min={1}
-                max={65535}
-                className={`${inputClass} font-mono`}
-              />
-            </div>
+                <div className="flex-1">
+                  <label htmlFor="pf-remote-port" className={labelClass}>{remotePortLabel}</label>
+                  <input
+                    id="pf-remote-port"
+                    data-testid="rule-remote-port"
+                    type="number"
+                    value={remotePort}
+                    onChange={(e) => setRemotePort(e.target.value)}
+                    placeholder="5432"
+                    min={1}
+                    max={65535}
+                    className={`${inputClass} font-mono`}
+                  />
+                </div>
+              </>
+            )}
           </div>
 
           <SectionHeader>Options</SectionHeader>

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -4,7 +4,7 @@ import { useSettingsStore } from "../../stores/settings-store";
 import { CustomSelect, type SelectOption } from "../shared/CustomSelect";
 import { useUpdaterStore } from "../../stores/updater-store";
 import { toast } from "../../stores/toast-store";
-import { RefreshCw, CheckCircle2, AlertCircle, Palette, SquareTerminal, ArrowUpDown, Info, ExternalLink, Check, FileCode, Plus, Trash2, FolderOpen, Star, Search, Database, Download, Upload, ShieldCheck } from "lucide-react";
+import { RefreshCw, CheckCircle2, AlertCircle, Palette, SquareTerminal, ArrowUpDown, Info, ExternalLink, Check, FileCode, Plus, Trash2, FolderOpen, Star, Search, Database, Download, Upload, ShieldCheck, Plug } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import type { CursorStyle, ThemeMode, EditorConfig, PasteButton, DoubleClickAction } from "../../stores/settings-store";
 
@@ -46,12 +46,13 @@ const REPO_URL = "https://github.com/macnev2013/anySCP";
 // Each settings category is a section here. To add a new category, add an entry
 // to SECTIONS, a description, and render its content in <SectionContent />.
 
-type SectionId = "appearance" | "terminal" | "explorer" | "transfers" | "editors" | "data" | "about";
+type SectionId = "appearance" | "terminal" | "explorer" | "tunnels" | "transfers" | "editors" | "data" | "about";
 
 const SECTIONS: { id: SectionId; label: string; icon: LucideIcon }[] = [
   { id: "appearance", label: "Appearance", icon: Palette },
   { id: "terminal", label: "Terminal", icon: SquareTerminal },
   { id: "explorer", label: "Explorer", icon: FolderOpen },
+  { id: "tunnels", label: "Tunnels", icon: Plug },
   { id: "transfers", label: "Transfers", icon: ArrowUpDown },
   { id: "editors", label: "Editors", icon: FileCode },
   { id: "data", label: "Data", icon: Database },
@@ -62,6 +63,7 @@ const SECTION_DESCRIPTIONS: Record<SectionId, string> = {
   appearance: "Theme and interface look.",
   terminal: "Font, cursor, and scrollback history.",
   explorer: "How the file browser behaves.",
+  tunnels: "Defaults for SSH port-forwarding tunnels.",
   transfers: "Control how files are transferred.",
   editors: "Editors used by “Edit” / “Open With” in the file browser.",
   data: "Back up, restore, and reset your data.",
@@ -151,6 +153,8 @@ function SectionContent({ section }: { section: SectionId }) {
       return <TerminalSettings />;
     case "explorer":
       return <ExplorerSettings />;
+    case "tunnels":
+      return <TunnelSettings />;
     case "transfers":
       return <TransferSettings />;
     case "editors":
@@ -656,6 +660,26 @@ function ExplorerSettings() {
       <p className="px-1 text-[length:var(--text-xs)] text-text-muted">
         Opening falls back to downloading when no editor is configured (see Editors).
       </p>
+    </SettingsGroup>
+  );
+}
+
+function TunnelSettings() {
+  const autoStartDefault = useSettingsStore((s) => s.tunnelsAutoStartDefault);
+  const setAutoStartDefault = useSettingsStore((s) => s.setTunnelsAutoStartDefault);
+
+  return (
+    <SettingsGroup>
+      <SettingRow>
+        <div>
+          <p className={LABEL_CLASS}>Auto-start tunnels by default</p>
+          <p className={DESC_CLASS}>
+            New tunnels (including those imported from your SSH config) start automatically when their
+            host connects. This sets the default for newly-created tunnels; each tunnel can override it.
+          </p>
+        </div>
+        <Toggle id="s-tunnels-autostart" checked={autoStartDefault} onChange={setAutoStartDefault} />
+      </SettingRow>
     </SettingsGroup>
   );
 }

--- a/src/components/terminal/DisconnectOverlay.tsx
+++ b/src/components/terminal/DisconnectOverlay.tsx
@@ -45,6 +45,14 @@ export function DisconnectOverlay({
         newSessionId = await invoke<string>("ssh_connect", { hostConfig });
       }
 
+      // Tear down the old (dead) backend session now that the new one is up.
+      // Done after connecting so the host is never seen as fully disconnected
+      // in between — otherwise its auto-started tunnels would be torn down and
+      // immediately re-created. Best-effort: the session may already be gone.
+      try {
+        await invoke("ssh_disconnect", { sessionId });
+      } catch { /* already disconnected */ }
+
       const { removeSession, addSession } = useSessionStore.getState();
       const label = hostConfig.label || `${hostConfig.username}@${hostConfig.host}`;
       useTabStore.getState().removeTab(sessionId);

--- a/src/hooks/use-port-forward-events.ts
+++ b/src/hooks/use-port-forward-events.ts
@@ -1,10 +1,16 @@
 import { useEffect } from "react";
 import { usePortForwardStore } from "../stores/port-forward-store";
+import { toast } from "../stores/toast-store";
 import type { TunnelStatus } from "../types";
 
 /**
  * Listens to `pf:status` Tauri events and updates the port forward store.
  * Mount once globally (in AppShell).
+ *
+ * Backend-driven failures (most importantly tunnels auto-started on host
+ * connect — e.g. a privileged/blocked port that can't bind) arrive here as an
+ * `Error` status. Surface those as a toast so the user finds out even when the
+ * Tunnels page isn't open; the per-card error remains as the persistent detail.
  */
 export function usePortForwardEvents() {
   const updateTunnelStatus = usePortForwardStore((s) => s.updateTunnelStatus);
@@ -19,7 +25,15 @@ export function usePortForwardEvents() {
         if (aborted) return;
 
         const unsub = await listen<TunnelStatus>("pf:status", (event) => {
-          updateTunnelStatus(event.payload);
+          const status = event.payload;
+          if (status.status === "Error" && status.error) {
+            const rule = usePortForwardStore
+              .getState()
+              .rules.find((r) => r.id === status.rule_id);
+            const name = rule?.label || `Port ${status.local_port || rule?.local_port || ""}`.trim();
+            toast.error(`Tunnel “${name}” failed to start: ${status.error}`);
+          }
+          updateTunnelStatus(status);
         });
 
         if (aborted) { unsub(); } else { unlisten = unsub; }

--- a/src/stores/port-forward-store.ts
+++ b/src/stores/port-forward-store.ts
@@ -99,14 +99,10 @@ export const usePortForwardStore = create<PortForwardState>((set, get) => ({
 
     try {
       const { invoke } = await import("@tauri-apps/api/core");
-      const status = await invoke<TunnelStatus>("pf_start_tunnel", {
-        ruleId,
-        hostId,
-        bindAddress: rule.bind_address,
-        localPort: rule.local_port,
-        remoteHost: rule.remote_host,
-        remotePort: rule.remote_port,
-      });
+      // The backend loads the rule (forward type + params) by id; hostId is
+      // kept in the signature for callers but no longer sent.
+      void hostId;
+      const status = await invoke<TunnelStatus>("pf_start_tunnel", { ruleId });
       set((state) => {
         const next = new Map(state.activeTunnels);
         next.set(ruleId, status);
@@ -117,6 +113,9 @@ export const usePortForwardStore = create<PortForwardState>((set, get) => ({
         ? String((err as { message: string }).message)
         : typeof err === "string" ? err : "Tunnel failed to start";
       console.error("Start tunnel failed:", msg);
+      const name = rule.label || `Port ${rule.local_port}`;
+      const { toast } = await import("../stores/toast-store");
+      toast.error(`Tunnel “${name}” failed to start: ${msg}`);
       set((state) => {
         const next = new Map(state.activeTunnels);
         next.set(ruleId, {

--- a/src/stores/settings-store.ts
+++ b/src/stores/settings-store.ts
@@ -49,6 +49,9 @@ interface SettingsState {
   // Explorer
   explorerDoubleClickAction: DoubleClickAction;
 
+  // Tunnels
+  tunnelsAutoStartDefault: boolean;
+
   // Transfers
   transferConcurrency: number;
 
@@ -75,6 +78,7 @@ interface SettingsState {
   setTerminalCopyOnSelect: (enabled: boolean) => void;
   setTerminalPasteButton: (button: PasteButton) => void;
   setExplorerDoubleClickAction: (action: DoubleClickAction) => void;
+  setTunnelsAutoStartDefault: (enabled: boolean) => void;
   setTransferConcurrency: (n: number) => void;
   addEditor: (editor: Omit<EditorConfig, "id">) => void;
   updateEditor: (id: string, patch: Partial<Omit<EditorConfig, "id">>) => void;
@@ -100,6 +104,7 @@ const DEFAULTS = {
   terminalCopyOnSelect: false,
   terminalPasteButton: "none" as PasteButton,
   explorerDoubleClickAction: "download" as DoubleClickAction,
+  tunnelsAutoStartDefault: true,
   transferConcurrency: 3,
   editors: [] as EditorConfig[],
   defaultEditorId: null as string | null,
@@ -280,6 +285,11 @@ export const useSettingsStore = create<SettingsState>((set) => ({
     persist("explorer_double_click_action", action);
   },
 
+  setTunnelsAutoStartDefault: (enabled) => {
+    set({ tunnelsAutoStartDefault: enabled });
+    persist("tunnels_auto_start_default", String(enabled));
+  },
+
   setTerminalPasteButton: (button) => {
     set({ terminalPasteButton: button });
     persist("terminal_paste_button", button);
@@ -352,6 +362,7 @@ export const useSettingsStore = create<SettingsState>((set) => ({
           case "terminal_copy_on_select": updates.terminalCopyOnSelect = value === "true"; break;
           case "terminal_paste_button": updates.terminalPasteButton = value === "right" || value === "middle" ? value : DEFAULTS.terminalPasteButton; break;
           case "explorer_double_click_action": updates.explorerDoubleClickAction = value === "open" ? "open" : "download"; break;
+          case "tunnels_auto_start_default": updates.tunnelsAutoStartDefault = value !== "false"; break;
           case "transfer_concurrency": updates.transferConcurrency = Number(value) || DEFAULTS.transferConcurrency; break;
           case "app_interface_font": updates.interfaceFont = value || DEFAULTS.interfaceFont; break;
           case "app_auto_update": updates.autoUpdate = value !== "false"; break;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -44,6 +44,7 @@ export type {
 export { S3_PROVIDERS } from "./s3";
 
 export type {
+  ForwardType,
   PortForwardRule,
   TunnelStatus,
 } from "./port-forwarding";

--- a/src/types/port-forwarding.ts
+++ b/src/types/port-forwarding.ts
@@ -1,9 +1,11 @@
+export type ForwardType = "Local" | "Remote" | "Dynamic";
+
 export interface PortForwardRule {
   id: string;
   host_id: string | null;
   label: string | null;
   description: string | null;
-  forward_type: "Local" | "Remote";
+  forward_type: ForwardType;
   bind_address: string;
   local_port: number;
   remote_host: string;

--- a/src/types/ssh.ts
+++ b/src/types/ssh.ts
@@ -122,6 +122,15 @@ export interface HostHealthCheckResult {
 
 // ─── SSH Config Import ────────────────────────────────────────────────────────
 
+/** A port-forwarding directive parsed from an ssh_config host block. */
+export interface SshForward {
+  forward_type: "local" | "remote" | "dynamic";
+  bind_address: string;
+  listen_port: number;
+  dest_host: string;
+  dest_port: number;
+}
+
 export interface SshConfigEntry {
   host_alias: string;
   hostname: string | null;
@@ -130,6 +139,7 @@ export interface SshConfigEntry {
   identity_file: string | null;
   proxy_jump: string | null;
   keep_alive_interval: number | null;
+  forwards: SshForward[];
   is_pattern: boolean;
   already_exists: boolean;
 }


### PR DESCRIPTION
This pull request improves the SSH config import process by making port-forwarding (tunnel) imports idempotent and more robust. It introduces a natural-key lookup for port-forwarding rules to avoid duplicate tunnels when re-importing the same SSH config, and adds support for parsing and importing SSH port-forwarding directives directly from config files. The changes are covered by new tests to ensure correctness.

**SSH config import improvements:**

* Added parsing and extraction of port-forwarding directives (`LocalForward`, `RemoteForward`, `DynamicForward`) from SSH config files, mapping them to a new `SshForward` struct and including them in `SshConfigEntry` and `SshConfigImportEntry` (`src-tauri/src/import/mod.rs`). [[1]](diffhunk://#diff-cc218819b4ace00b2fe590c527a7ab7d2e932a8cfedbc8e3f87a812492c8ed8cR5-R36) [[2]](diffhunk://#diff-cc218819b4ace00b2fe590c527a7ab7d2e932a8cfedbc8e3f87a812492c8ed8cR46-R48) [[3]](diffhunk://#diff-cc218819b4ace00b2fe590c527a7ab7d2e932a8cfedbc8e3f87a812492c8ed8cR62-R64) [[4]](diffhunk://#diff-cc218819b4ace00b2fe590c527a7ab7d2e932a8cfedbc8e3f87a812492c8ed8cR105-R109) [[5]](diffhunk://#diff-cc218819b4ace00b2fe590c527a7ab7d2e932a8cfedbc8e3f87a812492c8ed8cR164-R165) [[6]](diffhunk://#diff-cc218819b4ace00b2fe590c527a7ab7d2e932a8cfedbc8e3f87a812492c8ed8cR174)

* On import, port-forwarding rules are now created per host entry, but only if an identical rule does not already exist (idempotency). This is achieved by checking for an existing rule using a new natural-key lookup before creating a new one (`src-tauri/src/import/commands.rs`). [[1]](diffhunk://#diff-29cbe1c9d58138f01571b4af1378afdfe5ee53e6fb9fb75668c83cd3f23fdc39L51-R80) [[2]](diffhunk://#diff-29cbe1c9d58138f01571b4af1378afdfe5ee53e6fb9fb75668c83cd3f23fdc39L95-R142) [[3]](diffhunk://#diff-29cbe1c9d58138f01571b4af1378afdfe5ee53e6fb9fb75668c83cd3f23fdc39R193-R260)

**Database enhancements:**

* Added `find_pf_rule_id_by_natural_key` and `get_pf_rule` methods to `HostDb` to support natural-key lookup and retrieval of port-forwarding rules, enabling idempotent import and easier rule management (`src-tauri/src/db/mod.rs`). [[1]](diffhunk://#diff-ddc5c908ba2c743aa17aa0b66eb99e95b34937199225be06ca52f3ab6261abfbR1569-R1606) [[2]](diffhunk://#diff-ddc5c908ba2c743aa17aa0b66eb99e95b34937199225be06ca52f3ab6261abfbR1657-R1676)

**Testing and reliability:**

* Added tests to ensure that importing forwards is idempotent (no duplicate tunnels are created on repeated imports) and that the new database methods work as expected (`src-tauri/src/db/mod.rs`, `src-tauri/src/import/commands.rs`). [[1]](diffhunk://#diff-ddc5c908ba2c743aa17aa0b66eb99e95b34937199225be06ca52f3ab6261abfbR2958-R2995) [[2]](diffhunk://#diff-29cbe1c9d58138f01571b4af1378afdfe5ee53e6fb9fb75668c83cd3f23fdc39R422-R460)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds SSH config forward-directive import (LocalForward/RemoteForward/DynamicForward → tunnel records), makes both host and tunnel import idempotent via natural-key lookups, introduces Dynamic (SOCKS5) forwarding, adds per-tunnel SSH connections for all forward types, and wires up auto-start/auto-stop of tunnels on host connect/disconnect.

- **Import idempotency**: existing hosts are matched by `(host, user, port)` before inserting, and tunnel records are matched by their natural key before creating — re-importing the same SSH config is now a no-op, covered by new tests.
- **New forward types**: `Dynamic` (SOCKS5 proxy with a hand-rolled negotiation loop) and `Remote` (`ssh -R`, server-side listener) are fully implemented end-to-end from the DB through the manager to the UI.
- **Lifecycle plumbing**: `session_hosts` in `SshManager` tracks which sessions belong to which saved host so the last-disconnect event correctly tears down auto-started tunnels; reconnect in `DisconnectOverlay` intentionally delays the old-session teardown to avoid a false "host disconnected" flash.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

Safe to merge for local and dynamic tunnel types; remote forwarding tunnels will silently appear as Active after the underlying SSH connection drops and never recover on their own.

The import and local/dynamic forwarding paths are well-structured and tested. The remote-tunnel lifecycle has a concrete gap: the spawned task parks on the cancel token with no SSH-connection-loss detection, so a dropped server connection leaves the tunnel stuck forever as Active in the map with no Stopped event to the UI. For a feature that is on by default, this is likely to surface quickly in real use.

**Files Needing Attention:** src-tauri/src/portforward/manager.rs — specifically start_remote_tunnel and RemoteForwardHandler; the per-connection cancel-token inconsistency is a secondary concern in the same file.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src-tauri/src/portforward/manager.rs | Adds Local/Dynamic SOCKS5 and Remote forwarding support with per-tunnel SSH connections; remote tunnels have a lifecycle gap where SSH connection loss is not detected, leaving tunnels indefinitely Active in the map. |
| src-tauri/src/portforward/commands.rs | Refactors pf_start_tunnel to load the rule by id from the DB, adds start_auto_tunnels_for_host and stop_auto_tunnels_for_host helpers; logic is clean. |
| src-tauri/src/import/mod.rs | Adds forward-directive parsing via a manual line scan; handles bare port, bind:port, and [ipv6]:port forms, skips unix sockets and wildcards, well-tested. |
| src-tauri/src/import/commands.rs | Makes host import idempotent by matching existing (host, user, port) before inserting, then creates tunnel records idempotently; well-tested. |
| src-tauri/src/db/mod.rs | Adds find_pf_rule_id_by_natural_key and get_pf_rule; SQL queries are parameterised, logic correct, tests cover happy path and no-match. |
| src-tauri/src/ssh/manager.rs | Adds session_hosts map for host-to-session tracking to enable auto-tunnel teardown on last-disconnect. |
| src-tauri/src/ssh/commands.rs | Passes host_id through connect calls and spawns auto-tunnel start after successful connect. |
| src/components/port-forwarding/PortForwardingPage.tsx | Adds Dynamic/Remote type selector, adjusts labels, hides remote-port for SOCKS tunnels, shows type badges. |
| src/components/settings/SettingsPage.tsx | Adds Tunnels settings section with auto-start-by-default toggle. |
| src/hooks/use-port-forward-events.ts | Surfaces pf:status Error events as toasts for auto-start failures. |
| src/components/terminal/DisconnectOverlay.tsx | Defers old-session disconnect until after new session is up to avoid premature auto-tunnel teardown. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant UI as Frontend UI
    participant Cmd as portforward/commands
    participant Mgr as PortForwardManager
    participant SSH as SshManager
    participant DB as HostDb

    Note over UI,DB: Host connect + auto-start tunnels
    UI->>SSH: ssh_connect(host_id)
    SSH-->>UI: SessionId
    SSH->>Cmd: start_auto_tunnels_for_host(host_id)
    Cmd->>DB: list_pf_rules(host_id)
    DB-->>Cmd: "rules where auto_start=true"
    loop each auto_start rule
        Cmd->>DB: build_host_config_blocking
        Cmd->>Mgr: "start_tunnel(rule, auto_started=true)"
        Mgr-->>UI: pf:status Active
    end

    Note over UI,DB: Manual tunnel start
    UI->>Cmd: pf_start_tunnel(rule_id)
    Cmd->>DB: get_pf_rule(rule_id)
    Cmd->>Mgr: "start_tunnel(rule, auto_started=false)"
    Mgr-->>UI: pf:status Active

    Note over UI,DB: Host disconnect
    UI->>SSH: ssh_disconnect(session_id)
    SSH->>SSH: remove from session_hosts
    alt last session for host
        SSH->>Cmd: stop_auto_tunnels_for_host
        Mgr-->>UI: pf:status Stopped per tunnel
    end

    Note over UI,DB: SSH config import
    UI->>Cmd: import_save_ssh_hosts(entries)
    Cmd->>DB: list_hosts() snapshot
    loop each entry
        Cmd->>DB: find existing or save_host
        loop each forward
            Cmd->>DB: find_pf_rule_id_by_natural_key
            alt not found
                Cmd->>DB: create_pf_rule
            end
        end
    end
    Cmd-->>UI: ImportResult
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%205%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%205%0Asrc-tauri%2Fsrc%2Fportforward%2Fmanager.rs%3A377-404%0A**Remote%20tunnel%20stays%20%22Active%22%20after%20SSH%20connection%20drops**%0A%0AThe%20spawned%20task%20blocks%20indefinitely%20on%20%60cancel_token.cancelled%28%29.await%60.%20There%20is%20no%20mechanism%20to%20detect%20a%20broken%20SSH%20connection%20%E2%80%94%20if%20the%20server%20crashes%20or%20the%20network%20goes%20down%2C%20%60russh%60%20calls%20the%20handler's%20%60disconnected%28%29%60%20%28not%20implemented%20by%20%60RemoteForwardHandler%60%2C%20so%20the%20default%20no-op%20fires%29%2C%20but%20the%20cancel%20token%20is%20never%20signalled.%20The%20entry%20in%20%60self.tunnels%60%20is%20never%20removed%20and%20no%20%60pf%3Astatus%20Stopped%60%20event%20is%20emitted.%20The%20UI%20shows%20the%20tunnel%20as%20live%20even%20though%20the%20server-side%20listener%20is%20gone%20and%20all%20new%20remote%20connections%20silently%20fail.%0A%0A%60RemoteForwardHandler%60%20should%20implement%20%60disconnected%28%29%60%20and%20cancel%20the%20token%20%28or%20use%20a%20separate%20%60JoinHandle%60%20for%20the%20russh%20connection%20task%20and%20%60select!%60%20on%20it%20alongside%20the%20cancel%20token%29.%0A%0A%23%23%23%20Issue%202%20of%205%0Asrc-tauri%2Fsrc%2Fportforward%2Fmanager.rs%3A632-641%0A**In-progress%20remote-forward%20connections%20are%20not%20cancelled%20when%20tunnel%20is%20stopped**%0A%0AEach%20%60server_channel_open_forwarded_tcpip%60%20call%20pumps%20with%20%60CancellationToken%3A%3Anew%28%29%60%20%E2%80%94%20a%20fresh%2C%20never-cancelled%20token%20%E2%80%94%20rather%20than%20reusing%20the%20tunnel's%20own%20cancel%20token.%20When%20%60stop_tunnel%60%20fires%20the%20tunnel's%20token%2C%20already-established%20remote%20channels%20keep%20running%20to%20natural%20termination.%20By%20contrast%2C%20the%20local-forward%20path%20propagates%20the%20tunnel's%20cancel%20token%20to%20every%20per-connection%20%60proxy_to_remote%60%20call.%20Using%20the%20tunnel-level%20cancel%20token%20here%20would%20make%20behaviour%20consistent.%0A%0A%23%23%23%20Issue%203%20of%205%0Asrc-tauri%2Fsrc%2Fportforward%2Fmanager.rs%3A330-339%0A%60tcpip_forward%60%20returns%20%60Ok%28u32%29%60%20where%20the%20value%20is%20the%20server-allocated%20port%20when%20the%20requested%20port%20is%200.%20That%20value%20is%20silently%20discarded%20here.%20If%20a%20port-0%20remote%20tunnel%20is%20ever%20created%20%28the%20UI%20currently%20blocks%20it%2C%20but%20it%20can%20arrive%20via%20the%20import%20path%29%2C%20%60local_port%60%20in%20the%20%60ActiveTunnel%60%20entry%20would%20stay%200%20and%20the%20status%20event%20would%20also%20report%200%2C%20giving%20users%20no%20indication%20of%20which%20port%20to%20connect%20to%20on%20the%20remote%20side.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%2F%2F%20Ask%20the%20server%20to%20start%20listening.%20A%20bind%20conflict%20on%20the%20*server*%20is%0A%20%20%20%20%20%20%20%20%2F%2F%20reported%20here%20as%20a%20request%20denial.%0A%20%20%20%20%20%20%20%20let%20actual_listen_port%20%3D%20handle%0A%20%20%20%20%20%20%20%20%20%20%20%20.tcpip_forward%28bind_address.clone%28%29%2C%20listen_port%29%0A%20%20%20%20%20%20%20%20%20%20%20%20.await%0A%20%20%20%20%20%20%20%20%20%20%20%20.map_err%28%7Ce%7C%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20SshError%3A%3AIoError%28format!%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22server%20refused%20to%20forward%20%7Bbind_address%7D%3A%7Blisten_port%7D%3A%20%7Be%7D%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%29%3F%3B%0A%20%20%20%20%20%20%20%20%2F%2F%20When%20listen_port%20%3D%3D%200%20the%20server%20chooses%3B%20use%20the%20returned%20port.%0A%20%20%20%20%20%20%20%20let%20listen_port%20%3D%20if%20listen_port%20%3D%3D%200%20%7B%20actual_listen_port%20%7D%20else%20%7B%20listen_port%20%7D%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%204%20of%205%0Asrc%2Fstores%2Fport-forward-store.ts%3A102-105%0AThe%20%60void%20hostId%60%20idiom%20suppresses%20the%20%22unused%20variable%22%20lint%20but%20leaves%20dead%20code%20in%20place.%20Since%20the%20backend%20now%20resolves%20everything%20from%20%60ruleId%60%2C%20%60hostId%60%20can%20be%20dropped%20from%20the%20call.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20const%20status%20%3D%20await%20invoke%3CTunnelStatus%3E%28%22pf_start_tunnel%22%2C%20%7B%20ruleId%20%7D%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%205%20of%205%0Asrc-tauri%2Fsrc%2Fdb%2Fmod.rs%3A1573-1574%0A%60find_pf_rule_id_by_natural_key%60%20has%206%20non-%60self%60%20parameters%2C%20which%20is%20below%20Clippy's%20default%20limit%20of%207%2C%20so%20the%20%60%23%5Ballow%5D%60%20is%20unnecessary.%0A%0A%60%60%60suggestion%0A%20%20%20%20pub%20fn%20find_pf_rule_id_by_natural_key%28%0A%60%60%60%0A%0A&repo=macnev2013%2Fanyscp&pr=81&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 5 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 5
src-tauri/src/portforward/manager.rs:377-404
**Remote tunnel stays "Active" after SSH connection drops**

The spawned task blocks indefinitely on `cancel_token.cancelled().await`. There is no mechanism to detect a broken SSH connection — if the server crashes or the network goes down, `russh` calls the handler's `disconnected()` (not implemented by `RemoteForwardHandler`, so the default no-op fires), but the cancel token is never signalled. The entry in `self.tunnels` is never removed and no `pf:status Stopped` event is emitted. The UI shows the tunnel as live even though the server-side listener is gone and all new remote connections silently fail.

`RemoteForwardHandler` should implement `disconnected()` and cancel the token (or use a separate `JoinHandle` for the russh connection task and `select!` on it alongside the cancel token).

### Issue 2 of 5
src-tauri/src/portforward/manager.rs:632-641
**In-progress remote-forward connections are not cancelled when tunnel is stopped**

Each `server_channel_open_forwarded_tcpip` call pumps with `CancellationToken::new()` — a fresh, never-cancelled token — rather than reusing the tunnel's own cancel token. When `stop_tunnel` fires the tunnel's token, already-established remote channels keep running to natural termination. By contrast, the local-forward path propagates the tunnel's cancel token to every per-connection `proxy_to_remote` call. Using the tunnel-level cancel token here would make behaviour consistent.

### Issue 3 of 5
src-tauri/src/portforward/manager.rs:330-339
`tcpip_forward` returns `Ok(u32)` where the value is the server-allocated port when the requested port is 0. That value is silently discarded here. If a port-0 remote tunnel is ever created (the UI currently blocks it, but it can arrive via the import path), `local_port` in the `ActiveTunnel` entry would stay 0 and the status event would also report 0, giving users no indication of which port to connect to on the remote side.

```suggestion
        // Ask the server to start listening. A bind conflict on the *server* is
        // reported here as a request denial.
        let actual_listen_port = handle
            .tcpip_forward(bind_address.clone(), listen_port)
            .await
            .map_err(|e| {
                SshError::IoError(format!(
                    "server refused to forward {bind_address}:{listen_port}: {e}"
                ))
            })?;
        // When listen_port == 0 the server chooses; use the returned port.
        let listen_port = if listen_port == 0 { actual_listen_port } else { listen_port };
```

### Issue 4 of 5
src/stores/port-forward-store.ts:102-105
The `void hostId` idiom suppresses the "unused variable" lint but leaves dead code in place. Since the backend now resolves everything from `ruleId`, `hostId` can be dropped from the call.

```suggestion
      const status = await invoke<TunnelStatus>("pf_start_tunnel", { ruleId });
```

### Issue 5 of 5
src-tauri/src/db/mod.rs:1573-1574
`find_pf_rule_id_by_natural_key` has 6 non-`self` parameters, which is below Clippy's default limit of 7, so the `#[allow]` is unnecessary.

```suggestion
    pub fn find_pf_rule_id_by_natural_key(
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(tunnels): import SSH forwards as tu..."](https://github.com/macnev2013/anyscp/commit/1bbb492bcd8ad7579150653831a2856074dcd759) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47214320)</sub>

> Greptile also left **5 inline comments** on this PR.

<!-- /greptile_comment -->