### PR TITLE
feat(explorer): download multiple selected files at once

### DIFF
--- a/src/components/explorer/ExplorerFileTable.tsx
+++ b/src/components/explorer/ExplorerFileTable.tsx
@@ -40,6 +40,9 @@ interface ExplorerFileTableProps {
   onSetClipboard: (clipboard: ExplorerClipboard | null) => void;
   onNavigate: (path: string) => void;
   onDownload: (entry: ExplorerEntry) => void;
+  /** Download a multi-entry selection at once (into a chosen folder). Absent
+   *  for providers without a batch-download path. */
+  onDownloadMany?: (entries: ExplorerEntry[]) => void;
   onDelete: (entries: ExplorerEntry[]) => Promise<void>;
   onRename?: (entry: ExplorerEntry, newName: string) => Promise<void>;
   onEditInEditor?: (entry: ExplorerEntry, editor?: EditorConfig) => void;
@@ -273,6 +276,7 @@ export function ExplorerFileTable({
   onSetClipboard,
   onNavigate,
   onDownload,
+  onDownloadMany,
   onDelete,
   onRename,
   onEditInEditor,
@@ -646,6 +650,13 @@ export function ExplorerFileTable({
 
     if (isInSelection) {
       const count = selectedIds.size;
+      if (caps.canDownload && onDownloadMany) {
+        items.push({
+          label: `Download ${count} items`,
+          icon: Download,
+          onClick: () => onDownloadMany(selectedEntries),
+        });
+      }
       if (caps.canCopyPaste) {
         items.push({
           label: `Copy ${count} items`,

--- a/src/components/sftp/ExplorerView.tsx
+++ b/src/components/sftp/ExplorerView.tsx
@@ -399,6 +399,30 @@ export function ExplorerView({ sessionId, transport = "sftp", isActive = true }:
     }
   }, [sessionId, transport]);
 
+  // Download several selected entries at once. Unlike the single-file path
+  // (which lets you rename via a Save dialog), this asks for a destination
+  // folder once and downloads everything into it under their original names.
+  // `enqueue_download` accepts a mix of files and folders and recurses into
+  // folders, so one call covers the whole selection.
+  const handleDownloadMany = useCallback(async (entries: ExplorerEntry[]) => {
+    if (entries.length === 0) return;
+    try {
+      const { open } = await import("@tauri-apps/plugin-dialog");
+      const localDir = await open({
+        directory: true,
+        title: `Download ${entries.length} items to…`,
+      }) as string | null;
+      if (!localDir) return;
+
+      await explorerInvoke(transport, "enqueue_download", sessionId, {
+        remotePaths: entries.map((e) => e.id),
+        localDir,
+      });
+    } catch (err) {
+      console.error("Download failed:", err);
+    }
+  }, [sessionId, transport]);
+
   // ─── Drag-out (Explorer → OS desktop/Finder) ──────────────────────────────
   //
   // The whole drag-out runs in the backend `sftp_drag_out` command: it stages
@@ -754,6 +778,7 @@ export function ExplorerView({ sessionId, transport = "sftp", isActive = true }:
         onSetClipboard={handleSetClipboard}
         onNavigate={(path) => void loadDirectory(path)}
         onDownload={(entry) => void handleDownload(entry)}
+        onDownloadMany={(entries) => void handleDownloadMany(entries)}
         onDelete={handleDelete}
         onRename={handleRename}
         onEditInEditor={handleEditInEditor}

--- a/tests/e2e/specs/65-multi-download-menu.spec.ts
+++ b/tests/e2e/specs/65-multi-download-menu.spec.ts
@@ -1,0 +1,92 @@
+// Issue #6: with multiple files selected, the context menu only offered Copy,
+// Cut and Delete — no Download — so files had to be downloaded one at a time.
+// A "Download N items" entry is now offered for a multi-selection.
+//
+// The download itself opens a native folder picker the WebDriver can't drive,
+// so this asserts the menu entry is present for a multi-selection (the actual
+// gap the issue reports). The batch download is handled by the existing
+// enqueue_download backend, covered by 46-sftp-upload-recursive's sibling path.
+
+import { resetApp } from "../helpers/reset.js";
+import { waitForDashboard } from "../helpers/dashboard.js";
+import {
+    clickSave,
+    fillPasswordHostForm,
+    findHostCardByLabel,
+    getHostId,
+    openNewHostModal,
+    waitForModalClosed,
+} from "../helpers/host.js";
+import { createFile, waitForEntry, waitForExplorer } from "../helpers/sftp-ops.js";
+
+const SSHD_PASS_HOST = process.env.SSHD_PASS_HOST ?? "sshd-pass";
+const SSHD_PASS_PORT = Number(process.env.SSHD_PASS_PORT ?? 2222);
+const SSH_USER = process.env.SSH_USER ?? "testuser";
+const SSH_PASS = process.env.SSH_PASS ?? "testpass";
+
+describe("Explorer multi-select download (issue #6)", () => {
+    beforeEach(async () => {
+        await resetApp();
+        await waitForDashboard();
+    });
+
+    it("offers 'Download N items' when multiple files are selected", async () => {
+        await openNewHostModal();
+        await fillPasswordHostForm({
+            label: "multi-dl",
+            host: SSHD_PASS_HOST,
+            port: SSHD_PASS_PORT,
+            username: SSH_USER,
+            password: SSH_PASS,
+        });
+        await clickSave();
+        await waitForModalClosed();
+        await findHostCardByLabel("multi-dl");
+        const hostId = await getHostId("multi-dl");
+        await (await $(`[data-testid='host-card-${hostId}-explorer']`)).click();
+        await waitForExplorer();
+
+        const stamp = Date.now();
+        const a = `dl-a-${stamp}`;
+        const b = `dl-b-${stamp}`;
+        await createFile(a);
+        await createFile(b);
+
+        // Select both files via the e2e selection hook.
+        await waitForEntry(a);
+        await waitForEntry(b);
+        await browser.execute((names: string[]) => {
+            const fn = (window as unknown as {
+                __e2eExplorerSetSelection?: (n: string[]) => void;
+            }).__e2eExplorerSetSelection;
+            if (!fn) throw new Error("__e2eExplorerSetSelection not registered");
+            fn(names);
+        }, [a, b]);
+
+        // Open the multi-select context menu on a selected row. Dispatch a real
+        // DOM contextmenu event (WebKitWebDriver's synthetic right-click doesn't
+        // reliably fire one) — React's onContextMenu handles it the same way.
+        await browser.execute((name: string) => {
+            const el = document.querySelector(`[data-entry-name='${name}']`) as HTMLElement | null;
+            el?.dispatchEvent(
+                new MouseEvent("contextmenu", {
+                    bubbles: true,
+                    cancelable: true,
+                    clientX: 120,
+                    clientY: 120,
+                }),
+            );
+        }, a);
+
+        // The "Download N items" entry must be present and reflect the count.
+        await browser.waitUntil(
+            async () =>
+                browser.execute(() =>
+                    Array.from(document.querySelectorAll('button[role="menuitem"]')).some((b) =>
+                        (b.textContent || "").includes("Download 2 items"),
+                    ),
+                ),
+            { timeout: 5_000, timeoutMsg: "'Download 2 items' menu item was not shown" },
+        );
+    });
+});


### PR DESCRIPTION
Closes #6.

## Problem
With more than one file selected in the Explorer, the context menu only offered **Copy**, **Cut**, and **Delete** — there was no **Download**, so files had to be downloaded one at a time.

## Change
- Adds a **"Download N items"** action to the multi-select context menu (shown whenever the provider supports download).
- It asks for a destination folder **once**, then downloads the entire selection into it via the existing `enqueue_download` backend — which already accepts a mix of files and folders and recurses into folders. Works for SFTP and SCP.
- The single-file **Download** path (with its Save-as rename dialog) is unchanged.

## Verification
- `tsc --noEmit` clean.
- New e2e spec `65-multi-download-menu.spec.ts` selects two files, opens the multi-select context menu, and asserts the **Download 2 items** entry appears. (The download itself opens a native folder picker the WebDriver can't drive, so the spec asserts the menu entry — the exact gap the issue reports; the batch transfer is covered by the existing `enqueue_download` path.)

> Note: the e2e spec's menu-open step was reworked to dispatch a real DOM `contextmenu` event; it'll be validated by CI.