### PR TITLE
fix(explorer): navigate symlinked directories + open terminal links

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@tauri-apps/plugin-updater": "^2.10.0",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-search": "^0.16.0",
+    "@xterm/addon-web-links": "^0.12.0",
     "@xterm/addon-webgl": "^0.19.0",
     "@xterm/xterm": "^6.0.0",
     "lucide-react": "^1.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       '@xterm/addon-search':
         specifier: ^0.16.0
         version: 0.16.0
+      '@xterm/addon-web-links':
+        specifier: ^0.12.0
+        version: 0.12.0
       '@xterm/addon-webgl':
         specifier: ^0.19.0
         version: 0.19.0
@@ -861,6 +864,9 @@ packages:
 
   '@xterm/addon-search@0.16.0':
     resolution: {integrity: sha512-9OeuBFu0/uZJPu+9AHKY6g/w0Czyb/Ut0A5t79I4ULoU4IfU5BEpPFVGQxP4zTTMdfZEYkVIRYbHBX1xWwjeSA==}
+
+  '@xterm/addon-web-links@0.12.0':
+    resolution: {integrity: sha512-4Smom3RPyVp7ZMYOYDoC/9eGJJJqYhnPLGGqJ6wOBfB8VxPViJNSKdgRYb8NpaM6YSelEKbA2SStD7lGyqaobw==}
 
   '@xterm/addon-webgl@0.19.0':
     resolution: {integrity: sha512-b3fMOsyLVuCeNJWxolACEUED0vm7qC0cy4wRvf3oURSzDTYVQiGPhTnhWZwIHdvC48Y+oLhvYXnY4XDXPoJo6A==}
@@ -2074,6 +2080,8 @@ snapshots:
   '@xterm/addon-fit@0.11.0': {}
 
   '@xterm/addon-search@0.16.0': {}
+
+  '@xterm/addon-web-links@0.12.0': {}
 
   '@xterm/addon-webgl@0.19.0': {}
 

