### PR TITLE
Feat/ssh agent support

### DIFF
--- a/src-tauri/src/ssh/commands.rs
+++ b/src-tauri/src/ssh/commands.rs
@@ -571,6 +571,7 @@ fn auth_method_label(auth: &AuthMethod) -> &'static str {
         AuthMethod::Password { .. } => "password",
         AuthMethod::PrivateKey { .. } => "privateKey",
         AuthMethod::PrivateKeyData { .. } => "privateKeyData",
+        AuthMethod::SshAgent { .. } => "sshAgent",
     }
 }
 
@@ -591,6 +592,7 @@ fn resolve_auth_method(host_id: &str, auth_type: &str, key_path: Option<String>)
                 passphrase,
             }
         }
+        "sshAgent" => AuthMethod::SshAgent { socket_path: None },
         _ => {
             let password = match vault::get_credential(host_id) {
                 Ok(vault::StoredCredential::Password { password }) => password,

--- a/src-tauri/src/ssh/manager.rs
+++ b/src-tauri/src/ssh/manager.rs
@@ -448,16 +448,110 @@ impl SshManager {
         )))
     }
 
-    #[cfg(not(unix))]
+    #[cfg(windows)]
+    async fn auth_with_agent(
+        handle: &mut client::Handle<SshClientHandler>,
+        config: &HostConfig,
+        socket_path: Option<&str>,
+    ) -> Result<(), SshError> {
+        use russh_keys::agent::client::AgentClient;
+
+        const DEFAULT_PIPE: &str = r"\\.\pipe\openssh-ssh-agent";
+        let pipe = socket_path.unwrap_or(DEFAULT_PIPE);
+
+        // ── Windows OpenSSH named pipe ─────────────────────────────────────
+        if let Ok(mut first) = AgentClient::connect_named_pipe(pipe).await {
+            let identities = first.request_identities().await.unwrap_or_default();
+            let n = identities.len();
+
+            for pubkey in identities {
+                let fingerprint = pubkey.fingerprint();
+                let ag = AgentClient::connect_named_pipe(pipe).await.map_err(|e| {
+                    SshError::ConnectionFailed(format!("SSH agent reconnect failed: {e}"))
+                })?;
+                let (_ag, result) = handle
+                    .authenticate_future(config.username.clone(), pubkey, ag)
+                    .await;
+                match result {
+                    Ok(true) => return Ok(()),
+                    Ok(false) => tracing::debug!("server rejected agent key {fingerprint}"),
+                    Err(russh::AgentAuthError::Key(e)) => {
+                        return Err(SshError::AuthenticationFailed(format!(
+                            "SSH agent failed to sign with key {fingerprint}: {e}"
+                        )));
+                    }
+                    Err(russh::AgentAuthError::Send(e)) => {
+                        return Err(SshError::ConnectionFailed(format!(
+                            "SSH connection error during agent auth: {e}"
+                        )));
+                    }
+                }
+            }
+
+            if socket_path.is_some() || n > 0 {
+                return Err(SshError::AuthenticationFailed(format!(
+                    "none of the {n} key(s) offered by the SSH agent was accepted by the server \
+                     (check that the matching public key is in ~/.ssh/authorized_keys on the remote host; \
+                     run `ssh-add -L` to list agent keys)"
+                )));
+            }
+        } else if socket_path.is_some() {
+            return Err(SshError::ConnectionFailed(format!(
+                "cannot connect to SSH agent pipe '{pipe}'"
+            )));
+        }
+
+        // ── Pageant (PuTTY / WinCryptSSHAgent / YubiKey on Windows) ───────
+        let mut first = AgentClient::connect_pageant().await;
+        let identities = first
+            .request_identities()
+            .await
+            .map_err(|e| SshError::AuthenticationFailed(format!("Pageant: {e}")))?;
+
+        if identities.is_empty() {
+            return Err(SshError::AuthenticationFailed(
+                "SSH agent holds no keys — is ssh-agent or Pageant running?".into(),
+            ));
+        }
+
+        let n = identities.len();
+        for pubkey in identities {
+            let fingerprint = pubkey.fingerprint();
+            let ag = AgentClient::connect_pageant().await;
+            let (_ag, result) = handle
+                .authenticate_future(config.username.clone(), pubkey, ag)
+                .await;
+            match result {
+                Ok(true) => return Ok(()),
+                Ok(false) => tracing::debug!("server rejected agent key {fingerprint}"),
+                Err(russh::AgentAuthError::Key(e)) => {
+                    return Err(SshError::AuthenticationFailed(format!(
+                        "SSH agent failed to sign with key {fingerprint}: {e}"
+                    )));
+                }
+                Err(russh::AgentAuthError::Send(e)) => {
+                    return Err(SshError::ConnectionFailed(format!(
+                        "SSH connection error during agent auth: {e}"
+                    )));
+                }
+            }
+        }
+
+        Err(SshError::AuthenticationFailed(format!(
+            "none of the {n} key(s) offered by the SSH agent was accepted by the server \
+             (check that the matching public key is in ~/.ssh/authorized_keys on the remote host; \
+             run `ssh-add -L` to list agent keys)"
+        )))
+    }
+
+    #[cfg(not(any(unix, windows)))]
     async fn auth_with_agent(
         _handle: &mut client::Handle<SshClientHandler>,
         _config: &HostConfig,
         _socket_path: Option<&str>,
     ) -> Result<(), SshError> {
         Err(SshError::ConnectionFailed(
-            "SSH agent authentication requires a Unix socket and is not supported on Windows; \
-             use a private key file instead"
-                .into(),
+            "SSH agent authentication is not supported on this platform".into(),
         ))
     }
 

