### PR TITLE
Consolidate scroll buttons

### DIFF
--- a/src/components/layout/UnifiedTabBar.tsx
+++ b/src/components/layout/UnifiedTabBar.tsx
@@ -17,8 +17,16 @@ import {
   ChevronLeft,
   ChevronRight,
 } from "lucide-react";
-import { useTabStore, type UnifiedTab, type PageId } from "../../stores/tab-store";
-import { useSessionStore, countPanes, getTopDirection } from "../../stores/session-store";
+import {
+  useTabStore,
+  type UnifiedTab,
+  type PageId,
+} from "../../stores/tab-store";
+import {
+  useSessionStore,
+  countPanes,
+  getTopDirection,
+} from "../../stores/session-store";
 import { useUiStore } from "../../stores/ui-store";
 
 // ─── Icon mapping ───────────────────────────────────────────────────────────
@@ -112,10 +120,15 @@ export function UnifiedTabBar() {
 
   const scrollTabs = (dir: -1 | 1) => {
     const el = scrollRef.current;
-    if (el) el.scrollBy({ left: dir * el.clientWidth * 0.75, behavior: "smooth" });
+    if (el)
+      el.scrollBy({ left: dir * el.clientWidth * 0.75, behavior: "smooth" });
   };
 
-  const handleClose = async (tabId: string, tab: UnifiedTab, e: React.MouseEvent) => {
+  const handleClose = async (
+    tabId: string,
+    tab: UnifiedTab,
+    e: React.MouseEvent,
+  ) => {
     e.stopPropagation();
     const { invoke } = await import("@tauri-apps/api/core");
 
@@ -125,16 +138,28 @@ export function UnifiedTabBar() {
       if (termTab) {
         const sessionIds = collectLayoutIds(termTab.layout);
         for (const sid of sessionIds) {
-          try { await invoke("ssh_disconnect", { sessionId: sid }); } catch { /* ok */ }
+          try {
+            await invoke("ssh_disconnect", { sessionId: sid });
+          } catch {
+            /* ok */
+          }
           useSessionStore.getState().removeSession(sid);
         }
       }
     } else if (tab.type === "sftp") {
-      try { await invoke("sftp_close", { sftpSessionId: tabId }); } catch { /* ok */ }
+      try {
+        await invoke("sftp_close", { sftpSessionId: tabId });
+      } catch {
+        /* ok */
+      }
       const { useSftpStore } = await import("../../stores/sftp-store");
       useSftpStore.getState().closeSession(tabId);
     } else if (tab.type === "s3") {
-      try { await invoke("s3_disconnect", { s3SessionId: tabId }); } catch { /* ok */ }
+      try {
+        await invoke("s3_disconnect", { s3SessionId: tabId });
+      } catch {
+        /* ok */
+      }
       const { useS3Store } = await import("../../stores/s3-store");
       useS3Store.getState().closeSession(tabId);
     }
@@ -147,15 +172,26 @@ export function UnifiedTabBar() {
   return (
     <div className="flex items-center h-[var(--tabbar-height)] no-select px-2 pt-2">
       {overflow && (
-        <button
-          type="button"
-          onClick={() => scrollTabs(-1)}
-          disabled={!canLeft}
-          aria-label="Scroll tabs left"
-          className={`${CHEVRON_BTN} mr-1`}
-        >
-          <ChevronLeft size={16} strokeWidth={2} aria-hidden="true" />
-        </button>
+        <div className="flex items-center gap-0.5 mr-1 shrink-0">
+          <button
+            type="button"
+            onClick={() => scrollTabs(-1)}
+            disabled={!canLeft}
+            aria-label="Scroll tabs left"
+            className={CHEVRON_BTN}
+          >
+            <ChevronLeft size={16} strokeWidth={2} aria-hidden="true" />
+          </button>
+          <button
+            type="button"
+            onClick={() => scrollTabs(1)}
+            disabled={!canRight}
+            aria-label="Scroll tabs right"
+            className={CHEVRON_BTN}
+          >
+            <ChevronRight size={16} strokeWidth={2} aria-hidden="true" />
+          </button>
+        </div>
       )}
       <div
         ref={scrollRef}
@@ -184,13 +220,18 @@ export function UnifiedTabBar() {
             }
             // Status from first session in layout
             const firstSessionId = getFirstSessionIdFromTab(tabId);
-            const firstSession = firstSessionId ? sessions.get(firstSessionId) : null;
+            const firstSession = firstSessionId
+              ? sessions.get(firstSessionId)
+              : null;
             const status = firstSession?.status ?? "Disconnected";
             statusDot =
-              status === "Connected"    ? "bg-status-connected" :
-              status === "Connecting"   ? "bg-status-connecting motion-safe:animate-pulse" :
-              status === "Error"        ? "bg-status-error" :
-                                          "bg-status-disconnected";
+              status === "Connected"
+                ? "bg-status-connected"
+                : status === "Connecting"
+                  ? "bg-status-connecting motion-safe:animate-pulse"
+                  : status === "Error"
+                    ? "bg-status-error"
+                    : "bg-status-disconnected";
             isZoomed = isActive && zoomedPaneId !== null;
           }
 
@@ -207,8 +248,18 @@ export function UnifiedTabBar() {
               data-tab-label={tab.label}
               onClick={() => setActiveTab(tabId)}
               // Middle-click closes the tab, like a browser.
-              onAuxClick={(e) => { if (e.button === 1 && closeable) { e.preventDefault(); void handleClose(tabId, tab, e); } }}
-              onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); setActiveTab(tabId); } }}
+              onAuxClick={(e) => {
+                if (e.button === 1 && closeable) {
+                  e.preventDefault();
+                  void handleClose(tabId, tab, e);
+                }
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  setActiveTab(tabId);
+                }
+              }}
               title={tab.label + (paneCount > 1 ? ` (${paneCount} panes)` : "")}
               className={[
                 "group relative flex items-center gap-2 px-3.5 h-[32px] shrink-0 max-w-[220px]",
@@ -226,8 +277,12 @@ export function UnifiedTabBar() {
                 strokeWidth={1.8}
                 className={[
                   "shrink-0",
-                  tab.type === "terminal" && statusDot ? statusDot.replace("bg-", "text-") : "",
-                  tab.type === "sftp" || tab.type === "s3" ? "text-status-connected" : "",
+                  tab.type === "terminal" && statusDot
+                    ? statusDot.replace("bg-", "text-")
+                    : "",
+                  tab.type === "sftp" || tab.type === "s3"
+                    ? "text-status-connected"
+                    : "",
                   tab.type === "page" && isActive ? "text-accent" : "",
                   tab.type === "page" && !isActive ? "text-text-muted" : "",
                 ].join(" ")}
@@ -261,7 +316,11 @@ export function UnifiedTabBar() {
 
               {/* Zoom indicator */}
               {isZoomed && (
-                <span className="shrink-0 text-accent" aria-hidden="true" title="Zoomed pane">
+                <span
+                  className="shrink-0 text-accent"
+                  aria-hidden="true"
+                  title="Zoomed pane"
+                >
                   <Maximize2 size={11} strokeWidth={2} />
                 </span>
               )}
@@ -289,20 +348,7 @@ export function UnifiedTabBar() {
             </div>
           );
         })}
-
       </div>
-
-      {overflow && (
-        <button
-          type="button"
-          onClick={() => scrollTabs(1)}
-          disabled={!canRight}
-          aria-label="Scroll tabs right"
-          className={`${CHEVRON_BTN} ml-1`}
-        >
-          <ChevronRight size={16} strokeWidth={2} aria-hidden="true" />
-        </button>
-      )}
 
       {/* Right actions — only show snippet button when a terminal tab is active.
           A labelled button (with the ⌘K hint) reads as a control instead of a
@@ -337,7 +383,10 @@ export function UnifiedTabBar() {
 
 function collectLayoutIds(node: import("../../types").LayoutNode): string[] {
   if (node.type === "pane") return [node.sessionId];
-  return [...collectLayoutIds(node.children[0]), ...collectLayoutIds(node.children[1])];
+  return [
+    ...collectLayoutIds(node.children[0]),
+    ...collectLayoutIds(node.children[1]),
+  ];
 }
 
 function getFirstSessionIdFromTab(tabId: string): string | null {


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR consolidates the two tab-scroll chevron buttons — previously one on each side of the tab strip — into a single grouped container placed on the left of the tab bar. It also reformats several multi-line expressions and function signatures for readability.

- Both `ChevronLeft` and `ChevronRight` buttons are now rendered together in a `flex` wrapper on the left side of the tab bar, with the right-scroll button no longer occupying its own slot at the far right of the strip.
- Code style improvements include expanding inline ternaries and one-liner try/catch blocks into multi-line form, and reformatting long import statements.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — changes are limited to button layout and code formatting with no logic mutations.

The functional logic for scrolling, overflow detection, and tab management is untouched. The only behavioral change is moving the right-scroll chevron from the far right of the tab strip to a consolidated group on the left. This removes the right-side visual affordance that signalled more tabs exist in that direction — a UX trade-off worth team discussion before merging. A stale comment also remains that describes the old two-slot layout.

**Files Needing Attention:** src/components/layout/UnifiedTabBar.tsx — specifically the consolidated button group and the now-inaccurate comment block around line 79.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/components/layout/UnifiedTabBar.tsx | Both scroll-chevron buttons consolidated into a left-side group; remaining changes are code-style reformatting. One stale comment and a UX affordance question worth addressing. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[UnifiedTabBar renders] --> B{overflow?}
    B -- No --> C[Tab strip fills full width\nNo scroll buttons shown]
    B -- Yes --> D["Render consolidated button group on LEFT side\nChevronLeft + ChevronRight"]
    D --> E{canLeft?}
    D --> F{canRight?}
    E -- No --> G[Left button disabled]
    E -- Yes --> H[Left button enabled]
    F -- No --> I[Right button disabled]
    F -- Yes --> J[Right button enabled]
    D --> K[Tab strip fills remaining right-side width]
    H --> L["scrollTabs scroll left"]
    J --> M["scrollTabs scroll right"]
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/components/layout/UnifiedTabBar.tsx`, line 79-82 ([link](https://github.com/macnev2013/anyscp/blob/77883148f0c716cd75b2532ebd4ddc23a46a97d9/src/components/layout/UnifiedTabBar.tsx#L79-L82)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Stale comment after consolidation**

   The comment still says *"Both slots render whenever there's overflow"*, but the new layout has a single consolidated group rather than two separate slots. The comment should be updated to describe the new structure, e.g. noting that both buttons are grouped together on the left and individually disabled when their respective edge is reached.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/components/layout/UnifiedTabBar.tsx
   Line: 79-82

   Comment:
   **Stale comment after consolidation**

   The comment still says *"Both slots render whenever there's overflow"*, but the new layout has a single consolidated group rather than two separate slots. The comment should be updated to describe the new structure, e.g. noting that both buttons are grouped together on the left and individually disabled when their respective edge is reached.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fcomponents%2Flayout%2FUnifiedTabBar.tsx%0ALine%3A%2079-82%0A%0AComment%3A%0A**Stale%20comment%20after%20consolidation**%0A%0AThe%20comment%20still%20says%20*%22Both%20slots%20render%20whenever%20there's%20overflow%22*%2C%20but%20the%20new%20layout%20has%20a%20single%20consolidated%20group%20rather%20than%20two%20separate%20slots.%20The%20comment%20should%20be%20updated%20to%20describe%20the%20new%20structure%2C%20e.g.%20noting%20that%20both%20buttons%20are%20grouped%20together%20on%20the%20left%20and%20individually%20disabled%20when%20their%20respective%20edge%20is%20reached.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=macnev2013%2Fanyscp&pr=112&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asrc%2Fcomponents%2Flayout%2FUnifiedTabBar.tsx%3A79-82%0A**Stale%20comment%20after%20consolidation**%0A%0AThe%20comment%20still%20says%20*%22Both%20slots%20render%20whenever%20there's%20overflow%22*%2C%20but%20the%20new%20layout%20has%20a%20single%20consolidated%20group%20rather%20than%20two%20separate%20slots.%20The%20comment%20should%20be%20updated%20to%20describe%20the%20new%20structure%2C%20e.g.%20noting%20that%20both%20buttons%20are%20grouped%20together%20on%20the%20left%20and%20individually%20disabled%20when%20their%20respective%20edge%20is%20reached.%0A%0A%23%23%23%20Issue%202%20of%202%0Asrc%2Fcomponents%2Flayout%2FUnifiedTabBar.tsx%3A174-195%0A**Right-scroll%20affordance%20removed%20from%20right%20side**%0A%0APlacing%20both%20chevrons%20on%20the%20left%20removes%20the%20visual%20cue%20on%20the%20right%20side%20of%20the%20tab%20strip%20that%20additional%20tabs%20exist%20in%20that%20direction.%20With%20the%20previous%20layout%2C%20a%20visible%20%28or%20disabled%29%20right-arrow%20at%20the%20far%20right%20was%20the%20natural%20signal%20that%20there%20was%20more%20content.%20Users%20who%20scroll%20to%20the%20far%20right%20may%20not%20realise%20there's%20a%20%60ChevronRight%60%20button%20available%2C%20since%20it%20is%20now%20hidden%20behind%20the%20visible%20tabs%20on%20the%20left.%20Consider%20whether%20the%20consolidated%20placement%20still%20communicates%20intent%20sufficiently%20%E2%80%94%20adding%20a%20right-side%20fade%2Fgradient%20mask%20is%20one%20common%20alternative%20used%20by%20browser%20UIs.%0A%0A&repo=macnev2013%2Fanyscp&pr=112&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/components/layout/UnifiedTabBar.tsx:79-82
**Stale comment after consolidation**

The comment still says *"Both slots render whenever there's overflow"*, but the new layout has a single consolidated group rather than two separate slots. The comment should be updated to describe the new structure, e.g. noting that both buttons are grouped together on the left and individually disabled when their respective edge is reached.

### Issue 2 of 2
src/components/layout/UnifiedTabBar.tsx:174-195
**Right-scroll affordance removed from right side**

Placing both chevrons on the left removes the visual cue on the right side of the tab strip that additional tabs exist in that direction. With the previous layout, a visible (or disabled) right-arrow at the far right was the natural signal that there was more content. Users who scroll to the far right may not realise there's a `ChevronRight` button available, since it is now hidden behind the visible tabs on the left. Consider whether the consolidated placement still communicates intent sufficiently — adding a right-side fade/gradient mask is one common alternative used by browser UIs.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Consolidate scroll buttons"](https://github.com/macnev2013/anyscp/commit/77883148f0c716cd75b2532ebd4ddc23a46a97d9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47214303)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->