### PR TITLE
Auto relaunch in startup update

### DIFF
--- a/src/stores/updater-store.ts
+++ b/src/stores/updater-store.ts
@@ -5,9 +5,9 @@ import type { Update } from "@tauri-apps/plugin-updater";
 export type UpdaterStatus =
   | "idle"
   | "checking"
-  | "available"   // found, awaiting user decision (auto-update off)
+  | "available" // found, awaiting user decision (auto-update off)
   | "downloading"
-  | "ready"       // downloaded + installed, pending restart
+  | "ready" // downloaded + installed, pending restart
   | "up-to-date"
   | "error";
 
@@ -87,7 +87,9 @@ export const useUpdaterStore = create<UpdaterState>((set, get) => ({
     try {
       const { getVersion } = await import("@tauri-apps/api/app");
       set({ appVersion: await getVersion() });
-    } catch { /* best-effort */ }
+    } catch {
+      /* best-effort */
+    }
   },
 
   // Runs once on launch. With auto-update on, silently downloads + installs the
@@ -99,7 +101,10 @@ export const useUpdaterStore = create<UpdaterState>((set, get) => ({
     try {
       const { check } = await import("@tauri-apps/plugin-updater");
       const update = await check();
-      if (!update) { set({ status: "up-to-date" }); return; }
+      if (!update) {
+        set({ status: "up-to-date" });
+        return;
+      }
 
       set({ version: update.version });
       const { autoUpdate, skippedUpdateVersion } = useSettingsStore.getState();
@@ -108,13 +113,21 @@ export const useUpdaterStore = create<UpdaterState>((set, get) => ({
         // downloadInstall self-guards: on a debug/dev binary it just surfaces
         // that an update exists instead of overwriting the running executable.
         await downloadInstall(update, set);
+        // Relaunch straight into the new binary
+        if (get().status === "ready") {
+          const { relaunch } = await import("@tauri-apps/plugin-process");
+          await relaunch();
+        }
       } else if (skippedUpdateVersion === update.version) {
         set({ status: "idle" });
       } else {
         set({ status: "available", dialogOpen: true });
       }
     } catch (err) {
-      set({ status: "error", error: message(err, "Failed to check for updates") });
+      set({
+        status: "error",
+        error: message(err, "Failed to check for updates"),
+      });
     }
   },
 
@@ -126,7 +139,10 @@ export const useUpdaterStore = create<UpdaterState>((set, get) => ({
     try {
       const { check } = await import("@tauri-apps/plugin-updater");
       const update = await check();
-      if (!update) { set({ status: "up-to-date" }); return; }
+      if (!update) {
+        set({ status: "up-to-date" });
+        return;
+      }
 
       set({ version: update.version });
       if (useSettingsStore.getState().autoUpdate) {
@@ -135,7 +151,10 @@ export const useUpdaterStore = create<UpdaterState>((set, get) => ({
         set({ status: "available", dialogOpen: true });
       }
     } catch (err) {
-      set({ status: "error", error: message(err, "Failed to check for updates") });
+      set({
+        status: "error",
+        error: message(err, "Failed to check for updates"),
+      });
     }
   },
 
@@ -145,7 +164,10 @@ export const useUpdaterStore = create<UpdaterState>((set, get) => ({
     try {
       const { check } = await import("@tauri-apps/plugin-updater");
       const update = await check();
-      if (!update) { set({ status: "up-to-date" }); return; }
+      if (!update) {
+        set({ status: "up-to-date" });
+        return;
+      }
       await downloadInstall(update, set);
       // downloadInstall no-ops on a non-release build (status stays
       // "available"); only relaunch once an update is actually installed.
@@ -162,7 +184,13 @@ export const useUpdaterStore = create<UpdaterState>((set, get) => ({
       const { relaunch } = await import("@tauri-apps/plugin-process");
       await relaunch();
     } catch (err) {
-      set({ status: "error", error: message(err, "Couldn't restart automatically — please reopen the app") });
+      set({
+        status: "error",
+        error: message(
+          err,
+          "Couldn't restart automatically — please reopen the app",
+        ),
+      });
     }
   },
 


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds automatic relaunch behavior to the startup update check: when `autoUpdate` is enabled and an update is found on launch, the app now downloads, installs, and immediately relaunches into the new binary rather than deferring to the next manual launch. The accompanying comment on `checkOnStartup` is updated to reflect this.

- The relaunch is correctly gated behind `get().status === "ready"`, so non-release builds (where `downloadInstall` short-circuits to `status: "available"`) and failed downloads are safe.
- The relaunch error is handled in its own `try/catch` with a user-friendly message distinct from the outer "Failed to check for updates" catch, addressing a concern from a previous review.
- Formatting-only changes (brace style, line wrapping) make up the rest of the diff.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is narrowly scoped to the startup path and the relaunch is properly guarded and error-handled.

The relaunch is gated on get().status === 'ready', which prevents premature restarts on non-release builds or failed downloads. The relaunch error path produces a user-facing message distinct from the outer download/check error. No existing behavior outside checkOnStartup is affected.

**Files Needing Attention:** No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/stores/updater-store.ts | Adds auto-relaunch after silent startup install; relaunch is correctly gated on `status === 'ready'` and wrapped in its own try/catch with an accurate error message. The rest of the diff is cosmetic reformatting. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(updater): report relaunch failures a..."](https://github.com/macnev2013/anyscp/commit/b59a791a57b201e6ca94abbe67ce58d32474af78) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47214302)</sub>

<!-- /greptile_comment -->