--- a/src-tauri/src/ssh/manager.rs
+++ b/src-tauri/src/ssh/manager.rs
@@ -383,29 +383,55 @@ impl SshManager {
         use russh_keys::agent::client::AgentClient;
         use tokio::net::UnixStream;
 
-        let sock = socket_path
-            .map(|s| s.to_owned())
-            .or_else(|| std::env::var("SSH_AUTH_SOCK").ok())
-            .ok_or_else(|| {
-                SshError::ConnectionFailed(
-                    "SSH_AUTH_SOCK is not set — is an SSH agent running?".into(),
-                )
-            })?;
+        let candidates: Vec<String> = if let Some(p) = socket_path {
+            vec![p.to_owned()]
+        } else {
+            let mut list = Vec::new();
+            if let Ok(s) = std::env::var("SSH_AUTH_SOCK") {
+                list.push(s);
+            }
 
-        let stream = UnixStream::connect(&sock)
-            .await
-            .map_err(|e| SshError::ConnectionFailed(format!("cannot connect to SSH agent: {e}")))?;
-        let mut agent = AgentClient::connect(stream);
+            #[cfg(target_os = "macos")]
+            if let Ok(home) = std::env::var("HOME") {
+                let gpg = format!("{home}/.gnupg/S.gpg-agent.ssh");
+                if !list.contains(&gpg) {
+                    list.push(gpg);
+                }
+            }
+            list
+        };
 
-        let identities = agent
-            .request_identities()
-            .await
-            .map_err(|e| SshError::AuthenticationFailed(format!("SSH agent: {e}")))?;
+        if candidates.is_empty() {
+            return Err(SshError::ConnectionFailed(
+                "SSH_AUTH_SOCK is not set — is an SSH agent running?".into(),
+            ));
+        }
+
+        let mut sock = String::new();
+        let mut identities = Vec::new();
+        for candidate in &candidates {
+            let Ok(stream) = UnixStream::connect(candidate).await else {
+                tracing::debug!("SSH agent socket not reachable: {candidate}");
+                continue;
+            };
+            let mut agent = AgentClient::connect(stream);
+            match agent.request_identities().await {
+                Ok(ids) if !ids.is_empty() => {
+                    tracing::debug!("using SSH agent at {candidate} ({} key(s))", ids.len());
+                    sock = candidate.clone();
+                    identities = ids;
+                    break;
+                }
+                Ok(_) => tracing::debug!("SSH agent at {candidate} has no keys"),
+                Err(e) => tracing::debug!("SSH agent at {candidate}: {e}"),
+            }
+        }
 
         if identities.is_empty() {
-            return Err(SshError::AuthenticationFailed(
+            let tried = candidates.join(", ");
+            return Err(SshError::AuthenticationFailed(format!(
                 "SSH agent holds no keys — run `ssh-add` or check gpg-agent config".into(),
-            ));
+            )));
         }
 
         let n = identities.len();

--- a/src-tauri/src/ssh/manager.rs
+++ b/src-tauri/src/ssh/manager.rs
@@ -305,11 +305,18 @@ impl SshManager {
         handle: &mut client::Handle<SshClientHandler>,
         config: &HostConfig,
     ) -> Result<(), SshError> {
-        let authenticated = match &config.auth_method {
-            AuthMethod::Password { password } => handle
-                .authenticate_password(&config.username, password)
-                .await
-                .map_err(|e| SshError::AuthenticationFailed(e.to_string()))?,
+        match &config.auth_method {
+            AuthMethod::Password { password } => {
+                let ok = handle
+                    .authenticate_password(&config.username, password)
+                    .await
+                    .map_err(|e| SshError::AuthenticationFailed(e.to_string()))?;
+                if !ok {
+                    return Err(SshError::AuthenticationFailed(
+                        "server rejected credentials".to_string(),
+                    ));
+                }
+            }
             AuthMethod::PrivateKey {
                 key_path,
                 passphrase,
@@ -318,7 +325,6 @@ impl SshManager {
                     .await
                     .map_err(|e| SshError::IoError(e.to_string()))?;
 
-                // Auto-convert PPK to OpenSSH if detected
                 let key_data = if super::keys::is_ppk_format(&key_data) {
                     let kp = key_path.clone();
                     let pp = passphrase.clone();
@@ -331,24 +337,128 @@ impl SshManager {
                     key_data
                 };
 
-                Self::auth_with_key_data(handle, &config.username, &key_data, passphrase.as_deref())
-                    .await?
+                let ok = Self::auth_with_key_data(
+                    handle,
+                    &config.username,
+                    &key_data,
+                    passphrase.as_deref(),
+                )
+                .await?;
+                if !ok {
+                    return Err(SshError::AuthenticationFailed(
+                        "server rejected credentials".to_string(),
+                    ));
+                }
             }
             AuthMethod::PrivateKeyData {
                 key_data,
                 passphrase,
             } => {
-                Self::auth_with_key_data(handle, &config.username, key_data, passphrase.as_deref())
-                    .await?
+                let ok = Self::auth_with_key_data(
+                    handle,
+                    &config.username,
+                    key_data,
+                    passphrase.as_deref(),
+                )
+                .await?;
+                if !ok {
+                    return Err(SshError::AuthenticationFailed(
+                        "server rejected credentials".to_string(),
+                    ));
+                }
             }
-        };
-
-        if !authenticated {
-            return Err(SshError::AuthenticationFailed(
-                "server rejected credentials".to_string(),
-            ));
+            AuthMethod::SshAgent { socket_path } => {
+                Self::auth_with_agent(handle, config, socket_path.as_deref()).await?;
+            }
         }
         Ok(())
+    }
+
+    #[cfg(unix)]
+    async fn auth_with_agent(
+        handle: &mut client::Handle<SshClientHandler>,
+        config: &HostConfig,
+        socket_path: Option<&str>,
+    ) -> Result<(), SshError> {
+        use russh_keys::agent::client::AgentClient;
+        use tokio::net::UnixStream;
+
+        let sock = socket_path
+            .map(|s| s.to_owned())
+            .or_else(|| std::env::var("SSH_AUTH_SOCK").ok())
+            .ok_or_else(|| {
+                SshError::ConnectionFailed(
+                    "SSH_AUTH_SOCK is not set — is an SSH agent running?".into(),
+                )
+            })?;
+
+        let stream = UnixStream::connect(&sock)
+            .await
+            .map_err(|e| SshError::ConnectionFailed(format!("cannot connect to SSH agent: {e}")))?;
+        let mut agent = AgentClient::connect(stream);
+
+        let identities = agent
+            .request_identities()
+            .await
+            .map_err(|e| SshError::AuthenticationFailed(format!("SSH agent: {e}")))?;
+
+        if identities.is_empty() {
+            return Err(SshError::AuthenticationFailed(
+                "SSH agent holds no keys — run `ssh-add` or check gpg-agent config".into(),
+            ));
+        }
+
+        let n = identities.len();
+
+        for pubkey in identities {
+            let fingerprint = pubkey.fingerprint();
+
+            let stream_n = UnixStream::connect(&sock).await.map_err(|e| {
+                SshError::ConnectionFailed(format!("SSH agent reconnect failed: {e}"))
+            })?;
+            let ag: AgentClient<UnixStream> = AgentClient::connect(stream_n);
+
+            let (_ag, result) = handle
+                .authenticate_future(config.username.clone(), pubkey, ag)
+                .await;
+
+            match result {
+                Ok(true) => return Ok(()),
+                Ok(false) => {
+                    tracing::debug!("server rejected agent key {fingerprint}");
+                    continue;
+                }
+                Err(russh::AgentAuthError::Key(e)) => {
+                    return Err(SshError::AuthenticationFailed(format!(
+                        "SSH agent failed to sign with key {fingerprint}: {e}"
+                    )));
+                }
+                Err(russh::AgentAuthError::Send(e)) => {
+                    return Err(SshError::ConnectionFailed(format!(
+                        "SSH connection error during agent auth: {e}"
+                    )));
+                }
+            }
+        }
+
+        Err(SshError::AuthenticationFailed(format!(
+            "none of the {n} key(s) offered by the SSH agent was accepted by the server \
+             (check that the matching public key is in ~/.ssh/authorized_keys on the remote host; \
+             run `ssh-add -L` to list agent keys)"
+        )))
+    }
+
+    #[cfg(not(unix))]
+    async fn auth_with_agent(
+        _handle: &mut client::Handle<SshClientHandler>,
+        _config: &HostConfig,
+        _socket_path: Option<&str>,
+    ) -> Result<(), SshError> {
+        Err(SshError::ConnectionFailed(
+            "SSH agent authentication requires a Unix socket and is not supported on Windows; \
+             use a private key file instead"
+                .into(),
+        ))
     }
 
     async fn auth_with_key_data(

--- a/src-tauri/src/types/session.rs
+++ b/src-tauri/src/types/session.rs
@@ -36,6 +36,12 @@ pub enum AuthMethod {
         key_data: String,
         passphrase: Option<String>,
     },
+    /// Delegate signing to a running SSH agent (ssh-agent / gpg-agent with
+    /// `--enable-ssh-support`). Uses `$SSH_AUTH_SOCK` unless `socket_path` overrides it.
+    #[serde(rename = "sshAgent")]
+    SshAgent {
+        socket_path: Option<String>,
+    },
 }
 
 /// Everything needed to open an SSH connection.

--- a/src/components/dashboard/HostEditModal.tsx
+++ b/src/components/dashboard/HostEditModal.tsx
@@ -12,7 +12,7 @@ import { CustomSelect } from "../shared/CustomSelect";
 
 // ─── Field types ─────────────────────────────────────────────────────────────
 
-type AuthType = "password" | "privateKey";
+type AuthType = "password" | "privateKey" | "sshAgent";
 
 /** Sentinel value: when editingHostId === NEW_HOST_ID, we create a new host
  *  instead of loading an existing one. */
@@ -27,6 +27,7 @@ interface FormState {
   authType: AuthType;
   groupId: string;
   keyPath: string;
+  agentSocketPath: string;
   proxyJump: string;
   proxyJumpHostId: string;
   keepAliveInterval: string;
@@ -52,6 +53,7 @@ const EMPTY_FORM: FormState = {
   authType: "password",
   groupId: "",
   keyPath: "",
+  agentSocketPath: "",
   proxyJump: "",
   proxyJumpHostId: "",
   keepAliveInterval: "",
@@ -77,7 +79,11 @@ function extractError(err: unknown, fallback: string): string {
 
 function savedHostToForm(host: SavedHost): FormState {
   const authType: AuthType =
-    host.auth_type === "privateKey" ? "privateKey" : "password";
+    host.auth_type === "privateKey"
+      ? "privateKey"
+      : host.auth_type === "sshAgent"
+        ? "sshAgent"
+        : "password";
   return {
     label: host.label ?? "",
     host: host.host,
@@ -86,6 +92,7 @@ function savedHostToForm(host: SavedHost): FormState {
     authType,
     groupId: host.group_id ?? "",
     keyPath: host.key_path ?? "",
+    agentSocketPath: "",
     proxyJump: host.proxy_jump ?? "",
     proxyJumpHostId: host.proxy_jump_host_id ?? "",
     keepAliveInterval: host.keep_alive_interval != null ? String(host.keep_alive_interval) : "",
@@ -307,9 +314,10 @@ export function HostEditModal() {
       auth_type: form.authType,
       group_id: form.groupId === "" ? null : form.groupId,
       updated_at: new Date().toISOString(),
-      key_path: form.authType === "privateKey" && form.keyPath.trim()
-        ? form.keyPath.trim()
-        : null,
+      key_path:
+        form.authType === "privateKey" && form.keyPath.trim()
+          ? form.keyPath.trim()
+          : null,
       proxy_jump: form.proxyJump.trim() || null,
       proxy_jump_host_id:
         tunnelEnabled && form.proxyJumpHostId ? form.proxyJumpHostId : null,
@@ -348,7 +356,6 @@ export function HostEditModal() {
       const credential: StoredCredential = { type: "KeyPassphrase", passphrase: form.passphrase };
       await invoke("vault_save_credential", { hostId, credential });
     }
-    // If the field is empty and not cleared, leave the existing keychain entry untouched.
   };
 
   // ── Save ────────────────────────────────────────────────────────────────────
@@ -403,7 +410,9 @@ export function HostEditModal() {
         auth_method:
           form.authType === "privateKey"
             ? { type: "privateKey", key_path: form.keyPath }
-            : { type: "password", password: "" },
+            : form.authType === "sshAgent"
+              ? { type: "sshAgent", socket_path: form.agentSocketPath.trim() || undefined }
+              : { type: "password", password: "" },
       };
       addSession(sessionId, hostConfig);
       const label = hostConfig.label || `${hostConfig.username}@${hostConfig.host}`;
@@ -591,6 +600,7 @@ export function HostEditModal() {
                     options={[
                       { value: "password", label: "Password" },
                       { value: "privateKey", label: "Private Key" },
+                      { value: "sshAgent", label: "SSH Agent" },
                     ]}
                   />
                 </div>
@@ -611,7 +621,7 @@ export function HostEditModal() {
               </div>
 
               {/* Auth credentials — conditional on auth type */}
-              {form.authType === "password" ? (
+              {form.authType === "password" && (
                 <div>
                   <label htmlFor="hem-password" className={labelClass}>
                     Password
@@ -636,7 +646,9 @@ export function HostEditModal() {
                     onClear={() => setCredCleared(true)}
                   />
                 </div>
-              ) : (
+              )}
+
+              {form.authType === "privateKey" && (
                 <>
                   <div>
                     <label htmlFor="hem-keypath" className={labelClass}>
@@ -745,6 +757,16 @@ export function HostEditModal() {
                     />
                   </div>
                 </>
+              )}
+
+              {form.authType === "sshAgent" && (
+                <SshAgentPanel
+                  socketPath={form.agentSocketPath}
+                  onSocketPathChange={(v) => setField("agentSocketPath", v)}
+                  disabled={isBusy}
+                  inputClass={inputClass}
+                  labelClass={labelClass}
+                />
               )}
 
               {/* ════════════════ TUNNEL ════════════════ */}
@@ -1220,6 +1242,75 @@ function DeleteConfirmRow({ onCancel, onConfirm, busy }: DeleteConfirmRowProps) 
       >
         {busy ? "Deleting\u2026" : "Delete"}
       </button>
+    </div>
+  );
+}
+
+// ─── SshAgentPanel ───────────────────────────────────────────────────────────
+
+interface SshAgentPanelProps {
+  socketPath: string;
+  onSocketPathChange: (v: string) => void;
+  disabled: boolean;
+  inputClass: string;
+  labelClass: string;
+}
+
+function SshAgentPanel({
+  socketPath,
+  onSocketPathChange,
+  disabled,
+  inputClass,
+  labelClass,
+}: SshAgentPanelProps) {
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-start gap-2.5 px-3 py-2.5 rounded-lg bg-bg-subtle border border-border">
+        {/* Key icon */}
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 16 16"
+          fill="none"
+          aria-hidden="true"
+          className="text-text-muted shrink-0 mt-0.5"
+        >
+          <circle cx="5.5" cy="10.5" r="3.5" stroke="currentColor" strokeWidth="1.3" />
+          <path
+            d="M8.5 7.5L14 2M14 2H11.5M14 2V4.5"
+            stroke="currentColor"
+            strokeWidth="1.3"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+        <p className="text-[length:var(--text-xs)] text-text-secondary leading-relaxed">
+          Keys are provided by your SSH agent at runtime — nothing is stored in
+          the app.{" "}
+          <span className="text-text-muted">
+            Works with <code className="font-mono">ssh-agent</code> and{" "}
+            <code className="font-mono">gpg-agent --enable-ssh-support</code>{" "}
+            (Yubikey / PIV / OpenPGP cards).
+          </span>
+        </p>
+      </div>
+      <div>
+        <label htmlFor="hem-agent-socket" className={labelClass}>
+          Agent socket path
+          <span className="ml-1 text-text-muted font-normal">
+            (optional — defaults to <code className="font-mono">$SSH_AUTH_SOCK</code>)
+          </span>
+        </label>
+        <input
+          id="hem-agent-socket"
+          type="text"
+          value={socketPath}
+          onChange={(e) => onSocketPathChange(e.target.value)}
+          placeholder="/run/user/1000/gnupg/S.gpg-agent.ssh"
+          disabled={disabled}
+          className={`${inputClass} font-mono`}
+        />
+      </div>
     </div>
   );
 }

--- a/src/types/ssh.ts
+++ b/src/types/ssh.ts
@@ -3,7 +3,8 @@ export type SessionId = string;
 export type AuthMethod =
   | { type: "password"; password: string }
   | { type: "privateKey"; key_path: string; passphrase?: string }
-  | { type: "privateKeyData"; key_data: string; passphrase?: string };
+  | { type: "privateKeyData"; key_data: string; passphrase?: string }
+  | { type: "sshAgent"; socket_path?: string };
 
 export interface HostConfig {
   host: string;
@@ -58,7 +59,7 @@ export interface SavedHost {
   host: string;
   port: number;
   username: string;
-  auth_type: string; // "password" | "privateKey" | "privateKeyData"
+  auth_type: string; // "password" | "privateKey" | "privateKeyData" | "sshAgent"
   group_id: string | null;
   created_at: string;
   updated_at: string;


### PR DESCRIPTION
Adds SSH Agent as a new authentication type alongside password and private key, allowing users to
  delegate signing to a running SSH agent instead of storing any key material in the app.

  What's new

  - New auth type sshAgent — added to AuthMethod enum (Rust) and the AuthMethod union (TypeScript)
  - Unix — connects to the agent via $SSH_AUTH_SOCK (or an optional custom socket path), using
  AgentClient<UnixStream> which implements russh::auth::Signer directly. Iterates all identities
  held by the agent and tries each in turn via authenticate_future.
  - Windows — tries the Windows OpenSSH named pipe (\\.\pipe\openssh-ssh-agent) first, then falls
  back to Pageant (PuTTY / WinCryptSSHAgent / gpg4win). ⚠️ I did not have a Windows machine
  available to test this path — the implementation follows the russh-keys API exactly, but
  real-world validation is still needed.
  - UI — new "SSH Agent" option in the auth type selector with an info panel explaining that no
  credentials are stored, plus an optional socket path override field (defaults to $SSH_AUTH_SOCK)
  - No secrets stored — unlike password/key auth, the sshAgent path skips the OS keychain entirely;
  the agent holds all key material at runtime

  Compatibility

  Works with ssh-agent, gpg-agent --enable-ssh-support, and any agent that exposes SSH keys —
  including hardware tokens (Yubikey, PIV cards, OpenPGP cards) via gpg-agent.

  Error handling

  - If the agent holds no keys: clear message prompting ssh-add / gpg-agent config check
  - If the server rejects all keys: error includes key count and a hint to check authorized_keys
  - If the agent refuses to sign (e.g. PIN required, card removed): surfaces the signing error
  immediately and stops — avoids a session deadlock in russh where the session task waits
  indefinitely for Msg::Signed after a signing failure

  Files changed

  - src-tauri/src/types/session.rs — SshAgent variant in AuthMethod
  - src-tauri/src/ssh/manager.rs — auth_with_agent() (Unix + Windows + fallback stub)
  - src-tauri/src/ssh/commands.rs — label + resolve_auth_method for "sshAgent"
  - src/types/ssh.ts — sshAgent union member
  - src/components/dashboard/HostEditModal.tsx — auth selector + SshAgentPanel component