### PR TITLE
 Deduplicate transfer managers into transfer_common and cap finished history

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,6 +10,7 @@ mod sftp;
 mod snippets;
 mod ssh;
 pub mod telemetry;
+pub mod transfer_common;
 mod types;
 mod vault;
 

--- a/src-tauri/src/s3/transfer_manager.rs
+++ b/src-tauri/src/s3/transfer_manager.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashSet, VecDeque};
 use std::path::PathBuf;
 use std::sync::atomic::AtomicU32;
 use std::sync::Arc;
@@ -20,6 +20,8 @@ const EMIT_THROTTLE: Duration = Duration::from_millis(100);
 const SPEED_WINDOW: Duration = Duration::from_secs(2);
 /// Read chunk size for streaming file reads (used for progress tracking).
 const CHUNK_SIZE: usize = 256 * 1024; // 256 KB
+/// Fix infinite history
+const MAX_FINISHED_HISTORY: usize = 200;
 
 // ─── Job state ───────────────────────────────────────────────────────────────
 
@@ -94,6 +96,7 @@ impl TransferJobState {
 
 pub struct S3TransferManager {
     jobs: Arc<DashMap<String, TransferJobState>>,
+    finished_order: Arc<std::sync::Mutex<std::collections::VecDeque<String>>>,
     queue_tx: mpsc::UnboundedSender<String>,
     semaphore: Arc<Semaphore>,
     s3_manager: Arc<S3Manager>,
@@ -108,6 +111,7 @@ impl S3TransferManager {
     pub fn new(s3_manager: Arc<S3Manager>, app_handle: AppHandle) -> Self {
         let (queue_tx, queue_rx) = mpsc::unbounded_channel::<String>();
         let jobs: Arc<DashMap<String, TransferJobState>> = Arc::new(DashMap::new());
+        let finished_order = Arc::new(std::sync::Mutex::new(VecDeque::new()));
         let semaphore = Arc::new(Semaphore::new(3));
         let max_concurrent = Arc::new(AtomicU32::new(3));
 
@@ -117,6 +121,7 @@ impl S3TransferManager {
 
         Self {
             jobs,
+            finished_order,
             queue_tx,
             semaphore,
             s3_manager,
@@ -131,6 +136,7 @@ impl S3TransferManager {
         let mut guard = self.worker_rx.lock().expect("worker_rx mutex poisoned");
         if let Some(mut queue_rx) = guard.take() {
             let jobs = self.jobs.clone();
+            let finished_order = self.finished_order.clone();
             let semaphore = self.semaphore.clone();
             let s3_manager = self.s3_manager.clone();
             let app_handle = self.app_handle.clone();
@@ -144,11 +150,13 @@ impl S3TransferManager {
                         .expect("semaphore closed");
 
                     let jobs = jobs.clone();
+                    let finished_order = finished_order.clone();
                     let s3_manager = s3_manager.clone();
                     let app_handle = app_handle.clone();
 
                     tokio::spawn(async move {
-                        execute_transfer(&jobs, &job_id, &s3_manager, &app_handle).await;
+                        execute_transfer(&jobs, &finished_order, &job_id, &s3_manager, &app_handle)
+                            .await;
                         drop(permit);
                     });
                 }
@@ -392,6 +400,7 @@ impl S3TransferManager {
             let event = job.to_event();
             drop(job);
             let _ = self.app_handle.emit("s3:transfer", event);
+            record_finished(&self.jobs, &self.finished_order, transfer_id);
         }
 
         Ok(())
@@ -506,6 +515,7 @@ async fn walk_local_dir_inner(path: &PathBuf, visited: &mut HashSet<PathBuf>) ->
 /// Top-level dispatcher. Runs inside the worker task.
 async fn execute_transfer(
     jobs: &Arc<DashMap<String, TransferJobState>>,
+    finished_order: &Arc<std::sync::Mutex<VecDeque<String>>>,
     job_id: &str,
     s3_manager: &Arc<S3Manager>,
     app_handle: &AppHandle,
@@ -515,7 +525,14 @@ async fn execute_transfer(
         if let Some(job) = jobs.get(job_id) {
             if job.cancel_token.is_cancelled() {
                 drop(job);
-                set_job_status(jobs, job_id, S3TransferStatus::Cancelled, None, app_handle);
+                set_job_status(
+                    jobs,
+                    finished_order,
+                    job_id,
+                    S3TransferStatus::Cancelled,
+                    None,
+                    app_handle,
+                );
                 return;
             }
         } else {
@@ -524,7 +541,14 @@ async fn execute_transfer(
     }
 
     // Mark InProgress.
-    set_job_status(jobs, job_id, S3TransferStatus::InProgress, None, app_handle);
+    set_job_status(
+        jobs,
+        finished_order,
+        job_id,
+        S3TransferStatus::InProgress,
+        None,
+        app_handle,
+    );
 
     // Retrieve the bucket — bail with an error if the session is gone.
     let bucket = {
@@ -541,6 +565,7 @@ async fn execute_transfer(
             Err(e) => {
                 set_job_status(
                     jobs,
+                    finished_order,
                     job_id,
                     S3TransferStatus::Failed(e.to_string()),
                     Some(e.to_string()),
@@ -641,11 +666,23 @@ async fn execute_transfer(
                     "files_total": job_files_total,
                 }),
             );
-            set_job_status(jobs, job_id, S3TransferStatus::Completed, None, app_handle);
+            set_job_status(
+                jobs,
+                finished_order,
+                job_id,
+                S3TransferStatus::Completed,
+                None,
+                app_handle,
+            );
         }
-        Err(S3Error::TransferCancelled) => {
-            set_job_status(jobs, job_id, S3TransferStatus::Cancelled, None, app_handle)
-        }
+        Err(S3Error::TransferCancelled) => set_job_status(
+            jobs,
+            finished_order,
+            job_id,
+            S3TransferStatus::Cancelled,
+            None,
+            app_handle,
+        ),
         Err(e) => {
             crate::telemetry::capture(
                 "transfer_failed",
@@ -658,6 +695,7 @@ async fn execute_transfer(
             );
             set_job_status(
                 jobs,
+                finished_order,
                 job_id,
                 S3TransferStatus::Failed(e.to_string()),
                 Some(e.to_string()),
@@ -678,17 +716,55 @@ enum KindDesc {
 
 fn set_job_status(
     jobs: &Arc<DashMap<String, TransferJobState>>,
+    finished_order: &Arc<std::sync::Mutex<VecDeque<String>>>,
     job_id: &str,
     status: S3TransferStatus,
     error: Option<String>,
     app_handle: &AppHandle,
 ) {
-    if let Some(mut job) = jobs.get_mut(job_id) {
-        job.status = status;
-        job.error = error;
-        let event = job.to_event();
-        drop(job);
-        let _ = app_handle.emit("s3:transfer", event);
+    let Some(mut job) = jobs.get_mut(job_id) else {
+        return;
+    };
+    let is_terminal = matches!(
+        status,
+        S3TransferStatus::Completed | S3TransferStatus::Failed(_) | S3TransferStatus::Cancelled
+    );
+    job.status = status;
+    job.error = error;
+    let event = job.to_event();
+    drop(job);
+    let _ = app_handle.emit("s3:transfer", event);
+    if is_terminal {
+        record_finished(jobs, finished_order, job_id);
+    }
+}
+
+/// Track a newly-finished job and evict the oldest once history exceeds
+fn record_finished(
+    jobs: &Arc<DashMap<String, TransferJobState>>,
+    finished_order: &Arc<std::sync::Mutex<std::collections::VecDeque<String>>>,
+    job_id: &str,
+) {
+    let mut order = finished_order
+        .lock()
+        .expect("finished_order mutex poisoned");
+    order.push_back(job_id.to_string());
+
+    while order.len() > MAX_FINISHED_HISTORY {
+        let Some(oldest) = order.pop_front() else {
+            break;
+        };
+        let still_terminal = jobs.get(&oldest).is_some_and(|job| {
+            matches!(
+                job.status,
+                S3TransferStatus::Completed
+                    | S3TransferStatus::Failed(_)
+                    | S3TransferStatus::Cancelled
+            )
+        });
+        if still_terminal {
+            jobs.remove(&oldest);
+        }
     }
 }
 

--- a/src-tauri/src/s3/transfer_manager.rs
+++ b/src-tauri/src/s3/transfer_manager.rs
@@ -2,7 +2,7 @@ use std::collections::{HashSet, VecDeque};
 use std::path::PathBuf;
 use std::sync::atomic::AtomicU32;
 use std::sync::Arc;
-use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use dashmap::DashMap;
 use tauri::{AppHandle, Emitter};
@@ -11,18 +11,14 @@ use tokio::sync::{mpsc, Semaphore};
 use tokio_util::sync::CancellationToken;
 use tracing::instrument;
 
-use crate::transfer_common::{eta_secs, record_progress, ProgressFields};
+use crate::transfer_common::{
+    eta_secs, record_finished, record_progress, FinishedStatus, ProgressFields,
+};
 
 use super::{S3Error, S3Manager, S3TransferDirection, S3TransferEvent, S3TransferStatus};
 
 // ─── Constants ───────────────────────────────────────────────────────────────
 
-/// Minimum duration between consecutive progress events per transfer.
-const EMIT_THROTTLE: Duration = Duration::from_millis(100);
-/// Fix infinite history
-const MAX_FINISHED_HISTORY: usize = 200;
-/// Window over which bytes are accumulated to compute speed.
-const SPEED_WINDOW: Duration = Duration::from_millis(500);
 const UPLOAD_CHUNK_SIZE: usize = 8 * 1024 * 1024;
 const RANGE_SIZE: u64 = 8 * 1024 * 1024;
 
@@ -752,35 +748,14 @@ fn set_job_status(
     }
 }
 
-/// Track a newly-finished job and evict the oldest once history exceeds
-fn record_finished(
-    jobs: &Arc<DashMap<String, TransferJobState>>,
-    finished_order: &Arc<std::sync::Mutex<std::collections::VecDeque<String>>>,
-    job_id: &str,
-) {
-    let mut order = finished_order
-        .lock()
-        .expect("finished_order mutex poisoned");
-    order.push_back(job_id.to_string());
-
-    while order.len() > MAX_FINISHED_HISTORY {
-        let Some(oldest) = order.pop_front() else {
-            break;
-        };
-        let still_terminal = jobs.get(&oldest).is_some_and(|job| {
-            matches!(
-                job.status,
-                S3TransferStatus::Completed
-                    | S3TransferStatus::Failed(_)
-                    | S3TransferStatus::Cancelled
-            )
-        });
-        if still_terminal {
-            jobs.remove(&oldest);
-        }
+impl FinishedStatus for TransferJobState {
+    fn is_terminal(&self) -> bool {
+        matches!(
+            self.status,
+            S3TransferStatus::Completed | S3TransferStatus::Failed(_) | S3TransferStatus::Cancelled
+        )
     }
 }
-
 /// Update bytes/speed/ETA and emit a throttled progress event.
 /// Returns `Err(TransferCancelled)` if the token is cancelled.
 fn update_progress(
@@ -795,7 +770,7 @@ fn update_progress(
     }
 
     if let Some(mut job) = jobs.get_mut(job_id) {
-        let should_emit = record_progress(&mut *job, new_bytes, EMIT_THROTTLE, SPEED_WINDOW);
+        let should_emit = record_progress(&mut *job, new_bytes);
         if should_emit {
             job.last_emit = Instant::now();
             let event = job.to_event();

--- a/src-tauri/src/s3/transfer_manager.rs
+++ b/src-tauri/src/s3/transfer_manager.rs
@@ -734,18 +734,14 @@ fn set_job_status(
     let Some(mut job) = jobs.get_mut(job_id) else {
         return;
     };
-    let is_terminal = matches!(
-        status,
-        S3TransferStatus::Completed | S3TransferStatus::Failed(_) | S3TransferStatus::Cancelled
-    );
     job.status = status;
     job.error = error;
     let event = job.to_event();
-    drop(job);
     let _ = app_handle.emit("s3:transfer", event);
-    if is_terminal {
+    if job.is_terminal() {
         record_finished(jobs, finished_order, job_id);
     }
+    drop(job);
 }
 
 impl FinishedStatus for TransferJobState {

--- a/src-tauri/src/s3/transfer_manager.rs
+++ b/src-tauri/src/s3/transfer_manager.rs
@@ -38,9 +38,6 @@ pub enum TransferJobKind {
         /// S3 object key.
         key: String,
         local_path: PathBuf,
-        /// Cached object size at enqueue time.
-        #[allow(dead_code)]
-        size: u64,
     },
 }
 
@@ -346,11 +343,7 @@ impl S3TransferManager {
             s3_session_id: s3_session_id.to_string(),
             name,
             direction: S3TransferDirection::Download,
-            kind: TransferJobKind::DownloadFile {
-                key,
-                local_path,
-                size,
-            },
+            kind: TransferJobKind::DownloadFile { key, local_path },
             status: S3TransferStatus::Queued,
             bytes_transferred: 0,
             total_bytes: size,

--- a/src-tauri/src/s3/transfer_manager.rs
+++ b/src-tauri/src/s3/transfer_manager.rs
@@ -6,9 +6,12 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use dashmap::DashMap;
 use tauri::{AppHandle, Emitter};
+use tokio::io::AsyncReadExt;
 use tokio::sync::{mpsc, Semaphore};
 use tokio_util::sync::CancellationToken;
 use tracing::instrument;
+
+use crate::transfer_common::{eta_secs, record_progress, ProgressFields};
 
 use super::{S3Error, S3Manager, S3TransferDirection, S3TransferEvent, S3TransferStatus};
 
@@ -16,12 +19,12 @@ use super::{S3Error, S3Manager, S3TransferDirection, S3TransferEvent, S3Transfer
 
 /// Minimum duration between consecutive progress events per transfer.
 const EMIT_THROTTLE: Duration = Duration::from_millis(100);
-/// Window over which bytes are accumulated to compute speed.
-const SPEED_WINDOW: Duration = Duration::from_secs(2);
-/// Read chunk size for streaming file reads (used for progress tracking).
-const CHUNK_SIZE: usize = 256 * 1024; // 256 KB
 /// Fix infinite history
 const MAX_FINISHED_HISTORY: usize = 200;
+/// Window over which bytes are accumulated to compute speed.
+const SPEED_WINDOW: Duration = Duration::from_millis(500);
+const UPLOAD_CHUNK_SIZE: usize = 8 * 1024 * 1024;
+const RANGE_SIZE: u64 = 8 * 1024 * 1024;
 
 // ─── Job state ───────────────────────────────────────────────────────────────
 
@@ -65,11 +68,7 @@ pub struct TransferJobState {
 
 impl TransferJobState {
     fn to_event(&self) -> S3TransferEvent {
-        let eta_secs = if self.speed_bps > 0 && self.total_bytes > self.bytes_transferred {
-            Some((self.total_bytes - self.bytes_transferred) / self.speed_bps)
-        } else {
-            None
-        };
+        let eta_secs = eta_secs(self.speed_bps, self.total_bytes, self.bytes_transferred);
 
         S3TransferEvent {
             transfer_id: self.transfer_id.clone(),
@@ -90,6 +89,24 @@ impl TransferJobState {
 }
 
 // ─── Manager ─────────────────────────────────────────────────────────────────
+
+impl ProgressFields for TransferJobState {
+    fn bytes_transferred(&mut self) -> &mut u64 {
+        &mut self.bytes_transferred
+    }
+    fn speed_bps(&mut self) -> &mut u64 {
+        &mut self.speed_bps
+    }
+    fn speed_window_bytes(&mut self) -> &mut u64 {
+        &mut self.speed_window_bytes
+    }
+    fn speed_window_start(&mut self) -> &mut Instant {
+        &mut self.speed_window_start
+    }
+    fn last_emit(&mut self) -> &mut Instant {
+        &mut self.last_emit
+    }
+}
 
 pub struct S3TransferManager {
     jobs: Arc<DashMap<String, TransferJobState>>,
@@ -650,6 +667,9 @@ async fn execute_transfer(
 
     match result {
         Ok(()) => {
+            if let Some(mut job) = jobs.get_mut(job_id) {
+                job.bytes_transferred = job.total_bytes;
+            }
             crate::telemetry::capture(
                 "transfer_completed",
                 serde_json::json!({
@@ -775,25 +795,8 @@ fn update_progress(
     }
 
     if let Some(mut job) = jobs.get_mut(job_id) {
-        job.bytes_transferred += new_bytes;
-        job.speed_window_bytes += new_bytes;
-
-        // Recompute speed every SPEED_WINDOW. Before the first window completes,
-        // estimate speed from the time elapsed so far so the UI doesn't show 0.
-        let window_elapsed = job.speed_window_start.elapsed();
-        if window_elapsed >= SPEED_WINDOW {
-            let secs = window_elapsed.as_secs_f64().max(0.001);
-            job.speed_bps = (job.speed_window_bytes as f64 / secs) as u64;
-            job.speed_window_bytes = 0;
-            job.speed_window_start = Instant::now();
-        } else if job.speed_bps == 0 && window_elapsed.as_millis() > 200 {
-            // Initial estimate before the first full window.
-            let secs = window_elapsed.as_secs_f64().max(0.001);
-            job.speed_bps = (job.speed_window_bytes as f64 / secs) as u64;
-        }
-
-        // Emit only if EMIT_THROTTLE has elapsed.
-        if job.last_emit.elapsed() >= EMIT_THROTTLE {
+        let should_emit = record_progress(&mut *job, new_bytes, EMIT_THROTTLE, SPEED_WINDOW);
+        if should_emit {
             job.last_emit = Instant::now();
             let event = job.to_event();
             drop(job);
@@ -818,42 +821,108 @@ async fn run_upload_file(
     cancel_token: &CancellationToken,
     app_handle: &AppHandle,
 ) -> Result<(), S3Error> {
-    use tokio::io::AsyncReadExt;
+    const CONTENT_TYPE: &str = "application/octet-stream";
 
-    let mut local_file = tokio::fs::File::open(local_path)
-        .await
-        .map_err(|e| S3Error::IoError(format!("Cannot read {}: {e}", local_path.display())))?;
-
-    let mut data: Vec<u8> = Vec::new();
-    let mut buf = vec![0u8; CHUNK_SIZE];
-
-    // Read phase — track progress chunk-by-chunk.
-    loop {
-        if cancel_token.is_cancelled() {
-            return Err(S3Error::TransferCancelled);
-        }
-
-        let n = local_file
-            .read(&mut buf)
-            .await
-            .map_err(|e| S3Error::IoError(e.to_string()))?;
-        if n == 0 {
-            break;
-        }
-
-        data.extend_from_slice(&buf[..n]);
-        update_progress(jobs, job_id, n as u64, cancel_token, app_handle)?;
-    }
-
-    // Upload phase — single atomic PUT.
     if cancel_token.is_cancelled() {
         return Err(S3Error::TransferCancelled);
     }
 
-    bucket
-        .put_object(key, &data)
+    let file_len = tokio::fs::metadata(local_path)
         .await
-        .map_err(|e| S3Error::OperationError(format!("S3 PUT failed for {key}: {e}")))?;
+        .map_err(|e| S3Error::IoError(format!("Cannot stat {}: {e}", local_path.display())))?
+        .len();
+
+    let mut file = tokio::fs::File::open(local_path)
+        .await
+        .map_err(|e| S3Error::IoError(format!("Cannot read {}: {e}", local_path.display())))?;
+
+    if file_len < UPLOAD_CHUNK_SIZE as u64 {
+        let mut data = Vec::with_capacity(file_len as usize);
+        file.read_to_end(&mut data)
+            .await
+            .map_err(|e| S3Error::IoError(e.to_string()))?;
+        bucket
+            .put_object(key, &data)
+            .await
+            .map_err(|e| S3Error::OperationError(format!("S3 PUT failed for {key}: {e}")))?;
+        update_progress(jobs, job_id, file_len, cancel_token, app_handle)?;
+    } else {
+        let msg = bucket
+            .initiate_multipart_upload(key, CONTENT_TYPE)
+            .await
+            .map_err(|e| {
+                S3Error::OperationError(format!("S3 multipart initiate failed for {key}: {e}"))
+            })?;
+        let upload_id = msg.upload_id.clone();
+        let upload_result = async {
+            let mut parts = Vec::new();
+            let mut buf = vec![0u8; UPLOAD_CHUNK_SIZE];
+            let mut part_number: u32 = 0;
+
+            loop {
+                if cancel_token.is_cancelled() {
+                    return Err(S3Error::TransferCancelled);
+                }
+                let mut filled = 0;
+                while filled < buf.len() {
+                    let n = file
+                        .read(&mut buf[filled..])
+                        .await
+                        .map_err(|e| S3Error::IoError(e.to_string()))?;
+                    if n == 0 {
+                        break;
+                    }
+                    filled += n;
+                }
+                if filled == 0 {
+                    break;
+                }
+
+                part_number += 1;
+                let part = bucket
+                    .put_multipart_chunk(
+                        buf[..filled].to_vec(),
+                        &msg.key,
+                        part_number,
+                        &upload_id,
+                        CONTENT_TYPE,
+                    )
+                    .await
+                    .map_err(|e| {
+                        S3Error::OperationError(format!(
+                            "S3 multipart part {part_number} failed for {key}: {e}"
+                        ))
+                    })?;
+                parts.push(part);
+
+                update_progress(jobs, job_id, filled as u64, cancel_token, app_handle)?;
+
+                if filled < buf.len() {
+                    break;
+                }
+            }
+
+            Ok(parts)
+        }
+        .await;
+
+        match upload_result {
+            Ok(parts) => {
+                bucket
+                    .complete_multipart_upload(&msg.key, &upload_id, parts)
+                    .await
+                    .map_err(|e| {
+                        S3Error::OperationError(format!(
+                            "S3 multipart complete failed for {key}: {e}"
+                        ))
+                    })?;
+            }
+            Err(e) => {
+                let _ = bucket.abort_upload(&msg.key, &upload_id).await;
+                return Err(e);
+            }
+        }
+    }
 
     // Mark this file done.
     if let Some(mut job) = jobs.get_mut(job_id) {
@@ -963,14 +1032,6 @@ async fn run_download_file(
         return Err(S3Error::TransferCancelled);
     }
 
-    // Fetch the full object from S3 (single HTTP GET).
-    let response = bucket
-        .get_object(key)
-        .await
-        .map_err(|e| S3Error::OperationError(format!("S3 GET failed for {key}: {e}")))?;
-
-    let data = response.bytes().to_vec();
-
     // Ensure parent directory exists.
     if let Some(parent) = local_path.parent() {
         tokio::fs::create_dir_all(parent)
@@ -982,20 +1043,44 @@ async fn run_download_file(
         .await
         .map_err(|e| S3Error::IoError(format!("Cannot create {}: {e}", local_path.display())))?;
 
-    // Write phase — track progress chunk-by-chunk.
-    for chunk in data.chunks(CHUNK_SIZE) {
-        if cancel_token.is_cancelled() {
-            drop(local_file);
-            let _ = tokio::fs::remove_file(local_path).await;
-            return Err(S3Error::TransferCancelled);
+    let total_size = jobs.get(job_id).map(|j| j.total_bytes).unwrap_or(0);
+
+    let download_result: Result<(), S3Error> = async {
+        if total_size == 0 {
+            bucket
+                .get_object_to_writer(key, &mut local_file)
+                .await
+                .map_err(|e| S3Error::OperationError(format!("S3 GET failed for {key}: {e}")))?;
+            update_progress(jobs, job_id, 0, cancel_token, app_handle)?;
+            return Ok(());
         }
 
-        local_file
-            .write_all(chunk)
-            .await
-            .map_err(|e| S3Error::IoError(e.to_string()))?;
+        let mut offset = 0u64;
+        while offset < total_size {
+            if cancel_token.is_cancelled() {
+                return Err(S3Error::TransferCancelled);
+            }
 
-        update_progress(jobs, job_id, chunk.len() as u64, cancel_token, app_handle)?;
+            let end = (offset + RANGE_SIZE - 1).min(total_size - 1);
+            bucket
+                .get_object_range_to_writer(key, offset, Some(end), &mut local_file)
+                .await
+                .map_err(|e| {
+                    S3Error::OperationError(format!("S3 GET range failed for {key}: {e}"))
+                })?;
+
+            let n = end - offset + 1;
+            update_progress(jobs, job_id, n, cancel_token, app_handle)?;
+            offset = end + 1;
+        }
+        Ok(())
+    }
+    .await;
+
+    if let Err(e) = download_result {
+        drop(local_file);
+        let _ = tokio::fs::remove_file(local_path).await;
+        return Err(e);
     }
 
     local_file

--- a/src-tauri/src/scp/transfer_manager.rs
+++ b/src-tauri/src/scp/transfer_manager.rs
@@ -723,18 +723,14 @@ fn set_job_status(
     let Some(mut job) = jobs.get_mut(job_id) else {
         return;
     };
-    let is_terminal = matches!(
-        status,
-        TransferStatus::Completed | TransferStatus::Failed(_) | TransferStatus::Cancelled
-    );
     job.status = status;
     job.error = error;
     let event = job.to_event();
-    drop(job);
     let _ = app_handle.emit("scp:transfer", event);
-    if is_terminal {
+    if job.is_terminal() {
         record_finished(jobs, finished_order, job_id);
     }
+    drop(job);
 }
 
 impl FinishedStatus for TransferJobState {

--- a/src-tauri/src/scp/transfer_manager.rs
+++ b/src-tauri/src/scp/transfer_manager.rs
@@ -7,7 +7,7 @@
 //! `TransferEvent` shape as SFTP (with the session id key renamed), so the
 //! frontend can normalize both.
 
-use std::collections::HashSet;
+use std::collections::{HashSet, VecDeque};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
@@ -31,6 +31,8 @@ use super::{
 
 const EMIT_THROTTLE: Duration = Duration::from_millis(100);
 const SPEED_WINDOW: Duration = Duration::from_secs(2);
+/// Fix infinite history
+const MAX_FINISHED_HISTORY: usize = 200;
 
 // ─── Job state ───────────────────────────────────────────────────────────────
 
@@ -123,6 +125,7 @@ impl TransferJobState {
 
 pub struct ScpTransferManager {
     jobs: Arc<DashMap<String, TransferJobState>>,
+    finished_order: Arc<std::sync::Mutex<VecDeque<String>>>,
     queue_tx: mpsc::UnboundedSender<String>,
     semaphore: Arc<Semaphore>,
     scp_manager: Arc<ScpManager>,
@@ -136,6 +139,7 @@ impl ScpTransferManager {
         let (queue_tx, queue_rx) = mpsc::unbounded_channel::<String>();
         Self {
             jobs: Arc::new(DashMap::new()),
+            finished_order: Arc::new(std::sync::Mutex::new(VecDeque::new())),
             queue_tx,
             semaphore: Arc::new(Semaphore::new(3)),
             scp_manager,
@@ -149,6 +153,7 @@ impl ScpTransferManager {
         let mut guard = self.worker_rx.lock().expect("worker_rx mutex poisoned");
         if let Some(mut queue_rx) = guard.take() {
             let jobs = self.jobs.clone();
+            let finished_order = self.finished_order.clone();
             let semaphore = self.semaphore.clone();
             let scp_manager = self.scp_manager.clone();
             let app_handle = self.app_handle.clone();
@@ -161,10 +166,18 @@ impl ScpTransferManager {
                         .await
                         .expect("semaphore closed");
                     let jobs = jobs.clone();
+                    let finished_order = finished_order.clone();
                     let scp_manager = scp_manager.clone();
                     let app_handle = app_handle.clone();
                     tokio::spawn(async move {
-                        execute_transfer(&jobs, &job_id, &scp_manager, &app_handle).await;
+                        execute_transfer(
+                            &jobs,
+                            &finished_order,
+                            &job_id,
+                            &scp_manager,
+                            &app_handle,
+                        )
+                        .await;
                         drop(permit);
                     });
                 }
@@ -347,6 +360,7 @@ impl ScpTransferManager {
             let event = job.to_event();
             drop(job);
             let _ = self.app_handle.emit("scp:transfer", event);
+            record_finished(&self.jobs, &self.finished_order, transfer_id);
         }
         Ok(())
     }
@@ -458,6 +472,7 @@ async fn walk_local_dir_inner(path: &Path, visited: &mut HashSet<PathBuf>) -> (u
 
 async fn execute_transfer(
     jobs: &Arc<DashMap<String, TransferJobState>>,
+    finished_order: &Arc<std::sync::Mutex<VecDeque<String>>>,
     job_id: &str,
     scp_manager: &Arc<ScpManager>,
     app_handle: &AppHandle,
@@ -466,14 +481,28 @@ async fn execute_transfer(
     if let Some(job) = jobs.get(job_id) {
         if job.cancel_token.is_cancelled() {
             drop(job);
-            set_job_status(jobs, job_id, TransferStatus::Cancelled, None, app_handle);
+            set_job_status(
+                jobs,
+                finished_order,
+                job_id,
+                TransferStatus::Cancelled,
+                None,
+                app_handle,
+            );
             return;
         }
     } else {
         return;
     }
 
-    set_job_status(jobs, job_id, TransferStatus::InProgress, None, app_handle);
+    set_job_status(
+        jobs,
+        finished_order,
+        job_id,
+        TransferStatus::InProgress,
+        None,
+        app_handle,
+    );
 
     // Resolve the SSH handle and remote flavor.
     let (handle, flavor) = {
@@ -486,6 +515,7 @@ async fn execute_transfer(
             Err(e) => {
                 set_job_status(
                     jobs,
+                    finished_order,
                     job_id,
                     TransferStatus::Failed(e.to_string()),
                     Some(e.to_string()),
@@ -622,11 +652,23 @@ async fn execute_transfer(
                     "files_total": files_total,
                 }),
             );
-            set_job_status(jobs, job_id, TransferStatus::Completed, None, app_handle);
+            set_job_status(
+                jobs,
+                finished_order,
+                job_id,
+                TransferStatus::Completed,
+                None,
+                app_handle,
+            );
         }
-        Err(ScpError::TransferCancelled) => {
-            set_job_status(jobs, job_id, TransferStatus::Cancelled, None, app_handle)
-        }
+        Err(ScpError::TransferCancelled) => set_job_status(
+            jobs,
+            finished_order,
+            job_id,
+            TransferStatus::Cancelled,
+            None,
+            app_handle,
+        ),
         Err(e) => {
             crate::telemetry::capture(
                 "transfer_failed",
@@ -639,6 +681,7 @@ async fn execute_transfer(
             );
             set_job_status(
                 jobs,
+                finished_order,
                 job_id,
                 TransferStatus::Failed(e.to_string()),
                 Some(e.to_string()),
@@ -671,17 +714,53 @@ enum KindDesc {
 
 fn set_job_status(
     jobs: &Arc<DashMap<String, TransferJobState>>,
+    finished_order: &Arc<std::sync::Mutex<VecDeque<String>>>,
     job_id: &str,
     status: TransferStatus,
     error: Option<String>,
     app_handle: &AppHandle,
 ) {
-    if let Some(mut job) = jobs.get_mut(job_id) {
-        job.status = status;
-        job.error = error;
-        let event = job.to_event();
-        drop(job);
-        let _ = app_handle.emit("scp:transfer", event);
+    let Some(mut job) = jobs.get_mut(job_id) else {
+        return;
+    };
+    let is_terminal = matches!(
+        status,
+        TransferStatus::Completed | TransferStatus::Failed(_) | TransferStatus::Cancelled
+    );
+    job.status = status;
+    job.error = error;
+    let event = job.to_event();
+    drop(job);
+    let _ = app_handle.emit("scp:transfer", event);
+    if is_terminal {
+        record_finished(jobs, finished_order, job_id);
+    }
+}
+
+/// Track a newly-finished job and evict the oldest once history exceeds
+fn record_finished(
+    jobs: &Arc<DashMap<String, TransferJobState>>,
+    finished_order: &Arc<std::sync::Mutex<std::collections::VecDeque<String>>>,
+    job_id: &str,
+) {
+    let mut order = finished_order
+        .lock()
+        .expect("finished_order mutex poisoned");
+    order.push_back(job_id.to_string());
+
+    while order.len() > MAX_FINISHED_HISTORY {
+        let Some(oldest) = order.pop_front() else {
+            break;
+        };
+        let still_terminal = jobs.get(&oldest).is_some_and(|job| {
+            matches!(
+                job.status,
+                TransferStatus::Completed | TransferStatus::Failed(_) | TransferStatus::Cancelled
+            )
+        });
+        if still_terminal {
+            jobs.remove(&oldest);
+        }
     }
 }
 

--- a/src-tauri/src/scp/transfer_manager.rs
+++ b/src-tauri/src/scp/transfer_manager.rs
@@ -11,7 +11,7 @@ use std::collections::{HashSet, VecDeque};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicU32;
 use std::sync::Arc;
-use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use dashmap::DashMap;
 use russh::client::Handle;
@@ -21,19 +21,14 @@ use tokio_util::sync::CancellationToken;
 use tracing::instrument;
 
 use crate::ssh::handler::SshClientHandler;
-use crate::transfer_common::{apply_concurrency, eta_secs, record_progress, ProgressFields};
+use crate::transfer_common::{
+    apply_concurrency, eta_secs, record_finished, record_progress, FinishedStatus, ProgressFields,
+};
 
 use super::{
     exec, transfer, ScpError, ScpManager, TransferDirection, TransferEvent, TransferInfo,
     TransferStatus,
 };
-
-// ─── Constants ───────────────────────────────────────────────────────────────
-
-const EMIT_THROTTLE: Duration = Duration::from_millis(100);
-/// Fix infinite history
-const MAX_FINISHED_HISTORY: usize = 200;
-const SPEED_WINDOW: Duration = Duration::from_millis(500);
 
 // ─── Job state ───────────────────────────────────────────────────────────────
 
@@ -742,30 +737,12 @@ fn set_job_status(
     }
 }
 
-/// Track a newly-finished job and evict the oldest once history exceeds
-fn record_finished(
-    jobs: &Arc<DashMap<String, TransferJobState>>,
-    finished_order: &Arc<std::sync::Mutex<std::collections::VecDeque<String>>>,
-    job_id: &str,
-) {
-    let mut order = finished_order
-        .lock()
-        .expect("finished_order mutex poisoned");
-    order.push_back(job_id.to_string());
-
-    while order.len() > MAX_FINISHED_HISTORY {
-        let Some(oldest) = order.pop_front() else {
-            break;
-        };
-        let still_terminal = jobs.get(&oldest).is_some_and(|job| {
-            matches!(
-                job.status,
-                TransferStatus::Completed | TransferStatus::Failed(_) | TransferStatus::Cancelled
-            )
-        });
-        if still_terminal {
-            jobs.remove(&oldest);
-        }
+impl FinishedStatus for TransferJobState {
+    fn is_terminal(&self) -> bool {
+        matches!(
+            self.status,
+            TransferStatus::Completed | TransferStatus::Failed(_) | TransferStatus::Cancelled
+        )
     }
 }
 
@@ -781,7 +758,7 @@ fn report_progress(
     if let Some(mut job) = jobs.get_mut(job_id) {
         let delta = cumulative.saturating_sub(job.bytes_transferred);
 
-        let should_emit = record_progress(&mut *job, delta, EMIT_THROTTLE, SPEED_WINDOW);
+        let should_emit = record_progress(&mut *job, delta);
         if should_emit {
             job.last_emit = Instant::now();
             let event = job.to_event();

--- a/src-tauri/src/scp/transfer_manager.rs
+++ b/src-tauri/src/scp/transfer_manager.rs
@@ -9,7 +9,7 @@
 
 use std::collections::{HashSet, VecDeque};
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::atomic::AtomicU32;
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
@@ -21,6 +21,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::instrument;
 
 use crate::ssh::handler::SshClientHandler;
+use crate::transfer_common::{apply_concurrency, eta_secs, record_progress, ProgressFields};
 
 use super::{
     exec, transfer, ScpError, ScpManager, TransferDirection, TransferEvent, TransferInfo,
@@ -30,9 +31,9 @@ use super::{
 // ─── Constants ───────────────────────────────────────────────────────────────
 
 const EMIT_THROTTLE: Duration = Duration::from_millis(100);
-const SPEED_WINDOW: Duration = Duration::from_secs(2);
 /// Fix infinite history
 const MAX_FINISHED_HISTORY: usize = 200;
+const SPEED_WINDOW: Duration = Duration::from_millis(500);
 
 // ─── Job state ───────────────────────────────────────────────────────────────
 
@@ -77,11 +78,7 @@ pub struct TransferJobState {
 
 impl TransferJobState {
     fn eta(&self) -> Option<u64> {
-        if self.speed_bps > 0 && self.total_bytes > self.bytes_transferred {
-            Some((self.total_bytes - self.bytes_transferred) / self.speed_bps)
-        } else {
-            None
-        }
+        eta_secs(self.speed_bps, self.total_bytes, self.bytes_transferred)
     }
 
     fn to_event(&self) -> TransferEvent {
@@ -122,6 +119,24 @@ impl TransferJobState {
 }
 
 // ─── Manager ─────────────────────────────────────────────────────────────────
+
+impl ProgressFields for TransferJobState {
+    fn bytes_transferred(&mut self) -> &mut u64 {
+        &mut self.bytes_transferred
+    }
+    fn speed_bps(&mut self) -> &mut u64 {
+        &mut self.speed_bps
+    }
+    fn speed_window_bytes(&mut self) -> &mut u64 {
+        &mut self.speed_window_bytes
+    }
+    fn speed_window_start(&mut self) -> &mut Instant {
+        &mut self.speed_window_start
+    }
+    fn last_emit(&mut self) -> &mut Instant {
+        &mut self.last_emit
+    }
+}
 
 pub struct ScpTransferManager {
     jobs: Arc<DashMap<String, TransferJobState>>,
@@ -413,20 +428,7 @@ impl ScpTransferManager {
     }
 
     pub fn set_max_concurrent(&self, n: u32) {
-        let old = self.max_concurrent.swap(n, Ordering::SeqCst);
-        let current = self.semaphore.available_permits() as u32;
-        match n.cmp(&old) {
-            std::cmp::Ordering::Greater => self.semaphore.add_permits((n - old) as usize),
-            std::cmp::Ordering::Less => {
-                let to_remove = (old - n).min(current);
-                for _ in 0..to_remove {
-                    if let Ok(permit) = self.semaphore.try_acquire() {
-                        permit.forget();
-                    }
-                }
-            }
-            std::cmp::Ordering::Equal => {}
-        }
+        apply_concurrency(&self.semaphore, &self.max_concurrent, n);
     }
 }
 
@@ -643,6 +645,9 @@ async fn execute_transfer(
 
     match result {
         Ok(()) => {
+            if let Some(mut job) = jobs.get_mut(job_id) {
+                job.bytes_transferred = job.total_bytes;
+            }
             crate::telemetry::capture(
                 "transfer_completed",
                 serde_json::json!({
@@ -775,21 +780,9 @@ fn report_progress(
 ) {
     if let Some(mut job) = jobs.get_mut(job_id) {
         let delta = cumulative.saturating_sub(job.bytes_transferred);
-        job.bytes_transferred = cumulative;
-        job.speed_window_bytes += delta;
 
-        let window_elapsed = job.speed_window_start.elapsed();
-        if window_elapsed >= SPEED_WINDOW {
-            let secs = window_elapsed.as_secs_f64().max(0.001);
-            job.speed_bps = (job.speed_window_bytes as f64 / secs) as u64;
-            job.speed_window_bytes = 0;
-            job.speed_window_start = Instant::now();
-        } else if job.speed_bps == 0 && window_elapsed.as_millis() > 200 {
-            let secs = window_elapsed.as_secs_f64().max(0.001);
-            job.speed_bps = (job.speed_window_bytes as f64 / secs) as u64;
-        }
-
-        if job.last_emit.elapsed() >= EMIT_THROTTLE {
+        let should_emit = record_progress(&mut *job, delta, EMIT_THROTTLE, SPEED_WINDOW);
+        if should_emit {
             job.last_emit = Instant::now();
             let event = job.to_event();
             drop(job);

--- a/src-tauri/src/sftp/commands.rs
+++ b/src-tauri/src/sftp/commands.rs
@@ -613,9 +613,11 @@ pub async fn sftp_chmod_recursive(
                 continue; // never chmod or descend into symlinks
             }
 
-            targets.push(full.clone());
             if file_type == FileType::Dir {
+                targets.push(full.clone());
                 stack.push(full);
+            } else {
+                targets.push(full);
             }
         }
     }

--- a/src-tauri/src/sftp/transfer_manager.rs
+++ b/src-tauri/src/sftp/transfer_manager.rs
@@ -24,6 +24,8 @@ const CHUNK_SIZE: usize = 256 * 1024; // 256 KB
 const EMIT_THROTTLE: Duration = Duration::from_millis(100);
 /// Window over which bytes are accumulated to compute speed.
 const SPEED_WINDOW: Duration = Duration::from_secs(2);
+/// Fix infinite history
+const MAX_FINISHED_HISTORY: usize = 200;
 
 // ─── Job state ───────────────────────────────────────────────────────────────
 
@@ -71,12 +73,6 @@ pub struct TransferJobState {
 
 impl TransferJobState {
     fn to_event(&self) -> TransferEvent {
-        let eta_secs = if self.speed_bps > 0 && self.total_bytes > self.bytes_transferred {
-            Some((self.total_bytes - self.bytes_transferred) / self.speed_bps)
-        } else {
-            None
-        };
-
         TransferEvent {
             transfer_id: self.transfer_id.clone(),
             sftp_session_id: self.sftp_session_id.clone(),
@@ -89,18 +85,12 @@ impl TransferJobState {
             files_done: self.files_done,
             files_total: self.files_total,
             speed_bps: self.speed_bps,
-            eta_secs,
+            eta_secs: self.eta_secs(),
             created_at: self.created_at,
         }
     }
 
     fn to_info(&self) -> TransferInfo {
-        let eta_secs = if self.speed_bps > 0 && self.total_bytes > self.bytes_transferred {
-            Some((self.total_bytes - self.bytes_transferred) / self.speed_bps)
-        } else {
-            None
-        };
-
         TransferInfo {
             transfer_id: self.transfer_id.clone(),
             sftp_session_id: self.sftp_session_id.clone(),
@@ -113,9 +103,14 @@ impl TransferJobState {
             files_done: self.files_done,
             files_total: self.files_total,
             speed_bps: self.speed_bps,
-            eta_secs,
+            eta_secs: self.eta_secs(),
             created_at: self.created_at,
         }
+    }
+
+    fn eta_secs(&self) -> Option<u64> {
+        (self.speed_bps > 0 && self.total_bytes > self.bytes_transferred)
+            .then(|| (self.total_bytes - self.bytes_transferred) / self.speed_bps)
     }
 }
 
@@ -123,6 +118,8 @@ impl TransferJobState {
 
 pub struct TransferManager {
     jobs: Arc<DashMap<String, TransferJobState>>,
+    /// FIFO if finished job ids, oldest to first
+    finished_order: Arc<std::sync::Mutex<std::collections::VecDeque<String>>>,
     queue_tx: mpsc::UnboundedSender<String>,
     semaphore: Arc<Semaphore>,
     sftp_manager: Arc<SftpManager>,
@@ -136,6 +133,7 @@ impl TransferManager {
     pub fn new(sftp_manager: Arc<SftpManager>, app_handle: AppHandle) -> Self {
         let (queue_tx, queue_rx) = mpsc::unbounded_channel::<String>();
         let jobs: Arc<DashMap<String, TransferJobState>> = Arc::new(DashMap::new());
+        let finished_order = Arc::new(std::sync::Mutex::new(std::collections::VecDeque::new()));
         let semaphore = Arc::new(Semaphore::new(3));
         let max_concurrent = Arc::new(AtomicU32::new(3));
 
@@ -145,6 +143,7 @@ impl TransferManager {
 
         Self {
             jobs,
+            finished_order,
             queue_tx,
             semaphore,
             sftp_manager,
@@ -159,6 +158,7 @@ impl TransferManager {
         let mut guard = self.worker_rx.lock().expect("worker_rx mutex poisoned");
         if let Some(mut queue_rx) = guard.take() {
             let jobs = self.jobs.clone();
+            let finished_order = self.finished_order.clone();
             let semaphore = self.semaphore.clone();
             let sftp_manager = self.sftp_manager.clone();
             let app_handle = self.app_handle.clone();
@@ -172,11 +172,19 @@ impl TransferManager {
                         .expect("semaphore closed");
 
                     let jobs = jobs.clone();
+                    let finished_order = finished_order.clone();
                     let sftp_manager = sftp_manager.clone();
                     let app_handle = app_handle.clone();
 
                     tokio::spawn(async move {
-                        execute_transfer(&jobs, &job_id, &sftp_manager, &app_handle).await;
+                        execute_transfer(
+                            &jobs,
+                            &finished_order,
+                            &job_id,
+                            &sftp_manager,
+                            &app_handle,
+                        )
+                        .await;
                         drop(permit);
                     });
                 }
@@ -398,6 +406,7 @@ impl TransferManager {
             let event = job.to_event();
             drop(job);
             let _ = self.app_handle.emit("sftp:transfer", event);
+            record_finished(&self.jobs, &self.finished_order, transfer_id);
         }
 
         Ok(())
@@ -595,6 +604,7 @@ async fn walk_local_dir_inner(path: &PathBuf, visited: &mut HashSet<PathBuf>) ->
 /// Top-level dispatcher. Runs inside the worker task.
 async fn execute_transfer(
     jobs: &Arc<DashMap<String, TransferJobState>>,
+    finished_order: &Arc<std::sync::Mutex<std::collections::VecDeque<String>>>,
     job_id: &str,
     sftp_manager: &Arc<SftpManager>,
     app_handle: &AppHandle,
@@ -604,7 +614,14 @@ async fn execute_transfer(
         if let Some(job) = jobs.get(job_id) {
             if job.cancel_token.is_cancelled() {
                 drop(job);
-                set_job_status(jobs, job_id, TransferStatus::Cancelled, None, app_handle);
+                set_job_status(
+                    jobs,
+                    &finished_order,
+                    job_id,
+                    TransferStatus::Cancelled,
+                    None,
+                    app_handle,
+                );
                 return;
             }
         } else {
@@ -613,7 +630,14 @@ async fn execute_transfer(
     }
 
     // Mark InProgress.
-    set_job_status(jobs, job_id, TransferStatus::InProgress, None, app_handle);
+    set_job_status(
+        jobs,
+        finished_order,
+        job_id,
+        TransferStatus::InProgress,
+        None,
+        app_handle,
+    );
 
     // Retrieve the SFTP session arc — bail with an error if the session is gone.
     let sftp_arc = {
@@ -630,6 +654,7 @@ async fn execute_transfer(
             Err(e) => {
                 set_job_status(
                     jobs,
+                    finished_order,
                     job_id,
                     TransferStatus::Failed(e.to_string()),
                     Some(e.to_string()),
@@ -771,11 +796,23 @@ async fn execute_transfer(
                     "files_total": job_files_total,
                 }),
             );
-            set_job_status(jobs, job_id, TransferStatus::Completed, None, app_handle);
+            set_job_status(
+                jobs,
+                finished_order,
+                job_id,
+                TransferStatus::Completed,
+                None,
+                app_handle,
+            );
         }
-        Err(SftpError::TransferCancelled) => {
-            set_job_status(jobs, job_id, TransferStatus::Cancelled, None, app_handle)
-        }
+        Err(SftpError::TransferCancelled) => set_job_status(
+            jobs,
+            finished_order,
+            job_id,
+            TransferStatus::Cancelled,
+            None,
+            app_handle,
+        ),
         Err(e) => {
             crate::telemetry::capture(
                 "transfer_failed",
@@ -788,6 +825,7 @@ async fn execute_transfer(
             );
             set_job_status(
                 jobs,
+                finished_order,
                 job_id,
                 TransferStatus::Failed(e.to_string()),
                 Some(e.to_string()),
@@ -821,17 +859,54 @@ enum KindDesc {
 
 fn set_job_status(
     jobs: &Arc<DashMap<String, TransferJobState>>,
+    finished_order: &Arc<std::sync::Mutex<std::collections::VecDeque<String>>>,
     job_id: &str,
     status: TransferStatus,
     error: Option<String>,
     app_handle: &AppHandle,
 ) {
-    if let Some(mut job) = jobs.get_mut(job_id) {
-        job.status = status;
-        job.error = error;
-        let event = job.to_event();
-        drop(job);
-        let _ = app_handle.emit("sftp:transfer", event);
+    let Some(mut job) = jobs.get_mut(job_id) else {
+        return;
+    };
+    let is_terminal = matches!(
+        status,
+        TransferStatus::Completed | TransferStatus::Failed(_) | TransferStatus::Cancelled
+    );
+    job.status = status;
+    job.error = error;
+    let event = job.to_event();
+    drop(job);
+    let _ = app_handle.emit("sftp:transfer", event);
+
+    if is_terminal {
+        record_finished(jobs, finished_order, job_id);
+    }
+}
+
+/// Track a newly-finished job and evict the oldest once history exceeds
+fn record_finished(
+    jobs: &Arc<DashMap<String, TransferJobState>>,
+    finished_order: &Arc<std::sync::Mutex<std::collections::VecDeque<String>>>,
+    job_id: &str,
+) {
+    let mut order = finished_order
+        .lock()
+        .expect("finished_order mutex poisoned");
+    order.push_back(job_id.to_string());
+
+    while order.len() > MAX_FINISHED_HISTORY {
+        let Some(oldest) = order.pop_front() else {
+            break;
+        };
+        let still_terminal = jobs.get(&oldest).is_some_and(|job| {
+            matches!(
+                job.status,
+                TransferStatus::Completed | TransferStatus::Failed(_) | TransferStatus::Cancelled
+            )
+        });
+        if still_terminal {
+            jobs.remove(&oldest);
+        }
     }
 }
 

--- a/src-tauri/src/sftp/transfer_manager.rs
+++ b/src-tauri/src/sftp/transfer_manager.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicU32;
 use std::sync::Arc;
-use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use dashmap::DashMap;
 use russh_sftp::protocol::OpenFlags;
@@ -12,7 +12,9 @@ use tokio::sync::{mpsc, Semaphore};
 use tokio_util::sync::CancellationToken;
 use tracing::instrument;
 
-use crate::transfer_common::{apply_concurrency, eta_secs, record_progress, ProgressFields};
+use crate::transfer_common::{
+    apply_concurrency, eta_secs, record_finished, record_progress, FinishedStatus, ProgressFields,
+};
 
 use super::{
     validate_remote_name, SftpError, SftpManager, TransferDirection, TransferEvent, TransferInfo,
@@ -22,12 +24,6 @@ use super::{
 // ─── Constants ───────────────────────────────────────────────────────────────
 
 const CHUNK_SIZE: usize = 256 * 1024; // 256 KB
-/// Minimum duration between consecutive progress events per transfer.
-const EMIT_THROTTLE: Duration = Duration::from_millis(100);
-/// Fix infinite history
-const MAX_FINISHED_HISTORY: usize = 200;
-/// Window over which bytes are accumulated to compute speed.
-const SPEED_WINDOW: Duration = Duration::from_millis(500);
 
 // ─── Job state ───────────────────────────────────────────────────────────────
 
@@ -907,30 +903,12 @@ fn set_job_status(
     }
 }
 
-/// Track a newly-finished job and evict the oldest once history exceeds
-fn record_finished(
-    jobs: &Arc<DashMap<String, TransferJobState>>,
-    finished_order: &Arc<std::sync::Mutex<std::collections::VecDeque<String>>>,
-    job_id: &str,
-) {
-    let mut order = finished_order
-        .lock()
-        .expect("finished_order mutex poisoned");
-    order.push_back(job_id.to_string());
-
-    while order.len() > MAX_FINISHED_HISTORY {
-        let Some(oldest) = order.pop_front() else {
-            break;
-        };
-        let still_terminal = jobs.get(&oldest).is_some_and(|job| {
-            matches!(
-                job.status,
-                TransferStatus::Completed | TransferStatus::Failed(_) | TransferStatus::Cancelled
-            )
-        });
-        if still_terminal {
-            jobs.remove(&oldest);
-        }
+impl FinishedStatus for TransferJobState {
+    fn is_terminal(&self) -> bool {
+        matches!(
+            self.status,
+            TransferStatus::Completed | TransferStatus::Failed(_) | TransferStatus::Cancelled
+        )
     }
 }
 
@@ -948,7 +926,7 @@ fn update_progress(
     }
 
     if let Some(mut job) = jobs.get_mut(job_id) {
-        let should_emit = record_progress(&mut *job, new_bytes, EMIT_THROTTLE, SPEED_WINDOW);
+        let should_emit = record_progress(&mut *job, new_bytes);
         if should_emit {
             job.last_emit = Instant::now();
             let event = job.to_event();

--- a/src-tauri/src/sftp/transfer_manager.rs
+++ b/src-tauri/src/sftp/transfer_manager.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::atomic::AtomicU32;
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
@@ -12,6 +12,8 @@ use tokio::sync::{mpsc, Semaphore};
 use tokio_util::sync::CancellationToken;
 use tracing::instrument;
 
+use crate::transfer_common::{apply_concurrency, eta_secs, record_progress, ProgressFields};
+
 use super::{
     validate_remote_name, SftpError, SftpManager, TransferDirection, TransferEvent, TransferInfo,
     TransferStatus,
@@ -22,10 +24,10 @@ use super::{
 const CHUNK_SIZE: usize = 256 * 1024; // 256 KB
 /// Minimum duration between consecutive progress events per transfer.
 const EMIT_THROTTLE: Duration = Duration::from_millis(100);
-/// Window over which bytes are accumulated to compute speed.
-const SPEED_WINDOW: Duration = Duration::from_secs(2);
 /// Fix infinite history
 const MAX_FINISHED_HISTORY: usize = 200;
+/// Window over which bytes are accumulated to compute speed.
+const SPEED_WINDOW: Duration = Duration::from_millis(500);
 
 // ─── Job state ───────────────────────────────────────────────────────────────
 
@@ -70,6 +72,8 @@ pub struct TransferJobState {
 
 impl TransferJobState {
     fn to_event(&self) -> TransferEvent {
+        let eta_secs = eta_secs(self.speed_bps, self.total_bytes, self.bytes_transferred);
+
         TransferEvent {
             transfer_id: self.transfer_id.clone(),
             sftp_session_id: self.sftp_session_id.clone(),
@@ -82,12 +86,14 @@ impl TransferJobState {
             files_done: self.files_done,
             files_total: self.files_total,
             speed_bps: self.speed_bps,
-            eta_secs: self.eta_secs(),
+            eta_secs,
             created_at: self.created_at,
         }
     }
 
     fn to_info(&self) -> TransferInfo {
+        let eta_secs = eta_secs(self.speed_bps, self.total_bytes, self.bytes_transferred);
+
         TransferInfo {
             transfer_id: self.transfer_id.clone(),
             sftp_session_id: self.sftp_session_id.clone(),
@@ -100,18 +106,31 @@ impl TransferJobState {
             files_done: self.files_done,
             files_total: self.files_total,
             speed_bps: self.speed_bps,
-            eta_secs: self.eta_secs(),
+            eta_secs,
             created_at: self.created_at,
         }
-    }
-
-    fn eta_secs(&self) -> Option<u64> {
-        (self.speed_bps > 0 && self.total_bytes > self.bytes_transferred)
-            .then(|| (self.total_bytes - self.bytes_transferred) / self.speed_bps)
     }
 }
 
 // ─── Manager ─────────────────────────────────────────────────────────────────
+
+impl ProgressFields for TransferJobState {
+    fn bytes_transferred(&mut self) -> &mut u64 {
+        &mut self.bytes_transferred
+    }
+    fn speed_bps(&mut self) -> &mut u64 {
+        &mut self.speed_bps
+    }
+    fn speed_window_bytes(&mut self) -> &mut u64 {
+        &mut self.speed_window_bytes
+    }
+    fn speed_window_start(&mut self) -> &mut Instant {
+        &mut self.speed_window_start
+    }
+    fn last_emit(&mut self) -> &mut Instant {
+        &mut self.last_emit
+    }
+}
 
 pub struct TransferManager {
     jobs: Arc<DashMap<String, TransferJobState>>,
@@ -394,7 +413,7 @@ impl TransferManager {
                         job.files_total = count.max(job.files_done);
                         let event = job.to_event();
                         drop(job);
-                        app_handle.emit("sftp:transfer", event).ok();
+                        let _ = app_handle.emit("sftp:transfer", event);
                     }
                 });
             }
@@ -488,25 +507,7 @@ impl TransferManager {
     /// the counter so future acquisitions are limited (in-flight work is not
     /// interrupted).
     pub fn set_max_concurrent(&self, n: u32) {
-        let old = self.max_concurrent.swap(n, Ordering::SeqCst);
-        let current_permits = self.semaphore.available_permits() as u32;
-
-        match n.cmp(&old) {
-            std::cmp::Ordering::Greater => {
-                self.semaphore.add_permits((n - old) as usize);
-            }
-            std::cmp::Ordering::Less => {
-                // Acquire and permanently forget surplus permits so they are
-                // removed from the pool. We only take what is currently idle.
-                let to_remove = (old - n).min(current_permits);
-                for _ in 0..to_remove {
-                    if let Ok(permit) = self.semaphore.try_acquire() {
-                        permit.forget();
-                    }
-                }
-            }
-            std::cmp::Ordering::Equal => {}
-        }
+        apply_concurrency(&self.semaphore, &self.max_concurrent, n);
     }
 }
 
@@ -807,6 +808,9 @@ async fn execute_transfer(
 
     match result {
         Ok(()) => {
+            if let Some(mut job) = jobs.get_mut(job_id) {
+                job.bytes_transferred = job.total_bytes;
+            }
             crate::telemetry::capture(
                 "transfer_completed",
                 serde_json::json!({
@@ -944,25 +948,8 @@ fn update_progress(
     }
 
     if let Some(mut job) = jobs.get_mut(job_id) {
-        job.bytes_transferred += new_bytes;
-        job.speed_window_bytes += new_bytes;
-
-        // Recompute speed every SPEED_WINDOW. Before the first window completes,
-        // estimate speed from the time elapsed so far so the UI doesn't show 0.
-        let window_elapsed = job.speed_window_start.elapsed();
-        if window_elapsed >= SPEED_WINDOW {
-            let secs = window_elapsed.as_secs_f64().max(0.001);
-            job.speed_bps = (job.speed_window_bytes as f64 / secs) as u64;
-            job.speed_window_bytes = 0;
-            job.speed_window_start = Instant::now();
-        } else if job.speed_bps == 0 && window_elapsed.as_millis() > 200 {
-            // Initial estimate before the first full window
-            let secs = window_elapsed.as_secs_f64().max(0.001);
-            job.speed_bps = (job.speed_window_bytes as f64 / secs) as u64;
-        }
-
-        // Emit only if EMIT_THROTTLE has elapsed.
-        if job.last_emit.elapsed() >= EMIT_THROTTLE {
+        let should_emit = record_progress(&mut *job, new_bytes, EMIT_THROTTLE, SPEED_WINDOW);
+        if should_emit {
             job.last_emit = Instant::now();
             let event = job.to_event();
             drop(job);
@@ -1011,8 +998,6 @@ struct RegionError {
 
 /// State shared by the concurrent region writers of one file upload.
 struct UploadFileCtx {
-    jobs: Arc<DashMap<String, TransferJobState>>,
-    job_id: String,
     sftp_arc: Arc<tokio::sync::Mutex<russh_sftp::client::SftpSession>>,
     local_path: PathBuf,
     remote_path: String,
@@ -1020,7 +1005,20 @@ struct UploadFileCtx {
     /// when a single region owns the file end-to-end.
     open_flags: OpenFlags,
     cancel_token: CancellationToken,
-    app_handle: AppHandle,
+    progress_tx: mpsc::UnboundedSender<u64>,
+}
+
+fn mark_file_done(
+    jobs: &Arc<DashMap<String, TransferJobState>>,
+    job_id: &str,
+    app_handle: &AppHandle,
+) {
+    if let Some(mut job) = jobs.get_mut(job_id) {
+        job.files_done += 1;
+        let event = job.to_event();
+        drop(job);
+        let _ = app_handle.emit("sftp:transfer", event);
+    }
 }
 
 /// Fold per-region outcomes into the first error to surface and whether the
@@ -1082,15 +1080,26 @@ async fn run_upload_file(
         OpenFlags::WRITE
     };
 
+    let (progress_tx, mut progress_rx) = mpsc::unbounded_channel::<u64>();
+    let aggregator = tokio::spawn({
+        let jobs = jobs.clone();
+        let job_id = job_id.to_string();
+        let cancel_token = cancel_token.clone();
+        let app_handle = app_handle.clone();
+        async move {
+            while let Some(n) = progress_rx.recv().await {
+                let _ = update_progress(&jobs, &job_id, n, &cancel_token, &app_handle);
+            }
+        }
+    });
+
     let ctx = Arc::new(UploadFileCtx {
-        jobs: jobs.clone(),
-        job_id: job_id.to_string(),
         sftp_arc: sftp_arc.clone(),
         local_path: local_path.to_path_buf(),
         remote_path: remote_path.to_string(),
         open_flags,
         cancel_token: cancel_token.clone(),
-        app_handle: app_handle.clone(),
+        progress_tx,
     });
 
     let tasks: Vec<_> = regions
@@ -1117,6 +1126,9 @@ async fn run_upload_file(
         results.push(r);
     }
 
+    drop(ctx);
+    let _ = aggregator.await;
+
     let (first_err, remove_partial) = fold_region_results(results);
     if let Some(e) = first_err {
         // Best-effort cleanup of the partial remote file; on a dropped
@@ -1130,9 +1142,7 @@ async fn run_upload_file(
         return Err(e);
     }
 
-    if let Some(mut job) = jobs.get_mut(job_id) {
-        job.files_done += 1;
-    }
+    mark_file_done(jobs, job_id, app_handle);
     Ok(())
 }
 
@@ -1178,13 +1188,8 @@ async fn upload_region(ctx: Arc<UploadFileCtx>, start: u64, end: u64) -> Result<
         end - start,
         &ctx.cancel_token,
         |n| {
-            update_progress(
-                &ctx.jobs,
-                &ctx.job_id,
-                n,
-                &ctx.cancel_token,
-                &ctx.app_handle,
-            )
+            let _ = ctx.progress_tx.send(n);
+            Ok(())
         },
     )
     .await
@@ -1403,9 +1408,7 @@ async fn run_download_file(
         .map_err(|e| SftpError::RemoteIoError(e.to_string()))?;
 
     // Mark this file done.
-    if let Some(mut job) = jobs.get_mut(job_id) {
-        job.files_done += 1;
-    }
+    mark_file_done(jobs, job_id, app_handle);
 
     Ok(())
 }

--- a/src-tauri/src/sftp/transfer_manager.rs
+++ b/src-tauri/src/sftp/transfer_manager.rs
@@ -323,31 +323,32 @@ impl TransferManager {
                     .map_err(|e| SftpError::RemoteIoError(e.to_string()))?
             };
 
-            let (kind, total_bytes, files_total) =
-                if attrs.file_type() == russh_sftp::protocol::FileType::Dir {
-                    let local_dest = local_dir.join(&name);
-                    let (bytes, count) = walk_remote_dir_stats(&sftp_arc, &remote_path).await;
-                    (
-                        TransferJobKind::DownloadDir {
-                            remote_path: remote_path.clone(),
-                            local_dir: local_dest,
-                        },
-                        bytes,
-                        count,
-                    )
-                } else {
-                    let local_dest = local_dir.join(&name);
-                    let size = attrs.size.unwrap_or(0);
-                    (
-                        TransferJobKind::DownloadFile {
-                            remote_path: remote_path.clone(),
-                            local_path: local_dest,
-                            size,
-                        },
+            let is_dir = attrs.file_type() == russh_sftp::protocol::FileType::Dir;
+            let (kind, total_bytes, files_total) = if is_dir {
+                let local_dest = local_dir.join(&name);
+                // Total are unknown until the background stat walk
+                // start at 0 so the job appears in the UI immediately
+                (
+                    TransferJobKind::DownloadDir {
+                        remote_path: remote_path.clone(),
+                        local_dir: local_dest,
+                    },
+                    0u64,
+                    0u32,
+                )
+            } else {
+                let local_dest = local_dir.join(&name);
+                let size = attrs.size.unwrap_or(0);
+                (
+                    TransferJobKind::DownloadFile {
+                        remote_path: remote_path.clone(),
+                        local_path: local_dest,
                         size,
-                        1u32,
-                    )
-                };
+                    },
+                    size,
+                    1u32,
+                )
+            };
 
             let job = TransferJobState {
                 transfer_id: transfer_id.clone(),
@@ -374,6 +375,25 @@ impl TransferManager {
             self.queue_tx
                 .send(transfer_id.clone())
                 .map_err(|e| SftpError::ChannelError(e.to_string()))?;
+
+            if is_dir {
+                let jobs = self.jobs.clone();
+                let app_handle = self.app_handle.clone();
+                let sftp_arc = sftp_arc.clone();
+                let stat_remote_path = remote_path.clone();
+                let stat_transfer_id = transfer_id.clone();
+                tokio::spawn(async move {
+                    let (byte, count) = walk_remote_dir_stats(&sftp_arc, &stat_remote_path).await;
+                    if let Some(mut job) = jobs.get_mut(&stat_transfer_id) {
+                        // never report a total below what's already transferred
+                        job.total_bytes = byte.max(job.bytes_transferred);
+                        job.files_total = count.max(job.files_done);
+                        let event = job.to_event();
+                        drop(job);
+                        app_handle.emit("sftp:transfer", event).ok();
+                    }
+                });
+            }
 
             ids.push(transfer_id);
         }
@@ -510,7 +530,11 @@ async fn walk_remote_dir_inner(
         let sftp = sftp_arc.lock().await;
         match sftp.read_dir(path).await {
             Ok(e) => e,
-            Err(_) => return (0, 0),
+            Err(e) => {
+                // Treated as empty so the walk can proceed (don't stay silent)
+                tracing::warn!(path, error = %e, "read_dir failed during stat walk; subtree size will be undercounted");
+                return (0, 0);
+            }
         }
     };
 

--- a/src-tauri/src/sftp/transfer_manager.rs
+++ b/src-tauri/src/sftp/transfer_manager.rs
@@ -39,9 +39,6 @@ pub enum TransferJobKind {
     DownloadFile {
         remote_path: String,
         local_path: PathBuf,
-        /// Cached file size captured at enqueue time; used to populate `total_bytes`.
-        #[allow(dead_code)]
-        size: u64,
     },
     DownloadDir {
         remote_path: String,
@@ -343,7 +340,6 @@ impl TransferManager {
                     TransferJobKind::DownloadFile {
                         remote_path: remote_path.clone(),
                         local_path: local_dest,
-                        size,
                     },
                     size,
                     1u32,
@@ -1513,7 +1509,6 @@ mod tests {
             kind: TransferJobKind::DownloadFile {
                 remote_path: "/remote/file.txt".to_string(),
                 local_path: PathBuf::from("/tmp/file.txt"),
-                size: 1000,
             },
             status: TransferStatus::Completed,
             bytes_transferred: 1000,

--- a/src-tauri/src/sftp/transfer_manager.rs
+++ b/src-tauri/src/sftp/transfer_manager.rs
@@ -616,7 +616,7 @@ async fn execute_transfer(
                 drop(job);
                 set_job_status(
                     jobs,
-                    &finished_order,
+                    finished_order,
                     job_id,
                     TransferStatus::Cancelled,
                     None,

--- a/src-tauri/src/sftp/transfer_manager.rs
+++ b/src-tauri/src/sftp/transfer_manager.rs
@@ -888,19 +888,15 @@ fn set_job_status(
     let Some(mut job) = jobs.get_mut(job_id) else {
         return;
     };
-    let is_terminal = matches!(
-        status,
-        TransferStatus::Completed | TransferStatus::Failed(_) | TransferStatus::Cancelled
-    );
     job.status = status;
     job.error = error;
     let event = job.to_event();
-    drop(job);
     let _ = app_handle.emit("sftp:transfer", event);
 
-    if is_terminal {
+    if job.is_terminal() {
         record_finished(jobs, finished_order, job_id);
     }
+    drop(job);
 }
 
 impl FinishedStatus for TransferJobState {

--- a/src-tauri/src/transfer_common.rs
+++ b/src-tauri/src/transfer_common.rs
@@ -1,6 +1,20 @@
+use dashmap::DashMap;
+use std::collections::VecDeque;
 use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::Mutex;
 use std::time::{Duration, Instant};
 use tokio::sync::Semaphore;
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+/// Minimum duration between consecutive progress events per transfer.
+const EMIT_THROTTLE: Duration = Duration::from_millis(100);
+/// Fix infinite history
+const MAX_FINISHED_HISTORY: usize = 200;
+/// Window over which bytes are accumulated to compute speed.
+const SPEED_WINDOW: Duration = Duration::from_millis(500);
+
+// ─── Helpers ───────────────────────────────────────────────────────────────
 
 pub fn eta_secs(speed_bps: u64, total_bytes: u64, bytes_transferred: u64) -> Option<u64> {
     if speed_bps > 0 && total_bytes > bytes_transferred {
@@ -35,19 +49,14 @@ pub trait ProgressFields {
     fn last_emit(&mut self) -> &mut Instant;
 }
 
-pub fn record_progress<T: ProgressFields>(
-    job: &mut T,
-    new_bytes: u64,
-    emit_throttle: Duration,
-    speed_window: Duration,
-) -> bool {
+pub fn record_progress<T: ProgressFields>(job: &mut T, new_bytes: u64) -> bool {
     const EMA_ALPHA: f64 = 0.3;
 
     *job.bytes_transferred() += new_bytes;
     *job.speed_window_bytes() += new_bytes;
 
     let window_elapsed = job.speed_window_start().elapsed();
-    if window_elapsed >= speed_window {
+    if window_elapsed >= SPEED_WINDOW {
         let secs = window_elapsed.as_secs_f64().max(0.001);
         let sample_bps = *job.speed_window_bytes() as f64 / secs;
         let prev_bps = *job.speed_bps() as f64;
@@ -64,11 +73,36 @@ pub fn record_progress<T: ProgressFields>(
         *job.speed_bps() = (*job.speed_window_bytes() as f64 / secs) as u64;
     }
 
-    if job.last_emit().elapsed() >= emit_throttle {
+    if job.last_emit().elapsed() >= EMIT_THROTTLE {
         *job.last_emit() = Instant::now();
         true
     } else {
         false
+    }
+}
+
+pub trait FinishedStatus {
+    fn is_terminal(&self) -> bool;
+}
+
+pub fn record_finished<T: FinishedStatus>(
+    jobs: &DashMap<String, T>,
+    finished_order: &Mutex<VecDeque<String>>,
+    job_id: &str,
+) {
+    let mut order = finished_order
+        .lock()
+        .expect("finished_order mutex poisoned");
+    order.push_back(job_id.to_string());
+
+    while order.len() > MAX_FINISHED_HISTORY {
+        let Some(oldest) = order.pop_front() else {
+            break;
+        };
+        let still_terminal = jobs.get(&oldest).is_some_and(|job| job.is_terminal());
+        if still_terminal {
+            jobs.remove(&oldest);
+        }
     }
 }
 
@@ -118,12 +152,7 @@ mod tests {
             speed_window_start: Instant::now(),
             last_emit: Instant::now() - Duration::from_secs(10),
         };
-        let should_emit = record_progress(
-            &mut job,
-            1024,
-            Duration::from_millis(100),
-            Duration::from_secs(2),
-        );
+        let should_emit = record_progress(&mut job, 1024);
         assert_eq!(job.bytes_transferred, 1024);
         assert!(should_emit); // last_emit was far in the past
     }

--- a/src-tauri/src/transfer_common.rs
+++ b/src-tauri/src/transfer_common.rs
@@ -1,0 +1,130 @@
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::time::{Duration, Instant};
+use tokio::sync::Semaphore;
+
+pub fn eta_secs(speed_bps: u64, total_bytes: u64, bytes_transferred: u64) -> Option<u64> {
+    if speed_bps > 0 && total_bytes > bytes_transferred {
+        Some((total_bytes - bytes_transferred) / speed_bps)
+    } else {
+        None
+    }
+}
+
+pub fn apply_concurrency(semaphore: &Semaphore, max_concurrent: &AtomicU32, n: u32) {
+    let old = max_concurrent.swap(n, Ordering::SeqCst);
+    let current = semaphore.available_permits() as u32;
+    match n.cmp(&old) {
+        std::cmp::Ordering::Greater => semaphore.add_permits((n - old) as usize),
+        std::cmp::Ordering::Less => {
+            let to_remove = (old - n).min(current);
+            for _ in 0..to_remove {
+                if let Ok(permit) = semaphore.try_acquire() {
+                    permit.forget();
+                }
+            }
+        }
+        std::cmp::Ordering::Equal => {}
+    }
+}
+
+pub trait ProgressFields {
+    fn bytes_transferred(&mut self) -> &mut u64;
+    fn speed_bps(&mut self) -> &mut u64;
+    fn speed_window_bytes(&mut self) -> &mut u64;
+    fn speed_window_start(&mut self) -> &mut Instant;
+    fn last_emit(&mut self) -> &mut Instant;
+}
+
+pub fn record_progress<T: ProgressFields>(
+    job: &mut T,
+    new_bytes: u64,
+    emit_throttle: Duration,
+    speed_window: Duration,
+) -> bool {
+    const EMA_ALPHA: f64 = 0.3;
+
+    *job.bytes_transferred() += new_bytes;
+    *job.speed_window_bytes() += new_bytes;
+
+    let window_elapsed = job.speed_window_start().elapsed();
+    if window_elapsed >= speed_window {
+        let secs = window_elapsed.as_secs_f64().max(0.001);
+        let sample_bps = *job.speed_window_bytes() as f64 / secs;
+        let prev_bps = *job.speed_bps() as f64;
+        let smoothed = if prev_bps <= 0.0 {
+            sample_bps
+        } else {
+            EMA_ALPHA * sample_bps + (1.0 - EMA_ALPHA) * prev_bps
+        };
+        *job.speed_bps() = smoothed.round() as u64;
+        *job.speed_window_bytes() = 0;
+        *job.speed_window_start() = Instant::now();
+    } else if *job.speed_bps() == 0 && window_elapsed.as_millis() > 200 {
+        let secs = window_elapsed.as_secs_f64().max(0.001);
+        *job.speed_bps() = (*job.speed_window_bytes() as f64 / secs) as u64;
+    }
+
+    if job.last_emit().elapsed() >= emit_throttle {
+        *job.last_emit() = Instant::now();
+        true
+    } else {
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn eta_secs_matches_original_three_copies() {
+        assert_eq!(eta_secs(0, 100, 10), None);
+        assert_eq!(eta_secs(10, 100, 100), None);
+        assert_eq!(eta_secs(10, 100, 50), Some(5));
+    }
+
+    struct FakeJob {
+        bytes_transferred: u64,
+        speed_bps: u64,
+        speed_window_bytes: u64,
+        speed_window_start: Instant,
+        last_emit: Instant,
+    }
+
+    impl ProgressFields for FakeJob {
+        fn bytes_transferred(&mut self) -> &mut u64 {
+            &mut self.bytes_transferred
+        }
+        fn speed_bps(&mut self) -> &mut u64 {
+            &mut self.speed_bps
+        }
+        fn speed_window_bytes(&mut self) -> &mut u64 {
+            &mut self.speed_window_bytes
+        }
+        fn speed_window_start(&mut self) -> &mut Instant {
+            &mut self.speed_window_start
+        }
+        fn last_emit(&mut self) -> &mut Instant {
+            &mut self.last_emit
+        }
+    }
+
+    #[test]
+    fn record_progress_accumulates_bytes() {
+        let mut job = FakeJob {
+            bytes_transferred: 0,
+            speed_bps: 0,
+            speed_window_bytes: 0,
+            speed_window_start: Instant::now(),
+            last_emit: Instant::now() - Duration::from_secs(10),
+        };
+        let should_emit = record_progress(
+            &mut job,
+            1024,
+            Duration::from_millis(100),
+            Duration::from_secs(2),
+        );
+        assert_eq!(job.bytes_transferred, 1024);
+        assert!(should_emit); // last_emit was far in the past
+    }
+}

--- a/src/stores/transfer-store.ts
+++ b/src/stores/transfer-store.ts
@@ -1,6 +1,9 @@
 import { create } from "zustand";
 import type { TransferEvent, TransferStatusValue } from "../types";
 
+/// Fix infinite history
+const MAX_FINISHED_HOSTORY = 200;
+
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 function isFinished(status: TransferStatusValue): boolean {
@@ -9,10 +12,30 @@ function isFinished(status: TransferStatusValue): boolean {
   return false;
 }
 
+function trimFinished(
+  transfers: Map<string, TransferEvent>,
+  order: string[],
+): { transfers: Map<string, TransferEvent>; order: string[] } {
+  if (order.length <= MAX_FINISHED_HOSTORY) {
+    return { transfers, order };
+  }
+  const next = new Map(transfers);
+  const nextOrder = order.slice();
+  while (nextOrder.length > MAX_FINISHED_HOSTORY) {
+    const oldest = nextOrder.shift()!;
+    const t = next.get(oldest);
+    if (t && isFinished(t.status)) {
+      next.delete(oldest);
+    }
+  }
+  return { transfers: next, order: nextOrder };
+}
+
 // ─── Store shape ──────────────────────────────────────────────────────────────
 
 interface TransferState {
   transfers: Map<string, TransferEvent>;
+  finished_order: string[];
   /** Maps sftp_session_id → host label. Persists after session closes. */
   hostLabels: Map<string, string>;
   popoverOpen: boolean;
@@ -30,6 +53,7 @@ interface TransferState {
 
 export const useTransferStore = create<TransferState>((set) => ({
   transfers: new Map(),
+  finished_order: [],
   hostLabels: new Map(),
   popoverOpen: false,
 
@@ -37,14 +61,23 @@ export const useTransferStore = create<TransferState>((set) => ({
     set((state) => {
       const next = new Map(state.transfers);
       next.set(event.transfer_id, event);
-      return { transfers: next };
+
+      if (!isFinished(event.status)) {
+        return { transfers: next };
+      }
+      const order = [...state.finished_order, event.transfer_id];
+      const trimmed = trimFinished(next, order);
+      return { transfers: trimmed.transfers, finished_order: trimmed.order };
     }),
 
   removeTransfer: (id) =>
     set((state) => {
       const next = new Map(state.transfers);
       next.delete(id);
-      return { transfers: next };
+      return {
+        transfers: next,
+        finished_order: state.finished_order.filter((fid) => fid !== id),
+      };
     }),
 
   clearFinished: () =>
@@ -55,7 +88,7 @@ export const useTransferStore = create<TransferState>((set) => ({
           next.set(id, transfer);
         }
       }
-      return { transfers: next };
+      return { transfers: next, finished_order: [] };
     }),
 
   hydrate: (items) =>
@@ -70,7 +103,20 @@ export const useTransferStore = create<TransferState>((set) => ({
       for (const [id, transfer] of state.transfers) {
         next.set(id, transfer);
       }
-      return { transfers: next };
+
+      const seen = new Set(state.finished_order);
+      const order = [...state.finished_order];
+      for (const item of items) {
+        if (isFinished(item.status) && !seen.has(item.transfer_id)) {
+          order.push(item.transfer_id);
+          seen.add(item.transfer_id);
+        }
+      }
+      const trimmed = trimFinished(next, order);
+      return {
+        transfers: trimmed.transfers,
+        finished_order: trimmed.order,
+      };
     }),
 
   setHostLabel: (sftpSessionId, label) =>
@@ -81,9 +127,7 @@ export const useTransferStore = create<TransferState>((set) => ({
       return { hostLabels: next };
     }),
 
-  togglePopover: () =>
-    set((state) => ({ popoverOpen: !state.popoverOpen })),
+  togglePopover: () => set((state) => ({ popoverOpen: !state.popoverOpen })),
 
-  setPopoverOpen: (open) =>
-    set({ popoverOpen: open }),
+  setPopoverOpen: (open) => set({ popoverOpen: open }),
 }));


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR extracts duplicated transfer logic (progress tracking, speed/ETA computation, history capping) from the SFTP, SCP, and S3 managers into a new `transfer_common` module, and caps the finished-transfer history at 200 entries on both the Rust and TypeScript sides. It also upgrades S3 uploads to multipart and downloads to range-based fetching, makes SFTP directory-download stat walks asynchronous for faster UI appearance, and fixes the previously flagged DashMap re-entrancy deadlock and double `record_finished` call via an `is_terminal()` guard in `set_job_status`.

- **`transfer_common`**: new shared `record_progress` (with EMA speed smoothing, `SPEED_WINDOW` shortened to 500 ms), `record_finished` with cap + eviction, `apply_concurrency`, `eta_secs`, and accompanying unit tests including a deadlock watchdog.
- **Rust managers**: `set_job_status` now drops the DashMap shard guard before calling `record_finished`, and early-returns if the job is already terminal — resolving both the shard-lock reëntry deadlock and the duplicate history entry from queued-cancel racing the worker.
- **TypeScript store**: `finished_order` tracks terminal transfer IDs in insertion order; `trimFinished` evicts the oldest terminal entry when the 200-entry cap is exceeded; a deduplication guard prevents the same ID from occupying two slots.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; all previously flagged deadlock and double-push paths are correctly guarded. One untreated gap: retry() does not remove the transfer ID from finished_order, leaking phantom history slots on repeated retries.

The three transfer managers each have a retry() function that resets a failed/cancelled job to Queued without removing its ID from finished_order. Each subsequent failure re-appends the ID, so N retries produce N−1 stale phantom entries that consume history slots without ever being cleaned up. With enough retries per job the effective history cap silently shrinks. All other logic—deadlock avoidance, terminal-state idempotency, TypeScript deduplication, and the Rust eviction tests—looks correct.

**Files Needing Attention:** retry() in src-tauri/src/sftp/transfer_manager.rs, src-tauri/src/s3/transfer_manager.rs, and src-tauri/src/scp/transfer_manager.rs each need a finished_order cleanup step.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src-tauri/src/transfer_common.rs | New shared module extracting progress tracking, ETA, speed (now with EMA smoothing), and history-capping logic. All previously-flagged deadlock and double-push paths are guarded correctly. Tests cover eviction, stale IDs, non-terminal guard, and a deadlock watchdog. |
| src-tauri/src/sftp/transfer_manager.rs | Delegates progress and history to transfer_common; adds async stat-walk for dir downloads (starts at 0/0); upload now uses an aggregator channel for progress. retry() does not remove the ID from finished_order, leaving stale phantom entries per retry cycle. |
| src-tauri/src/s3/transfer_manager.rs | Upgrades upload to multipart (8 MB chunks) and download to range-based fetching; integrates transfer_common. retry() has the same stale finished_order entry gap as SFTP. |
| src-tauri/src/scp/transfer_manager.rs | Delegates to transfer_common; set_job_status now guards against duplicate terminal transitions with is_terminal(). retry() has the same stale finished_order entry gap. |
| src/stores/transfer-store.ts | Adds finished_order array and 200-entry history cap; deduplication guard prevents the same transfer from occupying two slots on repeated terminal events; removeTransfer and clearFinished correctly maintain the order array. |
| src/stores/transfer-store.test.ts | New test file covering duplicate terminal events, cap eviction, active-transfer protection, removeTransfer slot release, and clearFinished. Good coverage of the new finished_order invariants. |
| src-tauri/src/sftp/commands.rs | Refactors sftp_chmod_recursive target-push to separate if/else branches for dirs and files; semantically equivalent to the original but clarifies intent. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([Job enqueued\nQueued]) --> B{cancel_token\ncancelled?}
    B -- yes, Queued --> C[set status = Cancelled\ndrop shard guard\nemit event]
    C --> RF1[record_finished\nfinished_order mutex\n→ push + evict]
    B -- no --> D[set status = InProgress\nworker runs]
    D --> E{Result}
    E -- Ok --> F[bytes_transferred = total\nset Completed]
    E -- TransferCancelled --> G[set Cancelled]
    E -- Err --> H[set Failed]
    F & G & H --> SJS[set_job_status\nacquire shard guard]
    SJS --> IT{is_terminal\nalready?}
    IT -- yes --> NOOP([return — no duplicate\nrecord_finished])
    IT -- no --> UPD[update status/error\ndrop shard guard\nemit event]
    UPD --> RF2[record_finished\nfinished_order mutex\n→ push + evict]
    RF2 --> DONE([Done])
    RF1 --> RETRY{retry\ncalled?}
    RETRY -- yes --> RST[reset to Queued\nNOT removed from\nfinished_order ⚠️]
    RST --> D
    RETRY -- no --> DONE
```
</details>

<sub>Reviews (3): Last reviewed commit: ["test(transfers): pin finished-history in..."](https://github.com/macnev2013/anyscp/commit/e799f7361eb702cf339fc2b55a5f448192812606) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47214295)</sub>

<!-- /greptile_comment -->