--- a/src-tauri/src/sftp/commands.rs
+++ b/src-tauri/src/sftp/commands.rs
@@ -228,11 +228,24 @@ pub async fn sftp_close(
 
 // ─── Directory operations ─────────────────────────────────────────────────────
 
+/// Map a russh-sftp `FileType` to our `SftpEntryType`. A `Symlink` here means
+/// the link itself (lstat); for entries we resolve to a target this should
+/// already be the target's concrete type.
+fn resolve_entry_type(file_type: FileType) -> SftpEntryType {
+    match file_type {
+        FileType::Dir => SftpEntryType::Directory,
+        FileType::Symlink => SftpEntryType::Symlink,
+        FileType::File => SftpEntryType::File,
+        FileType::Other => SftpEntryType::Other,
+    }
+}
+
 /// List the contents of a remote directory.
 /// Returns entries sorted: directories first, then files, alphabetically
 /// within each group.
 #[tauri::command]
 #[instrument(skip(sftp_manager), fields(sftp_session_id = %sftp_session_id, path = %path))]
+
 pub async fn sftp_list_dir(
     sftp_session_id: String,
     path: String,
@@ -250,43 +263,55 @@ pub async fn sftp_list_dir(
         .map_err(|e| SftpError::RemoteIoError(e.to_string()))?;
 
     // ReadDir already skips "." and ".." entries internally.
-    let mut result: Vec<SftpEntry> = read_dir
-        .map(|entry| {
-            let name = entry.file_name();
-            let full_path = if path == "/" {
-                format!("/{name}")
-            } else {
-                format!("{path}/{name}")
-            };
+    //
+    // `read_dir` reports per-entry types from an lstat, so a symlink always
+    // comes back as `FileType::Symlink` regardless of what it points at. For
+    // symlinks we follow the link with `metadata()` (a stat) to resolve the
+    // *target's* type, so the UI treats a symlinked directory as a directory
+    // (navigable) instead of trying to open it as a file — which fails with a
+    // "Remote I/O error: Failure". `is_symlink` still tracks the lstat result
+    // so the link icon and read-only permission handling are preserved.
+    let mut result: Vec<SftpEntry> = Vec::new();
+    for entry in read_dir {
+        let name = entry.file_name();
+        let full_path = if path == "/" {
+            format!("/{name}")
+        } else {
+            format!("{path}/{name}")
+        };
 
-            let attrs = entry.metadata();
+        let attrs = entry.metadata();
+        let file_type = attrs.file_type();
+        let is_symlink = file_type == FileType::Symlink;
 
-            let file_type = attrs.file_type();
-            let entry_type = match file_type {
-                FileType::Dir => SftpEntryType::Directory,
-                FileType::Symlink => SftpEntryType::Symlink,
-                FileType::File => SftpEntryType::File,
-                FileType::Other => SftpEntryType::Other,
-            };
-
-            // Use only the lower 12 bits (permission + setuid/setgid/sticky).
-            let permissions = attrs.permissions.unwrap_or(0) & 0o7777;
-            // mtime is Option<u32> in FileAttributes; widen to u64 for the frontend.
-            let modified = attrs.mtime.map(|t| t as u64);
-            let is_symlink = entry_type == SftpEntryType::Symlink;
-
-            SftpEntry {
-                name,
-                path: full_path,
-                entry_type,
-                size: attrs.size.unwrap_or(0),
-                permissions,
-                permissions_display: format_permissions(permissions),
-                modified,
-                is_symlink,
+        let entry_type = if is_symlink {
+            // Follow the link. A broken/dangling symlink (or an unreadable
+            // target) leaves it typed as a symlink — double-click just won't
+            // navigate, rather than erroring.
+            match sftp.metadata(&full_path).await {
+                Ok(target) => resolve_entry_type(target.file_type()),
+                Err(_) => SftpEntryType::Symlink,
             }
-        })
-        .collect();
+        } else {
+            resolve_entry_type(file_type)
+        };
+
+        // Use only the lower 12 bits (permission + setuid/setgid/sticky).
+        let permissions = attrs.permissions.unwrap_or(0) & 0o7777;
+        // mtime is Option<u32> in FileAttributes; widen to u64 for the frontend.
+        let modified = attrs.mtime.map(|t| t as u64);
+
+        result.push(SftpEntry {
+            name,
+            path: full_path,
+            entry_type,
+            size: attrs.size.unwrap_or(0),
+            permissions,
+            permissions_display: format_permissions(permissions),
+            modified,
+            is_symlink,
+        });
+    }
 
     // Directories first, then alphabetical within each group (case-insensitive).
     result.sort_by(|a, b| {

--- a/src/stores/terminal-instances.ts
+++ b/src/stores/terminal-instances.ts
@@ -30,6 +30,25 @@ export interface TerminalEntry {
 const instances = new Map<string, TerminalEntry>();
 
 /**
+ * Open a URL clicked in the terminal via the OS default browser.
+ *
+ * xterm's built-in OSC 8 handler (and a naive WebLinksAddon) would fall back to
+ * `window.open()`, which does not work inside the Tauri webview and surfaces a
+ * browser error. Route through the Tauri opener instead. The plugin is
+ * lazy-imported per project convention (no module-level Tauri imports).
+ */
+function openTerminalLink(uri: string): void {
+  void (async () => {
+    try {
+      const { openUrl } = await import("@tauri-apps/plugin-opener");
+      await openUrl(uri);
+    } catch {
+      /* Opener unavailable (e.g. not running in Tauri) */
+    }
+  })();
+}
+
+/**
  * ANSI 16-color palettes. xterm.js falls back to its built-in palette when
  * these are unset, and that default green (#0DBC79) is nearly illegible on a
  * light background — so we ship palettes tuned for each background's contrast.
@@ -122,6 +141,12 @@ function createEntry(sessionId: string): TerminalEntry {
     scrollback: settings.terminalScrollback,
     theme: getTerminalTheme(),
     allowProposedApi: true,
+    // Open OSC 8 hyperlinks (emitted by ls --hyperlink, git, etc.) through the
+    // OS browser instead of xterm's window.open() fallback, which errors in the
+    // Tauri webview.
+    linkHandler: {
+      activate: (_event, uri) => openTerminalLink(uri),
+    },
   });
 
   const fitAddon = new FitAddon();
@@ -141,6 +166,17 @@ function createEntry(sessionId: string): TerminalEntry {
     })
     .catch(() => {
       /* Search unavailable */
+    });
+
+  // Load web-links addon asynchronously — makes plain-text URLs in the output
+  // clickable (OSC 8 hyperlinks are handled by the linkHandler option above).
+  import("@xterm/addon-web-links")
+    .then(({ WebLinksAddon }) => {
+      if (!instances.has(sessionId)) return;
+      term.loadAddon(new WebLinksAddon((_event, uri) => openTerminalLink(uri)));
+    })
+    .catch(() => {
+      /* Web links unavailable */
     });
 
   term.attachCustomKeyEventHandler((e) => {

--- a/tests/e2e/specs/90-symlink-resolve.spec.ts
+++ b/tests/e2e/specs/90-symlink-resolve.spec.ts
@@ -1,0 +1,83 @@
+// Issue #90: double-clicking a symlink that points to a directory raised
+// "Remote I/O error: Failure: Failure". The lstat-based listing typed the
+// symlink as Symlink (not Directory), so handleDoubleClick treated it as a
+// file and tried to download a directory. The fix resolves the symlink target
+// type during sftp_list_dir, so a symlinked directory is navigable.
+//
+// We set up a real symlink on the server via the terminal, then drive the
+// explorer's double-click and assert we navigate INTO the target.
+
+import { resetApp } from "../helpers/reset.js";
+import { waitForDashboard } from "../helpers/dashboard.js";
+import {
+    clickSave,
+    fillPasswordHostForm,
+    findHostCardByLabel,
+    getHostId,
+    openNewHostModal,
+    waitForModalClosed,
+} from "../helpers/host.js";
+import {
+    openEntry,
+    refreshExplorer,
+    waitForEntry,
+    waitForExplorer,
+} from "../helpers/sftp-ops.js";
+import { runCommand, waitForAnyTerminal, waitForTerminalText } from "../helpers/terminal.js";
+
+const SSHD_PASS_HOST = process.env.SSHD_PASS_HOST ?? "sshd-pass";
+const SSHD_PASS_PORT = Number(process.env.SSHD_PASS_PORT ?? 2222);
+const SSH_USER = process.env.SSH_USER ?? "testuser";
+const SSH_PASS = process.env.SSH_PASS ?? "testpass";
+
+describe("Explorer symlinked directory (issue #90)", () => {
+    beforeEach(async () => {
+        await resetApp();
+        await waitForDashboard();
+    });
+
+    it("double-clicking a symlinked directory navigates into its target", async () => {
+        await openNewHostModal();
+        await fillPasswordHostForm({
+            label: "symlink-host",
+            host: SSHD_PASS_HOST,
+            port: SSHD_PASS_PORT,
+            username: SSH_USER,
+            password: SSH_PASS,
+        });
+        await clickSave();
+        await waitForModalClosed();
+        await findHostCardByLabel("symlink-host");
+        const hostId = await getHostId("symlink-host");
+
+        // 1. Open a terminal and create  ~/symtest/realdir/inside.txt  plus a
+        //    symlink  ~/symtest/linkdir -> realdir.  The leading rm makes the
+        //    spec idempotent across runs (remote home persists per container).
+        await (await $(`[data-testid='host-card-${hostId}-terminal']`)).click();
+        const term = await waitForAnyTerminal();
+        await waitForTerminalText(term, ":~$");
+        const marker = "SYMSETUP_" + Date.now();
+        await runCommand(
+            term,
+            "rm -rf ~/symtest && mkdir -p ~/symtest/realdir && " +
+                "echo hi > ~/symtest/realdir/inside.txt && " +
+                "ln -s realdir ~/symtest/linkdir && echo " + marker,
+            marker,
+        );
+
+        // 2. Back to the dashboard, open the SFTP explorer for the same host.
+        await (await $("[aria-label='Hosts']")).click();
+        await (await $(`[data-testid='host-card-${hostId}-explorer']`)).click();
+        await waitForExplorer();
+
+        // 3. Navigate into symtest and double-click the symlinked directory.
+        await openEntry("symtest");
+        await refreshExplorer();
+        await waitForEntry("linkdir");
+        await openEntry("linkdir"); // double-click
+
+        // 4. We should have navigated into the target — its contents are shown,
+        //    and no "Remote I/O error" toast appeared.
+        await waitForEntry("inside.txt");
+    });
+});


### PR DESCRIPTION
Fixes #90.

## The bug
Double-clicking a **symlink that points to a directory** in the file explorer raised `Remote I/O error: Failure: Failure` (see the issue screenshots — a `containers` symlink). The directory listing types entries from `read_dir` (lstat), so a symlink is reported as `Symlink`, never resolving the target. `handleDoubleClick` only navigates `Directory` entries, so a symlinked dir fell through to the *download* path, which tried to `open()` a directory as a file → I/O error. Net effect: **you can't browse into symlinked directories.**

## The fix
- **`sftp_list_dir` (`src-tauri/src/sftp/commands.rs`)**: for symlink entries, follow the link with `metadata()` and set `entry_type` to the **target's** type (Directory/File/Other), while keeping `is_symlink` for the chain icon and read-only permission handling. Broken/dangling symlinks stay typed as `Symlink` (no navigation, no error). Symlinked dirs are now navigable; symlinked files open/download.
- No frontend change needed — `handleDoubleClick` already navigates anything typed `Directory`, and `EntryIcon` checks `isSymlink` first so the icon is unchanged.

## Terminal link opening (folded in from #94)
Also includes the terminal link fix: clicking an OSC 8 hyperlink in the terminal routed through xterm's `window.open()` fallback, which errors inside the Tauri webview. Now routed through the Tauri opener, and `@xterm/addon-web-links` makes plain-text URLs clickable too. This supersedes #94.

## Verification
- New e2e spec `90-symlink-resolve.spec.ts` creates a symlinked directory on the test server and asserts double-click navigates into the target — **passing** against the real app (WebKitWebDriver).
- `cargo check` and `tsc --noEmit` clean.