### PR TITLE
fix(terminal): open clicked links via the OS browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@tauri-apps/plugin-updater": "^2.10.0",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-search": "^0.16.0",
+    "@xterm/addon-web-links": "^0.12.0",
     "@xterm/addon-webgl": "^0.19.0",
     "@xterm/xterm": "^6.0.0",
     "lucide-react": "^1.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       '@xterm/addon-search':
         specifier: ^0.16.0
         version: 0.16.0
+      '@xterm/addon-web-links':
+        specifier: ^0.12.0
+        version: 0.12.0
       '@xterm/addon-webgl':
         specifier: ^0.19.0
         version: 0.19.0
@@ -861,6 +864,9 @@ packages:
 
   '@xterm/addon-search@0.16.0':
     resolution: {integrity: sha512-9OeuBFu0/uZJPu+9AHKY6g/w0Czyb/Ut0A5t79I4ULoU4IfU5BEpPFVGQxP4zTTMdfZEYkVIRYbHBX1xWwjeSA==}
+
+  '@xterm/addon-web-links@0.12.0':
+    resolution: {integrity: sha512-4Smom3RPyVp7ZMYOYDoC/9eGJJJqYhnPLGGqJ6wOBfB8VxPViJNSKdgRYb8NpaM6YSelEKbA2SStD7lGyqaobw==}
 
   '@xterm/addon-webgl@0.19.0':
     resolution: {integrity: sha512-b3fMOsyLVuCeNJWxolACEUED0vm7qC0cy4wRvf3oURSzDTYVQiGPhTnhWZwIHdvC48Y+oLhvYXnY4XDXPoJo6A==}
@@ -2074,6 +2080,8 @@ snapshots:
   '@xterm/addon-fit@0.11.0': {}
 
   '@xterm/addon-search@0.16.0': {}
+
+  '@xterm/addon-web-links@0.12.0': {}
 
   '@xterm/addon-webgl@0.19.0': {}
 

--- a/src/stores/terminal-instances.ts
+++ b/src/stores/terminal-instances.ts
@@ -30,6 +30,25 @@ export interface TerminalEntry {
 const instances = new Map<string, TerminalEntry>();
 
 /**
+ * Open a URL clicked in the terminal via the OS default browser.
+ *
+ * xterm's built-in OSC 8 handler (and a naive WebLinksAddon) would fall back to
+ * `window.open()`, which does not work inside the Tauri webview and surfaces a
+ * browser error. Route through the Tauri opener instead. The plugin is
+ * lazy-imported per project convention (no module-level Tauri imports).
+ */
+function openTerminalLink(uri: string): void {
+  void (async () => {
+    try {
+      const { openUrl } = await import("@tauri-apps/plugin-opener");
+      await openUrl(uri);
+    } catch {
+      /* Opener unavailable (e.g. not running in Tauri) */
+    }
+  })();
+}
+
+/**
  * ANSI 16-color palettes. xterm.js falls back to its built-in palette when
  * these are unset, and that default green (#0DBC79) is nearly illegible on a
  * light background — so we ship palettes tuned for each background's contrast.
@@ -122,6 +141,12 @@ function createEntry(sessionId: string): TerminalEntry {
     scrollback: settings.terminalScrollback,
     theme: getTerminalTheme(),
     allowProposedApi: true,
+    // Open OSC 8 hyperlinks (emitted by ls --hyperlink, git, etc.) through the
+    // OS browser instead of xterm's window.open() fallback, which errors in the
+    // Tauri webview.
+    linkHandler: {
+      activate: (_event, uri) => openTerminalLink(uri),
+    },
   });
 
   const fitAddon = new FitAddon();
@@ -141,6 +166,17 @@ function createEntry(sessionId: string): TerminalEntry {
     })
     .catch(() => {
       /* Search unavailable */
+    });
+
+  // Load web-links addon asynchronously — makes plain-text URLs in the output
+  // clickable (OSC 8 hyperlinks are handled by the linkHandler option above).
+  import("@xterm/addon-web-links")
+    .then(({ WebLinksAddon }) => {
+      if (!instances.has(sessionId)) return;
+      term.loadAddon(new WebLinksAddon((_event, uri) => openTerminalLink(uri)));
+    })
+    .catch(() => {
+      /* Web links unavailable */
     });
 
   term.attachCustomKeyEventHandler((e) => {


### PR DESCRIPTION
## Problem
Clicking a link in the remote terminal output raised a browser error instead of opening it (reported on Debian 11).

## Cause
xterm v6's built-in OSC 8 hyperlink handler falls back to `window.open()`, which doesn't work inside the Tauri WebKitGTK webview. Additionally, `@xterm/addon-web-links` wasn't installed, so plain-text URLs weren't clickable at all.

## Fix
- Add a `linkHandler` to the `XTerm` constructor that routes activation through the Tauri opener (`openUrl`), lazy-imported per the project's no-module-level-Tauri-imports rule.
- Install and load `@xterm/addon-web-links` with the same handler so plain-text URLs become clickable too.

The opener plugin (`tauri-plugin-opener`/`@tauri-apps/plugin-opener`) and the `opener:default` capability were already configured — no Rust or capability changes needed.

Fixes #90