### PR TITLE
chore(macos): add hardened-runtime entitlements

### DIFF
--- a/src-tauri/macos/anyscp.entitlements
+++ b/src-tauri/macos/anyscp.entitlements
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- Hardened-runtime entitlements. The release build enables the hardened
+         runtime (required for notarization); these grant the exceptions a Tauri
+         app needs under it. The app is NOT sandboxed, so no app-sandbox /
+         network entitlements are included (outbound network already works). -->
+
+    <!-- WKWebView (the Tauri webview) needs JIT and writable/executable memory. -->
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <!-- Allow loading the dynamically-linked native dependencies bundled with
+         the app (e.g. the drag and clipboard crates). -->
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+</dict>
+</plist>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -29,7 +29,10 @@
       "icons/icon.icns",
       "icons/icon.ico"
     ],
-    "createUpdaterArtifacts": "v1Compatible"
+    "createUpdaterArtifacts": "v1Compatible",
+    "macOS": {
+      "entitlements": "./macos/anyscp.entitlements"
+    }
   },
   "plugins": {
     "updater": {


### PR DESCRIPTION
Adds the standard hardened-runtime entitlements a Tauri app needs. The release build enables the hardened runtime (for notarization) but currently ships **no entitlements** (verified via `codesign -d --entitlements` on the released v0.10.4 app).

## Entitlements added
- `com.apple.security.cs.allow-jit`
- `com.apple.security.cs.allow-unsigned-executable-memory` — both for the WKWebView's JS engine.
- `com.apple.security.cs.disable-library-validation` — for the bundled native dependencies (drag, clipboard crates).

…wired up via `bundle.macOS.entitlements` in `tauri.conf.json`.

## ⚠️ Does NOT fix #89
This was originally proposed as a fix for the #89 "bad file descriptor" connection error via `com.apple.security.network.client`. Inspecting the shipped v0.10.4 binary showed it is **hardened-runtime + Developer ID signed but NOT sandboxed** — and `network.client` only has any effect under `app-sandbox`. So that entitlement was a no-op and has been **removed**; this PR is now purely hardening and is **decoupled from #89** (which remains open pending a real root-cause fix).

This is safe hardening that aligns the build with Tauri's recommended hardened-runtime setup.