### PR TITLE
Add keyboard shortcuts

### DIFF
--- a/src/components/explorer/ExplorerFileTable.tsx
+++ b/src/components/explorer/ExplorerFileTable.tsx
@@ -970,7 +970,13 @@ export function ExplorerFileTable({
   // reserves a constant width and position — sorting never shifts the header. It
   // sits on the side away from the label's alignment edge; a centered label gets
   // a `col={null}` reserving-only copy on the far side to stay centered.
-  const SortArrow = ({ col, gap }: { col: "name" | "size" | "modified" | null; gap: "ml-0.5" | "mr-0.5" }) => {
+  const SortArrow = ({
+    col,
+    gap,
+  }: {
+    col: "name" | "size" | "modified" | null;
+    gap: "ml-0.5" | "mr-0.5";
+  }) => {
     const active = col !== null && sortBy === col;
     const Icon = active && !sortAsc ? ChevronDown : ChevronUp;
     return (
@@ -983,14 +989,15 @@ export function ExplorerFileTable({
     );
   };
 
-  const thClass = (col: "name" | "size" | "modified") => [
-    // No text-align here — each header sets its own (buttons default to center).
-    // A hardcoded one would beat the columns' text-center in the CSS cascade.
-    "text-[length:var(--text-xs)] font-semibold uppercase tracking-wide text-text-muted",
-    "cursor-pointer select-none hover:text-text-secondary transition-colors duration-[var(--duration-fast)]",
-    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-sm",
-    sortBy === col ? "text-text-secondary" : "",
-  ].join(" ");
+  const thClass = (col: "name" | "size" | "modified") =>
+    [
+      // No text-align here — each header sets its own (buttons default to center).
+      // A hardcoded one would beat the columns' text-center in the CSS cascade.
+      "text-[length:var(--text-xs)] font-semibold uppercase tracking-wide text-text-muted",
+      "cursor-pointer select-none hover:text-text-secondary transition-colors duration-[var(--duration-fast)]",
+      "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-sm",
+      sortBy === col ? "text-text-secondary" : "",
+    ].join(" ");
 
   // ─── Loading state ───────────────────────────────────────────────────────
   // Only show the skeleton on a genuine first load (no entries yet). When
@@ -1038,7 +1045,9 @@ export function ExplorerFileTable({
           data-testid="explorer-sort-name"
           className={`flex-1 text-left ${thClass("name")}`}
           onClick={() => handleSortClick("name")}
-          aria-sort={sortBy === "name" ? (sortAsc ? "ascending" : "descending") : "none"}
+          aria-sort={
+            sortBy === "name" ? (sortAsc ? "ascending" : "descending") : "none"
+          }
         >
           Name <SortArrow col="name" gap="ml-0.5" />
         </button>
@@ -1047,7 +1056,9 @@ export function ExplorerFileTable({
           data-testid="explorer-sort-size"
           className={`w-20 text-right ${thClass("size")}`}
           onClick={() => handleSortClick("size")}
-          aria-sort={sortBy === "size" ? (sortAsc ? "ascending" : "descending") : "none"}
+          aria-sort={
+            sortBy === "size" ? (sortAsc ? "ascending" : "descending") : "none"
+          }
         >
           <SortArrow col="size" gap="mr-0.5" /> Size
         </button>
@@ -1056,14 +1067,25 @@ export function ExplorerFileTable({
           data-testid="explorer-sort-modified"
           className={`w-44 text-center ${thClass("modified")}`}
           onClick={() => handleSortClick("modified")}
-          aria-sort={sortBy === "modified" ? (sortAsc ? "ascending" : "descending") : "none"}
+          aria-sort={
+            sortBy === "modified"
+              ? sortAsc
+                ? "ascending"
+                : "descending"
+              : "none"
+          }
         >
-          <SortArrow col="modified" gap="mr-0.5" /> Modified <SortArrow col={null} gap="ml-0.5" />
+          <SortArrow col="modified" gap="mr-0.5" /> Modified{" "}
+          <SortArrow col={null} gap="ml-0.5" />
         </button>
 
         {/* Last column: Permissions for SFTP, Class for S3 */}
         <span className="w-24 text-[length:var(--text-xs)] font-semibold uppercase tracking-wide text-text-muted select-none">
-          {caps.hasPermissions ? "Permissions" : caps.hasStorageClass ? "Class" : ""}
+          {caps.hasPermissions
+            ? "Permissions"
+            : caps.hasStorageClass
+              ? "Class"
+              : ""}
         </span>
       </div>
 
@@ -1171,6 +1193,44 @@ export function ExplorerFileTable({
                   onKeyDown={(e) => {
                     const isInput = (e.target as Element).tagName === "INPUT";
                     if (e.key === "Enter" && !isInput) handleDoubleClick(entry);
+                    if (
+                      (e.key === "ArrowDown" || e.key === "ArrowUp") &&
+                      !isInput
+                    ) {
+                      e.preventDefault();
+                      const ids = sortedEntries.map((en) => en.id);
+                      const currentIdx = ids.indexOf(entry.id);
+                      const direction = e.key === "ArrowDown" ? 1 : -1;
+                      const nextIdx = Math.min(
+                        Math.max(currentIdx + direction, 0),
+                        ids.length - 1,
+                      );
+                      if (nextIdx === currentIdx) return;
+                      const nextId = ids[nextIdx];
+
+                      if (e.shiftKey) {
+                        const anchorId = lastClickedId.current ?? entry.id;
+                        lastClickedId.current = anchorId;
+                        const anchorIdx = ids.indexOf(anchorId);
+                        const from = Math.min(anchorIdx, nextIdx);
+                        const to = Math.max(anchorIdx, nextIdx);
+                        const range = new Set<string>();
+                        for (let i = from; i <= to; i++) range.add(ids[i]);
+                        setSelectedIds(range);
+                      } else {
+                        setSelectedIds(new Set([nextId]));
+                        lastClickedId.current = nextId;
+                      }
+
+                      const currentRow = e.currentTarget as HTMLElement;
+                      const nextRow = (
+                        direction === 1
+                          ? currentRow.nextElementSibling
+                          : currentRow.previousElementSibling
+                      ) as HTMLElement | null;
+                      nextRow?.focus();
+                      nextRow?.scrollIntoView({ block: "nearest" });
+                    }
                     if (e.key === "F2" && caps.canRename && !isInput) {
                       e.preventDefault();
                       setRenamingId(entry.id);
@@ -1264,7 +1324,9 @@ export function ExplorerFileTable({
 
                   {/* Size */}
                   <span className="w-20 text-right text-[length:var(--text-xs)] text-text-muted shrink-0 font-mono tabular-nums whitespace-nowrap">
-                    {entry.entryType === "Directory" ? "—" : formatBytes(entry.size)}
+                    {entry.entryType === "Directory"
+                      ? "—"
+                      : formatBytes(entry.size)}
                   </span>
 
                   {/* Modified — centered so it doesn't crowd the right-aligned
@@ -1280,7 +1342,11 @@ export function ExplorerFileTable({
 
                   {/* Permissions / Storage Class */}
                   <span
-                    data-entry-perms={caps.hasPermissions ? entry.permissionsDisplay ?? "" : undefined}
+                    data-entry-perms={
+                      caps.hasPermissions
+                        ? (entry.permissionsDisplay ?? "")
+                        : undefined
+                    }
                     className="w-24 font-mono text-[length:var(--text-xs)] text-text-muted shrink-0 tracking-tight whitespace-nowrap"
                   >
                     {caps.hasPermissions

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -52,6 +52,7 @@ export function AppShell() {
   useTerminalAutoFocus();
 
   const openNewHost = () => setEditingHostId(NEW_HOST_ID);
+  const preZoomFontSizeRef = useRef<number | null>(null);
 
   const shortcuts = useMemo<ShortcutDef[]>(
     () => [
@@ -268,6 +269,55 @@ export function AppShell() {
           useUiStore.getState().toggleSnippetPanel();
         },
       },
+      // Terminal font zoom
+      {
+        key: "=",
+        meta: true,
+        action: () => {
+          const { terminalFontSize, setTerminalFontSize } =
+            useSettingsStore.getState();
+          if (preZoomFontSizeRef.current === null) {
+            preZoomFontSizeRef.current = terminalFontSize;
+          }
+          setTerminalFontSize(terminalFontSize + 1);
+        },
+        when: () =>
+          useTabStore
+            .getState()
+            .tabs.get(useTabStore.getState().activeTabId ?? "")?.type ===
+          "terminal",
+      },
+      {
+        key: "-",
+        meta: true,
+        action: () => {
+          const { terminalFontSize, setTerminalFontSize } =
+            useSettingsStore.getState();
+          if (preZoomFontSizeRef.current === null) {
+            preZoomFontSizeRef.current = terminalFontSize;
+          }
+          setTerminalFontSize(terminalFontSize - 1);
+        },
+        when: () =>
+          useTabStore
+            .getState()
+            .tabs.get(useTabStore.getState().activeTabId ?? "")?.type ===
+          "terminal",
+      },
+      {
+        key: "0",
+        meta: true,
+        action: () => {
+          const target = preZoomFontSizeRef.current ?? 14; // TODO: export DEFAULT
+          useSettingsStore.getState().setTerminalFontSize(target);
+          preZoomFontSizeRef.current = null;
+        },
+        when: () =>
+          useTabStore
+            .getState()
+            .tabs.get(useTabStore.getState().activeTabId ?? "")?.type ===
+          "terminal",
+      },
     ],
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [toggleSidebar, setEditingHostId],
@@ -310,7 +360,10 @@ export function AppShell() {
   }, [interfaceFont]);
 
   useLayoutEffect(() => {
-    document.documentElement.style.setProperty("--font-mono", interfaceMonoFont);
+    document.documentElement.style.setProperty(
+      "--font-mono",
+      interfaceMonoFont,
+    );
     document.documentElement.dataset.interfaceMonoFont = interfaceMonoFont;
   }, [interfaceMonoFont]);
 


### PR DESCRIPTION
Enable keyboard row navigation and shift-range selection in the file explorer, plus terminal font zoom shortcuts.

- ExplorerFileTable: handle ArrowUp/ArrowDown to move focus between rows, support Shift+Arrow for range selection, scroll focused row into view, and update selection state. Also tidy aria-sort/JSX formatting and minor data-entry-perms/size rendering adjustments.
- AppShell: introduce preZoomFontSizeRef and add Meta+=, Meta+-, Meta+0 shortcuts to increase, decrease, and reset terminal font size (active only on terminal tabs).

Close #104

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds two keyboard-shortcut features: row-level Arrow navigation and Shift+Arrow range selection in the file explorer, and `Meta+=` / `Meta+-` / `Meta+0` terminal font zoom shortcuts in the app shell. It also memoises `sortedEntries` and the derived `sortedIds` array to avoid rebuilding them on every keypress.

- **ExplorerFileTable**: Arrow key navigation walks the sorted row list with DOM-sibling focus/scroll; `Shift+Arrow` builds a range selection anchored at `lastClickedId`; `sortedEntries` and `sortedIds` are wrapped in `useMemo`; additional changes are formatting-only.
- **AppShell**: A `preZoomFontSizeRef` stores the font size before the first zoom step so `Meta+0` can restore it; the ref is initialised to `null` and Meta+0 exits early when no zoom session is active, addressing a previous issue where it would hard-code 14 as the reset value.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; both feature areas are well-scoped and the previously reported regressions are resolved.

The keyboard navigation in the file explorer is straightforward DOM-sibling walking with a correctly memoised ID list. The font-zoom logic guards the pre-zoom ref properly and exits early on Meta+0 when nothing is zoomed. The two remaining observations (Cmd++ not covered, stale baseline on mid-session Settings change) are edge-case UX gaps rather than data-loss or crash conditions.

**Files Needing Attention:** AppShell.tsx — the zoom-baseline ref is the only place that could produce a surprising font-size reset.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/components/layout/AppShell.tsx | Introduces terminal font zoom shortcuts (Meta+=/−/0) with a stable preZoomFontSizeRef; previous Meta+0 regression addressed. Minor: external Settings changes during an active zoom session will cause Meta+0 to restore a stale pre-zoom baseline rather than the user's updated configured value. |
| src/components/explorer/ExplorerFileTable.tsx | Adds ArrowUp/Down keyboard navigation and Shift+Arrow range selection for file rows, with DOM-sibling focus traversal and scrollIntoView. sortedEntries and sortedIds are properly memoised. Formatting-only changes to JSX and sort helpers are clean. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant KeyboardHandler as useKeyboardShortcuts
    participant AppShell
    participant SettingsStore

    Note over User,SettingsStore: Terminal Font Zoom (AppShell)
    User->>KeyboardHandler: "Meta+="
    KeyboardHandler->>AppShell: action()
    AppShell->>SettingsStore: getState().terminalFontSize
    AppShell->>AppShell: "preZoomFontSizeRef.current = fontSize (if null)"
    AppShell->>SettingsStore: setTerminalFontSize(fontSize + 1)

    User->>KeyboardHandler: Meta+0
    KeyboardHandler->>AppShell: action()
    AppShell->>AppShell: "if preZoomFontSizeRef.current === null return"
    AppShell->>SettingsStore: setTerminalFontSize(preZoomFontSizeRef.current)
    AppShell->>AppShell: "preZoomFontSizeRef.current = null"

    Note over User,SettingsStore: Explorer Arrow Navigation (ExplorerFileTable)
    User->>KeyboardHandler: ArrowDown / ArrowUp (on row)
    KeyboardHandler->>KeyboardHandler: lookup nextIdx in sortedIds
    alt no Shift
        KeyboardHandler->>KeyboardHandler: setSelectedIds(nextId)
        KeyboardHandler->>KeyboardHandler: "lastClickedId = nextId"
    else Shift held
        KeyboardHandler->>KeyboardHandler: "anchor = lastClickedId or entry.id"
        KeyboardHandler->>KeyboardHandler: setSelectedIds(range anchor to next)
    end
    KeyboardHandler->>KeyboardHandler: nextRow.focus() + scrollIntoView()
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix: address review — safe Meta+0 reset ..."](https://github.com/macnev2013/anyscp/commit/5eb960bb0d287cd4d8563b1d023a0f2f9a125d8d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47214299)</sub>

<!-- /greptile_comment -->