### PR TITLE
fix(transfers): stop the transfer popover from reopening on every progress event

### DIFF
--- a/src/hooks/use-sftp-transfers.ts
+++ b/src/hooks/use-sftp-transfers.ts
@@ -176,3 +176,16 @@ export function useSftpTransfers() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [updateTransfer, setPopoverOpen, setHostLabel]);
 }
+
+// E2E test hook — emit a synthetic transfer event so specs can drive the
+// auto-open behaviour deterministically (the backend's progress events are
+// otherwise too fast/short to script). Mirrors the `__e2e*` invoke wrappers in
+// the stores; the import is bundled so it resolves inside the app context.
+if (typeof window !== "undefined") {
+  (window as unknown as {
+    __e2eEmitTransfer?: (event: string, payload: unknown) => Promise<void>;
+  }).__e2eEmitTransfer = async (event, payload) => {
+    const { emit } = await import("@tauri-apps/api/event");
+    await emit(event, payload);
+  };
+}

--- a/src/hooks/use-sftp-transfers.ts
+++ b/src/hooks/use-sftp-transfers.ts
@@ -58,6 +58,12 @@ export function useSftpTransfers() {
 
         const unsub = await listen<TransferEvent>("sftp:transfer", (event) => {
           const transfer = event.payload;
+
+          // Auto-open popover only the first time we see a transfer — checked
+          // before updateTransfer() so the id isn't in the map yet. Otherwise
+          // every progress event would reopen a popover the user just closed.
+          const isNew = !useTransferStore.getState().transfers.has(transfer.transfer_id);
+
           updateTransfer(transfer);
 
           // Cache the host label for this session
@@ -69,7 +75,7 @@ export function useSftpTransfers() {
           }
 
           // Auto-open popover when a new transfer starts
-          if (transfer.status === "InProgress" || transfer.status === "Queued") {
+          if (isNew && (transfer.status === "InProgress" || transfer.status === "Queued")) {
             if (!useTransferStore.getState().popoverOpen) {
               setPopoverOpen(true);
             }
@@ -96,6 +102,11 @@ export function useSftpTransfers() {
 
         const unsub = await listen<TransferEvent>("scp:transfer", (event) => {
           const transfer = event.payload;
+
+          // Auto-open popover only the first time we see a transfer (see the
+          // SFTP listener above for why this is checked before updateTransfer).
+          const isNew = !useTransferStore.getState().transfers.has(transfer.transfer_id);
+
           updateTransfer(transfer);
 
           // Cache the host label for this session
@@ -107,7 +118,7 @@ export function useSftpTransfers() {
           }
 
           // Auto-open popover when a new transfer starts
-          if (transfer.status === "InProgress" || transfer.status === "Queued") {
+          if (isNew && (transfer.status === "InProgress" || transfer.status === "Queued")) {
             if (!useTransferStore.getState().popoverOpen) {
               setPopoverOpen(true);
             }
@@ -134,6 +145,11 @@ export function useSftpTransfers() {
 
         const unsub = await listen<TransferEvent>("s3:transfer", (event) => {
           const transfer = event.payload;
+
+          // Auto-open popover only the first time we see a transfer (see the
+          // SFTP listener above for why this is checked before updateTransfer).
+          const isNew = !useTransferStore.getState().transfers.has(transfer.transfer_id);
+
           updateTransfer(transfer);
 
           // Cache the host label for this session
@@ -145,7 +161,7 @@ export function useSftpTransfers() {
           }
 
           // Auto-open popover when a new transfer starts
-          if (transfer.status === "InProgress" || transfer.status === "Queued") {
+          if (isNew && (transfer.status === "InProgress" || transfer.status === "Queued")) {
             if (!useTransferStore.getState().popoverOpen) {
               setPopoverOpen(true);
             }

--- a/tests/e2e/specs/93-transfer-popover.spec.ts
+++ b/tests/e2e/specs/93-transfer-popover.spec.ts
@@ -1,0 +1,76 @@
+// Issue #88 / PR #93: the transfer popover must not reopen on every progress
+// event. The event listeners auto-opened the popover whenever an InProgress
+// event arrived; since the backend emits one per chunk, dismissing the popover
+// during an active upload reopened it immediately — impossible to close.
+//
+// The fix auto-opens only the first time a transfer id is seen. We drive the
+// real listener (mounted globally in AppShell) with synthetic `sftp:transfer`
+// events — exactly what the backend emits — so we can deterministically deliver
+// many InProgress updates for the same transfer without a slow upload.
+
+import { resetApp } from "../helpers/reset.js";
+import { waitForDashboard } from "../helpers/dashboard.js";
+
+const POPOVER = "[aria-label='Transfer items']";
+const CLOSE_BTN = "[aria-label='Close transfers']";
+
+interface TransferOverrides {
+    transfer_id: string;
+    status?: unknown;
+    bytes_transferred?: number;
+}
+
+async function emitTransfer(o: TransferOverrides): Promise<void> {
+    await browser.execute(async (over: TransferOverrides) => {
+        const fn = (window as unknown as {
+            __e2eEmitTransfer?: (event: string, payload: unknown) => Promise<void>;
+        }).__e2eEmitTransfer;
+        if (!fn) throw new Error("__e2eEmitTransfer not registered");
+        await fn("sftp:transfer", {
+            transfer_id: over.transfer_id,
+            sftp_session_id: "sess-1",
+            name: "big-file.bin",
+            direction: "Upload",
+            status: over.status ?? "InProgress",
+            error: null,
+            bytes_transferred: over.bytes_transferred ?? 1,
+            total_bytes: 1_000_000,
+            files_done: 0,
+            files_total: 1,
+            speed_bps: 1000,
+            eta_secs: 60,
+            created_at: 1_700_000_000,
+        });
+    }, o);
+}
+
+describe("Transfer popover — no reopen on progress (issue #88)", () => {
+    beforeEach(async () => {
+        await resetApp();
+        await waitForDashboard();
+    });
+
+    it("stays closed after the user dismisses it during an active transfer", async () => {
+        // Nothing in flight → popover is closed.
+        await expect($(POPOVER)).not.toBeExisting();
+
+        // First event for a new transfer → auto-opens.
+        await emitTransfer({ transfer_id: "t1", bytes_transferred: 1 });
+        await expect($(POPOVER)).toBeExisting();
+
+        // User closes it.
+        await (await $(CLOSE_BTN)).click();
+        await expect($(POPOVER)).not.toBeExisting();
+
+        // Further progress events for the SAME transfer must NOT reopen it.
+        for (let i = 2; i <= 5; i++) {
+            await emitTransfer({ transfer_id: "t1", bytes_transferred: i * 100_000 });
+        }
+        await browser.pause(800); // give any stray re-render time to happen
+        await expect($(POPOVER)).not.toBeExisting();
+
+        // A genuinely new transfer should still auto-open (feature intact).
+        await emitTransfer({ transfer_id: "t2", bytes_transferred: 1 });
+        await expect($(POPOVER)).toBeExisting();
+    });
+});


### PR DESCRIPTION
## Problem
During an SFTP/SCP/S3 upload the transfer-status popover could not be closed — pressing the X (or Esc, or clicking outside) dismissed it, but it reopened a fraction of a second later, repeatedly, until the transfer finished. In practice this blocked the terminal beneath it.

## Cause
The transfer-event listeners in `use-sftp-transfers.ts` re-ran the auto-open check on **every** progress event:
```ts
if (transfer.status === "InProgress" || transfer.status === "Queued") {
  if (!popoverOpen) setPopoverOpen(true);
}
```
The backend emits a progress event per chunk, so each one re-opened a popover the user had just closed.

## Fix
Auto-open only the **first** time a transfer id is seen — captured via `!transfers.has(transfer_id)` *before* `updateTransfer()` runs (so the id isn't in the map yet). Applied consistently to the SFTP, SCP, and S3 listeners.

New transfers still auto-open as before; the existing close button, Esc, and outside-click dismissal now stay closed.

Fixes #88