### PR TITLE
Defer directory stat walk to background task

### DIFF
--- a/src-tauri/src/s3/transfer_manager.rs
+++ b/src-tauri/src/s3/transfer_manager.rs
@@ -38,9 +38,6 @@ pub enum TransferJobKind {
         /// S3 object key.
         key: String,
         local_path: PathBuf,
-        /// Cached object size at enqueue time.
-        #[allow(dead_code)]
-        size: u64,
     },
 }
 
@@ -346,11 +343,7 @@ impl S3TransferManager {
             s3_session_id: s3_session_id.to_string(),
             name,
             direction: S3TransferDirection::Download,
-            kind: TransferJobKind::DownloadFile {
-                key,
-                local_path,
-                size,
-            },
+            kind: TransferJobKind::DownloadFile { key, local_path },
             status: S3TransferStatus::Queued,
             bytes_transferred: 0,
             total_bytes: size,

--- a/src-tauri/src/sftp/transfer_manager.rs
+++ b/src-tauri/src/sftp/transfer_manager.rs
@@ -323,31 +323,32 @@ impl TransferManager {
                     .map_err(|e| SftpError::RemoteIoError(e.to_string()))?
             };
 
-            let (kind, total_bytes, files_total) =
-                if attrs.file_type() == russh_sftp::protocol::FileType::Dir {
-                    let local_dest = local_dir.join(&name);
-                    let (bytes, count) = walk_remote_dir_stats(&sftp_arc, &remote_path).await;
-                    (
-                        TransferJobKind::DownloadDir {
-                            remote_path: remote_path.clone(),
-                            local_dir: local_dest,
-                        },
-                        bytes,
-                        count,
-                    )
-                } else {
-                    let local_dest = local_dir.join(&name);
-                    let size = attrs.size.unwrap_or(0);
-                    (
-                        TransferJobKind::DownloadFile {
-                            remote_path: remote_path.clone(),
-                            local_path: local_dest,
-                            size,
-                        },
+            let is_dir = attrs.file_type() == russh_sftp::protocol::FileType::Dir;
+            let (kind, total_bytes, files_total) = if is_dir {
+                let local_dest = local_dir.join(&name);
+                // Total are unknown until the background stat walk
+                // start at 0 so the job appears in the UI immediately
+                (
+                    TransferJobKind::DownloadDir {
+                        remote_path: remote_path.clone(),
+                        local_dir: local_dest,
+                    },
+                    0u64,
+                    0u32,
+                )
+            } else {
+                let local_dest = local_dir.join(&name);
+                let size = attrs.size.unwrap_or(0);
+                (
+                    TransferJobKind::DownloadFile {
+                        remote_path: remote_path.clone(),
+                        local_path: local_dest,
                         size,
-                        1u32,
-                    )
-                };
+                    },
+                    size,
+                    1u32,
+                )
+            };
 
             let job = TransferJobState {
                 transfer_id: transfer_id.clone(),
@@ -374,6 +375,25 @@ impl TransferManager {
             self.queue_tx
                 .send(transfer_id.clone())
                 .map_err(|e| SftpError::ChannelError(e.to_string()))?;
+
+            if is_dir {
+                let jobs = self.jobs.clone();
+                let app_handle = self.app_handle.clone();
+                let sftp_arc = sftp_arc.clone();
+                let stat_remote_path = remote_path.clone();
+                let stat_transfer_id = transfer_id.clone();
+                tokio::spawn(async move {
+                    let (byte, count) = walk_remote_dir_stats(&sftp_arc, &stat_remote_path).await;
+                    if let Some(mut job) = jobs.get_mut(&stat_transfer_id) {
+                        // never report a total below what's already transferred
+                        job.total_bytes = byte.max(job.bytes_transferred);
+                        job.files_total = count.max(job.files_done);
+                        let event = job.to_event();
+                        drop(job);
+                        app_handle.emit("sftp:transfer", event).ok();
+                    }
+                });
+            }
 
             ids.push(transfer_id);
         }
@@ -510,7 +530,11 @@ async fn walk_remote_dir_inner(
         let sftp = sftp_arc.lock().await;
         match sftp.read_dir(path).await {
             Ok(e) => e,
-            Err(_) => return (0, 0),
+            Err(e) => {
+                // Treated as empty so the walk can proceed (don't stay silent)
+                tracing::warn!(path, error = %e, "read_dir failed during stat walk; subtree size will be undercounted");
+                return (0, 0);
+            }
         }
     };
 

--- a/src-tauri/src/sftp/transfer_manager.rs
+++ b/src-tauri/src/sftp/transfer_manager.rs
@@ -39,9 +39,6 @@ pub enum TransferJobKind {
     DownloadFile {
         remote_path: String,
         local_path: PathBuf,
-        /// Cached file size captured at enqueue time; used to populate `total_bytes`.
-        #[allow(dead_code)]
-        size: u64,
     },
     DownloadDir {
         remote_path: String,
@@ -343,7 +340,6 @@ impl TransferManager {
                     TransferJobKind::DownloadFile {
                         remote_path: remote_path.clone(),
                         local_path: local_dest,
-                        size,
                     },
                     size,
                     1u32,
@@ -1513,7 +1509,6 @@ mod tests {
             kind: TransferJobKind::DownloadFile {
                 remote_path: "/remote/file.txt".to_string(),
                 local_path: PathBuf::from("/tmp/file.txt"),
-                size: 1000,
             },
             status: TransferStatus::Completed,
             bytes_transferred: 1000,


### PR DESCRIPTION
Improve UI responsiveness by enqueuing directory download jobs immediately with 0 totals instead of blocking to calculate them first. A background task now walks the remote directory and updates the job totals once complete. Also add warning logging in walk_remote_dir_inner for read_dir errors instead of silently returning.

Fixes #111